### PR TITLE
Run standard cargo fmt on the directories zebra-crosslink and tenderlink

### DIFF
--- a/tenderlink/src/bandwidth_test.rs
+++ b/tenderlink/src/bandwidth_test.rs
@@ -536,7 +536,7 @@ mod linux {
         msg.msg_iov = &mut iov as *mut libc::iovec;
         msg.msg_iovlen = 1;
         msg.msg_control = cbuf.as_mut_ptr() as *mut libc::c_void;
-        msg.msg_controllen = cbuf.len();
+        msg.msg_controllen = cbuf.len() as u32;
     
         let tclass_byte = ((dscp as u8) << 2) | 0b10; // ecn
     
@@ -600,7 +600,7 @@ mod linux {
         msg.msg_iov = &mut iov as *mut libc::iovec;
         msg.msg_iovlen = 1;
         msg.msg_control = cbuf.as_mut_ptr() as *mut libc::c_void;
-        msg.msg_controllen = cbuf.len();
+        msg.msg_controllen = cbuf.len() as u32;
     
         let n = unsafe { libc::recvmsg(fd, &mut msg as *mut libc::msghdr, 0) };
         let timestamp_ns = monotonic_clock_ns();

--- a/tenderlink/src/bandwidth_test.rs
+++ b/tenderlink/src/bandwidth_test.rs
@@ -1,10 +1,9 @@
-
 use std::net::{Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, UdpSocket};
 
 #[test]
 fn bwdth_test() {
     println!("Begin the test!");
-    
+
     let _handle = std::thread::spawn(|| {
         do_the_reflector(32345);
     });
@@ -15,25 +14,25 @@ fn bwdth_test() {
 fn do_the_test_program(port: u16, reflector_port: u16) {
     let socket = setup_and_bind_udp_socket(port);
     let mut time_of_last_status_print = std::time::Instant::now();
-    
+
     let mut drop_cursor = 50_u64;
     let mut serial_number = 50_u64;
     let mut bytes_on_the_wire = 0_u64;
-    
+
     let mut min_seen_rtt_buckets = [u64::MAX; 10];
     let mut rtt_bucket_cursor = 0_u64;
     let mut rtt_bucket_cursor_last_time = 0_u64;
-    
+
     let mut bytes_delivered_buckets = [0_u64; 10];
     let mut bytes_delivered_bucket_cursor = 0_u64;
     let mut bytes_delivered_bucket_cursor_last_time = 0_u64;
-    
+
     let mut state_machine_cursor = 0_u64;
     let mut state_machine_cursor_last_time = 0_u64;
     let mut old_measured_allowed_bytes_on_the_wire = 0_u64;
-    
+
     let mut packet_buffer = vec![0_u32; PACKET_HISTORY_BUFFER_LEN];
-    
+
     let mut buf = [0_u8; 16384];
     loop {
         let current_min_rtt_on_connection_ns = {
@@ -42,7 +41,10 @@ fn do_the_test_program(port: u16, reflector_port: u16) {
             let c = min_seen_rtt_buckets[4].min(min_seen_rtt_buckets[5]);
             let d = min_seen_rtt_buckets[6].min(min_seen_rtt_buckets[7]);
             let e = min_seen_rtt_buckets[8].min(min_seen_rtt_buckets[9]);
-            a.min(b).min(c).min(d).min(e)
+            a.min(b)
+                .min(c)
+                .min(d)
+                .min(e)
                 .min(10_000_000_000) // RTT assumed to be always less than 10 seconds.
                 .max(5_000_000) // The maths breaks down with RTT close to zero so we pad up to 5 ms always.
         };
@@ -54,79 +56,131 @@ fn do_the_test_program(port: u16, reflector_port: u16) {
             let e = bytes_delivered_buckets[8].max(bytes_delivered_buckets[9]);
             a.max(b).max(c).max(d).max(e)
         };
-    
-        
-        let bottleneck_bandwidth_Bps = (current_max_delivered_bucket_bytes*1_000_000_000) / current_min_rtt_on_connection_ns;
-        let measured_allowed_bytes_on_the_wire = ((bottleneck_bandwidth_Bps as u128 * current_min_rtt_on_connection_ns as u128) / 1_000_000_000).max(2000) as u64;
-        
+
+        let bottleneck_bandwidth_Bps =
+            (current_max_delivered_bucket_bytes * 1_000_000_000) / current_min_rtt_on_connection_ns;
+        let measured_allowed_bytes_on_the_wire = ((bottleneck_bandwidth_Bps as u128
+            * current_min_rtt_on_connection_ns as u128)
+            / 1_000_000_000)
+            .max(2000) as u64;
+
         let drop_back_edge_timestamp_ns = monotonic_clock_ns();
-        
-        if drop_back_edge_timestamp_ns > state_machine_cursor_last_time + current_min_rtt_on_connection_ns {
+
+        if drop_back_edge_timestamp_ns
+            > state_machine_cursor_last_time + current_min_rtt_on_connection_ns
+        {
             state_machine_cursor += 1;
             state_machine_cursor_last_time = drop_back_edge_timestamp_ns;
         }
-        if measured_allowed_bytes_on_the_wire > old_measured_allowed_bytes_on_the_wire*102/100 { state_machine_cursor = 0; println!("GROW"); }
+        if measured_allowed_bytes_on_the_wire > old_measured_allowed_bytes_on_the_wire * 102 / 100 {
+            state_machine_cursor = 0;
+            println!("GROW");
+        }
         old_measured_allowed_bytes_on_the_wire = measured_allowed_bytes_on_the_wire;
-        if state_machine_cursor >= 12 { state_machine_cursor = 2; }
-        
-        let allowed_bytes_on_the_wire = if state_machine_cursor < 2 { (measured_allowed_bytes_on_the_wire*2).max(measured_allowed_bytes_on_the_wire + 100_000) } else if state_machine_cursor < 4 { (measured_allowed_bytes_on_the_wire*125/100).max(measured_allowed_bytes_on_the_wire + 20_000) } else if state_machine_cursor < 6 { measured_allowed_bytes_on_the_wire*75/100 } else { measured_allowed_bytes_on_the_wire };
-        
+        if state_machine_cursor >= 12 {
+            state_machine_cursor = 2;
+        }
+
+        let allowed_bytes_on_the_wire = if state_machine_cursor < 2 {
+            (measured_allowed_bytes_on_the_wire * 2)
+                .max(measured_allowed_bytes_on_the_wire + 100_000)
+        } else if state_machine_cursor < 4 {
+            (measured_allowed_bytes_on_the_wire * 125 / 100)
+                .max(measured_allowed_bytes_on_the_wire + 20_000)
+        } else if state_machine_cursor < 6 {
+            measured_allowed_bytes_on_the_wire * 75 / 100
+        } else {
+            measured_allowed_bytes_on_the_wire
+        };
+
         if time_of_last_status_print.elapsed() > std::time::Duration::from_millis(1000) {
             time_of_last_status_print = std::time::Instant::now();
-            println!("rtt: {} us MaxBucket: {} B bottleneck bandwidth: {}", current_min_rtt_on_connection_ns / 1000, current_max_delivered_bucket_bytes, BytesPerSecond(bottleneck_bandwidth_Bps));
-            println!("{} < m: {} t: {}", bytes_on_the_wire, measured_allowed_bytes_on_the_wire, allowed_bytes_on_the_wire);
+            println!(
+                "rtt: {} us MaxBucket: {} B bottleneck bandwidth: {}",
+                current_min_rtt_on_connection_ns / 1000,
+                current_max_delivered_bucket_bytes,
+                BytesPerSecond(bottleneck_bandwidth_Bps)
+            );
+            println!(
+                "{} < m: {} t: {}",
+                bytes_on_the_wire, measured_allowed_bytes_on_the_wire, allowed_bytes_on_the_wire
+            );
         }
-    
-        while drop_cursor < serial_number { // The drop back edge.
-            let (packet_size_bytes, send_timestamp_ns, _ecn_marked, acked) = decompress_packet_info(packet_buffer[drop_cursor as usize % PACKET_HISTORY_BUFFER_LEN]);
-            let time_since_send_ns = subtract_22_bit_timestamps_with_a_known_more_recent(drop_back_edge_timestamp_ns, send_timestamp_ns);
-            if time_since_send_ns < current_min_rtt_on_connection_ns * bytes_delivered_buckets.len() as u64 { break; }
+
+        while drop_cursor < serial_number {
+            // The drop back edge.
+            let (packet_size_bytes, send_timestamp_ns, _ecn_marked, acked) = decompress_packet_info(
+                packet_buffer[drop_cursor as usize % PACKET_HISTORY_BUFFER_LEN],
+            );
+            let time_since_send_ns = subtract_22_bit_timestamps_with_a_known_more_recent(
+                drop_back_edge_timestamp_ns,
+                send_timestamp_ns,
+            );
+            if time_since_send_ns
+                < current_min_rtt_on_connection_ns * bytes_delivered_buckets.len() as u64
+            {
+                break;
+            }
             if acked == false {
                 bytes_on_the_wire -= packet_size_bytes as u64;
             }
             drop_cursor += 1;
         }
-    
+
         if serial_number + 1 >= drop_cursor + (PACKET_HISTORY_BUFFER_LEN as u64) {
             eprintln!("Error! PACKET_HISTORY_BUFFER_LEN is too small.\n");
             continue;
-        }
-        else {
-            let to_send_len_compressed = decompress_packet_size_to_8_bits(compress_packet_size_to_8_bits(1280)) as u64;
+        } else {
+            let to_send_len_compressed =
+                decompress_packet_size_to_8_bits(compress_packet_size_to_8_bits(1280)) as u64;
             if to_send_len_compressed + bytes_on_the_wire <= allowed_bytes_on_the_wire {
                 store_u64(&mut buf[0..8], serial_number);
                 buf[8] = 1;
                 let packet_size = 1280;
-                let res = udp_send_with_congestion_and_dscp(socket, Ipv6Addr::LOCALHOST, reflector_port, &buf[0..packet_size], Dscp::BestEffort);
+                let res = udp_send_with_congestion_and_dscp(
+                    socket,
+                    Ipv6Addr::LOCALHOST,
+                    reflector_port,
+                    &buf[0..packet_size],
+                    Dscp::BestEffort,
+                );
                 if let Ok(timestamp_ns) = res {
-                    packet_buffer[serial_number as usize % PACKET_HISTORY_BUFFER_LEN] = compress_packet_info(packet_size as u16, timestamp_ns, false, false);
+                    packet_buffer[serial_number as usize % PACKET_HISTORY_BUFFER_LEN] =
+                        compress_packet_info(packet_size as u16, timestamp_ns, false, false);
                     serial_number += 1;
                     bytes_on_the_wire += to_send_len_compressed;
                 }
             }
         }
-    
+
         let res = udp_recv_with_congestion_and_dscp(socket, &mut buf);
-        if matches!(res, Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock) { continue; }
+        if matches!(res, Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock) {
+            continue;
+        }
         //println!("{}: res = {:?}", port, res);
-        if res.is_err() { continue; }
-        let (buf_len, other_ip_addr, other_port, ecn_marked, _service_class, timestamp_ns) = res.unwrap();
-        if buf_len < 8 { continue; }
+        if res.is_err() {
+            continue;
+        }
+        let (buf_len, other_ip_addr, other_port, ecn_marked, _service_class, timestamp_ns) =
+            res.unwrap();
+        if buf_len < 8 {
+            continue;
+        }
         let packet_serial = load_u64(&buf[0..8]);
         let packet_plaintext = &buf[8..buf_len];
-        
+
         if packet_plaintext[0] == 2 {
-            if packet_plaintext.len() < 1+8+3 || (packet_plaintext.len()-1-8) % 3 != 0 {
+            if packet_plaintext.len() < 1 + 8 + 3 || (packet_plaintext.len() - 1 - 8) % 3 != 0 {
                 eprintln!("Error! Bad Ack. data = {}\n", hex::encode(packet_plaintext));
                 continue;
             }
             let mut min_rtt_this_ack = u64::MAX;
             let mut total_bytes_acked_this_ack = 0_u64;
-            
+
             let ack_base = load_u64(&packet_plaintext[1..9]);
             let mut o = 9;
             while o < packet_plaintext.len() {
-                let val = load_u24(&packet_plaintext[o..o+3]);
+                let val = load_u24(&packet_plaintext[o..o + 3]);
                 o += 3;
                 let ecn_marked = val & 0x80_0000 != 0;
                 let ack_number = ack_base + (val & 0x7f_ffff) as u64;
@@ -135,16 +189,26 @@ fn do_the_test_program(port: u16, reflector_port: u16) {
                     continue;
                 }
                 if ack_number + (PACKET_HISTORY_BUFFER_LEN as u64) < serial_number {
-                    eprintln!("Error! Ack number out of range. Too old for buffer. {}\n", ack_number);
+                    eprintln!(
+                        "Error! Ack number out of range. Too old for buffer. {}\n",
+                        ack_number
+                    );
                     continue;
                 }
-                let (packet_size_bytes, send_timestamp_ns, _ecn_marked, acked) = decompress_packet_info(packet_buffer[ack_number as usize % PACKET_HISTORY_BUFFER_LEN]);
+                let (packet_size_bytes, send_timestamp_ns, _ecn_marked, acked) =
+                    decompress_packet_info(
+                        packet_buffer[ack_number as usize % PACKET_HISTORY_BUFFER_LEN],
+                    );
                 if acked {
                     eprintln!("Error! Already recieved ack for {}\n", ack_number);
                     continue;
                 }
-                packet_buffer[ack_number as usize % PACKET_HISTORY_BUFFER_LEN] |= 1 | (ecn_marked as u32) << 1;
-                let rtt_ns = subtract_22_bit_timestamps_with_a_known_more_recent(timestamp_ns, send_timestamp_ns);
+                packet_buffer[ack_number as usize % PACKET_HISTORY_BUFFER_LEN] |=
+                    1 | (ecn_marked as u32) << 1;
+                let rtt_ns = subtract_22_bit_timestamps_with_a_known_more_recent(
+                    timestamp_ns,
+                    send_timestamp_ns,
+                );
                 min_rtt_this_ack = min_rtt_this_ack.min(rtt_ns);
                 if ack_number >= drop_cursor {
                     total_bytes_acked_this_ack += packet_size_bytes as u64;
@@ -152,25 +216,33 @@ fn do_the_test_program(port: u16, reflector_port: u16) {
             }
             if total_bytes_acked_this_ack > 0 {
                 bytes_on_the_wire -= total_bytes_acked_this_ack;
-                
+
                 let current_time_ns = monotonic_clock_ns();
-                
+
                 if current_time_ns > rtt_bucket_cursor_last_time + 1_000_000_000 {
                     rtt_bucket_cursor += 1;
-                    min_seen_rtt_buckets[rtt_bucket_cursor as usize % min_seen_rtt_buckets.len()] = u64::MAX;
+                    min_seen_rtt_buckets[rtt_bucket_cursor as usize % min_seen_rtt_buckets.len()] =
+                        u64::MAX;
                     rtt_bucket_cursor_last_time = current_time_ns;
                 }
-                min_seen_rtt_buckets[rtt_bucket_cursor as usize % min_seen_rtt_buckets.len()] = min_seen_rtt_buckets[rtt_bucket_cursor as usize % min_seen_rtt_buckets.len()].min(min_rtt_this_ack);
-                
-                if current_time_ns > bytes_delivered_bucket_cursor_last_time + current_min_rtt_on_connection_ns {
+                min_seen_rtt_buckets[rtt_bucket_cursor as usize % min_seen_rtt_buckets.len()] =
+                    min_seen_rtt_buckets[rtt_bucket_cursor as usize % min_seen_rtt_buckets.len()]
+                        .min(min_rtt_this_ack);
+
+                if current_time_ns
+                    > bytes_delivered_bucket_cursor_last_time + current_min_rtt_on_connection_ns
+                {
                     bytes_delivered_bucket_cursor += 1;
-                    bytes_delivered_buckets[bytes_delivered_bucket_cursor as usize % bytes_delivered_buckets.len()] = 0;
+                    bytes_delivered_buckets
+                        [bytes_delivered_bucket_cursor as usize % bytes_delivered_buckets.len()] =
+                        0;
                     bytes_delivered_bucket_cursor_last_time = current_time_ns;
                 }
-                bytes_delivered_buckets[bytes_delivered_bucket_cursor as usize % bytes_delivered_buckets.len()] += total_bytes_acked_this_ack;
+                bytes_delivered_buckets
+                    [bytes_delivered_bucket_cursor as usize % bytes_delivered_buckets.len()] +=
+                    total_bytes_acked_this_ack;
             }
-        }
-        else {
+        } else {
             println!("{}: data = {:?}", port, packet_plaintext);
         }
     }
@@ -178,78 +250,104 @@ fn do_the_test_program(port: u16, reflector_port: u16) {
 
 fn do_the_reflector(port: u16) {
     let socket = setup_and_bind_udp_socket(port);
-    
+
     let mut saved_other_ip_addr = Ipv6Addr::LOCALHOST;
     let mut saved_other_port = 0;
-    
+
     let mut serial_number = 2000;
-    
+
     let mut acks_in_waiting_min = 0_u64;
     let mut acks_in_waiting_buf = [(0_u64, false); ASSUMED_ACK_CAPACITY];
     let mut acks_in_waiting_count = 0;
     let mut first_waiting_ack_time_ns = 0_u64;
     let mut ack_send_buf = [0_u8; ASSUMED_DELIVERY_INNER_PAYLOAD_SIZE];
-    
+
     let mut buf = [0_u8; 16384];
     loop {
-        if acks_in_waiting_count > 0 && monotonic_clock_ns() - first_waiting_ack_time_ns > MAX_WAIT_BEFORE_SENDING_NON_FULL_ACK {
+        if acks_in_waiting_count > 0
+            && monotonic_clock_ns() - first_waiting_ack_time_ns
+                > MAX_WAIT_BEFORE_SENDING_NON_FULL_ACK
+        {
             store_u64(&mut ack_send_buf[0..8], serial_number);
             ack_send_buf[8] = 2;
             serial_number += 1;
             let mut o = 9;
-            store_u64(&mut ack_send_buf[o..o+8], acks_in_waiting_min);
+            store_u64(&mut ack_send_buf[o..o + 8], acks_in_waiting_min);
             o += 8;
             for i in 0..acks_in_waiting_count {
-                let val = ((acks_in_waiting_buf[i].0 - acks_in_waiting_min) as u32 & 0x7f_ffff) | ((acks_in_waiting_buf[i].1 as u32) << 23);
-                store_u24(&mut ack_send_buf[o..o+3], val);
+                let val = ((acks_in_waiting_buf[i].0 - acks_in_waiting_min) as u32 & 0x7f_ffff)
+                    | ((acks_in_waiting_buf[i].1 as u32) << 23);
+                store_u24(&mut ack_send_buf[o..o + 3], val);
                 o += 3;
             }
-            let res = udp_send_with_congestion_and_dscp(socket, saved_other_ip_addr, saved_other_port, &ack_send_buf[0..o], Dscp::Af21);
+            let res = udp_send_with_congestion_and_dscp(
+                socket,
+                saved_other_ip_addr,
+                saved_other_port,
+                &ack_send_buf[0..o],
+                Dscp::Af21,
+            );
             acks_in_waiting_count = 0;
         }
-    
+
         let res = udp_recv_with_congestion_and_dscp(socket, &mut buf);
-        if matches!(res, Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock) { continue; }
+        if matches!(res, Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock) {
+            continue;
+        }
         //println!("{}: res = {:?}", port, res);
-        if res.is_err() { continue; }
-        let (buf_len, other_ip_addr, other_port, ecn_marked, _service_class, timestamp_ns) = res.unwrap();
-        if buf_len < 8 { continue; }
+        if res.is_err() {
+            continue;
+        }
+        let (buf_len, other_ip_addr, other_port, ecn_marked, _service_class, timestamp_ns) =
+            res.unwrap();
+        if buf_len < 8 {
+            continue;
+        }
         let packet_serial = load_u64(&buf[0..8]);
-        let packet_plaintext = &buf[8..buf_len-8];
+        let packet_plaintext = &buf[8..buf_len - 8];
         //println!("{}: data = {:?}", port, packet_plaintext);
-        
+
         saved_other_ip_addr = other_ip_addr;
         saved_other_port = other_port;
-        
+
         if acks_in_waiting_count == 0 {
             acks_in_waiting_min = packet_serial;
             first_waiting_ack_time_ns = timestamp_ns;
-        }
-        else {
+        } else {
             acks_in_waiting_min = acks_in_waiting_min.min(packet_serial);
         }
         acks_in_waiting_buf[acks_in_waiting_count] = (packet_serial, ecn_marked);
         acks_in_waiting_count += 1;
-        if acks_in_waiting_count == ASSUMED_ACK_CAPACITY || monotonic_clock_ns() - first_waiting_ack_time_ns > MIN_WAIT_BEFORE_SENDING_NON_FULL_ACK {
+        if acks_in_waiting_count == ASSUMED_ACK_CAPACITY
+            || monotonic_clock_ns() - first_waiting_ack_time_ns
+                > MIN_WAIT_BEFORE_SENDING_NON_FULL_ACK
+        {
             store_u64(&mut ack_send_buf[0..8], serial_number);
             ack_send_buf[8] = 2;
             serial_number += 1;
             let mut o = 9;
-            store_u64(&mut ack_send_buf[o..o+8], acks_in_waiting_min);
+            store_u64(&mut ack_send_buf[o..o + 8], acks_in_waiting_min);
             o += 8;
             for i in 0..acks_in_waiting_count {
-                let val = ((acks_in_waiting_buf[i].0 - acks_in_waiting_min) as u32 & 0x7f_ffff) | ((acks_in_waiting_buf[i].1 as u32) << 23);
-                store_u24(&mut ack_send_buf[o..o+3], val);
+                let val = ((acks_in_waiting_buf[i].0 - acks_in_waiting_min) as u32 & 0x7f_ffff)
+                    | ((acks_in_waiting_buf[i].1 as u32) << 23);
+                store_u24(&mut ack_send_buf[o..o + 3], val);
                 o += 3;
             }
-            let res = udp_send_with_congestion_and_dscp(socket, saved_other_ip_addr, saved_other_port, &ack_send_buf[0..o], Dscp::Af21);
+            let res = udp_send_with_congestion_and_dscp(
+                socket,
+                saved_other_ip_addr,
+                saved_other_port,
+                &ack_send_buf[0..o],
+                Dscp::Af21,
+            );
             acks_in_waiting_count = 0;
         }
     }
 }
 
 const ASSUMED_DELIVERY_INNER_PAYLOAD_SIZE: usize = 1232;
-const ASSUMED_ACK_CAPACITY: usize = (ASSUMED_DELIVERY_INNER_PAYLOAD_SIZE-8-1-8)/3;
+const ASSUMED_ACK_CAPACITY: usize = (ASSUMED_DELIVERY_INNER_PAYLOAD_SIZE - 8 - 1 - 8) / 3;
 
 const MIN_WAIT_BEFORE_SENDING_NON_FULL_ACK: u64 = 5_000_000;
 const MAX_WAIT_BEFORE_SENDING_NON_FULL_ACK: u64 = 20_000_000;
@@ -257,17 +355,22 @@ const MAX_WAIT_BEFORE_SENDING_NON_FULL_ACK: u64 = 20_000_000;
 const PACKET_HISTORY_BUFFER_LEN: usize = 1048576;
 
 #[inline]
-fn compress_packet_info(packet_size_bytes: u16, timestamp_ns: u64, ecn_marked: bool, acked: bool) -> u32 {
+fn compress_packet_info(
+    packet_size_bytes: u16,
+    timestamp_ns: u64,
+    ecn_marked: bool,
+    acked: bool,
+) -> u32 {
     let size8 = compress_packet_size_to_8_bits(packet_size_bytes) as u32;
-    let ts22  = ((compress_timestamp_to_22_bits(timestamp_ns) >> 13) as u32) & ((1u32 << 22) - 1);
+    let ts22 = ((compress_timestamp_to_22_bits(timestamp_ns) >> 13) as u32) & ((1u32 << 22) - 1);
     (size8 << 24) | (ts22 << 2) | ((ecn_marked as u32) << 1) | (acked as u32)
 }
 #[inline]
 fn decompress_packet_info(x: u32) -> (u16, u64, bool, bool) {
     let size8 = (x >> 24) as u8;
-    let ts22  = (x >> 2) & ((1u32 << 22) - 1);
-    let ecn   = ((x >> 1) & 1) != 0;
-    let ack   = (x & 1) != 0;
+    let ts22 = (x >> 2) & ((1u32 << 22) - 1);
+    let ecn = ((x >> 1) & 1) != 0;
+    let ack = (x & 1) != 0;
 
     let packet_size_bytes = decompress_packet_size_to_8_bits(size8);
     let timestamp_ns_quantized = (ts22 as u64) << 13;
@@ -277,9 +380,9 @@ fn decompress_packet_info(x: u32) -> (u16, u64, bool, bool) {
 
 #[inline]
 fn subtract_22_bit_timestamps_with_a_known_more_recent(mut recent: u64, mut old: u64) -> u64 {
-    const ROUND_MASK: u64 = 0x1fff;                 // clear low 13 bits
-    const KEEP_MASK:  u64 = 0x0000_0007_ffff_ffff;  // keep low 35 bits
-    const MOD:        u64 = 0x8_0000_0000;            // 1 << 35
+    const ROUND_MASK: u64 = 0x1fff; // clear low 13 bits
+    const KEEP_MASK: u64 = 0x0000_0007_ffff_ffff; // keep low 35 bits
+    const MOD: u64 = 0x8_0000_0000; // 1 << 35
 
     recent = recent.wrapping_add(ROUND_MASK) & !ROUND_MASK;
     recent &= KEEP_MASK;
@@ -293,7 +396,7 @@ fn subtract_22_bit_timestamps_with_a_known_more_recent(mut recent: u64, mut old:
 #[inline]
 fn compress_timestamp_to_22_bits(mut n: u64) -> u64 {
     const ROUND_MASK: u64 = 0x1fff;
-    const KEEP_MASK:  u64 = 0x0000_0007_ffff_ffff;
+    const KEEP_MASK: u64 = 0x0000_0007_ffff_ffff;
 
     n = n.wrapping_add(ROUND_MASK) & !ROUND_MASK;
     n & KEEP_MASK
@@ -311,14 +414,30 @@ fn compress_packet_size_to_8_bits(n: u16) -> u8 {
     let mut out: u8 = 0;
 
     // i = 7 ..= 0
-    let t7 = (rem >= K[7]) as u16; rem = rem.wrapping_sub(t7 * K[7]); out |= (t7 as u8) << 7;
-    let t6 = (rem >= K[6]) as u16; rem = rem.wrapping_sub(t6 * K[6]); out |= (t6 as u8) << 6;
-    let t5 = (rem >= K[5]) as u16; rem = rem.wrapping_sub(t5 * K[5]); out |= (t5 as u8) << 5;
-    let t4 = (rem >= K[4]) as u16; rem = rem.wrapping_sub(t4 * K[4]); out |= (t4 as u8) << 4;
-    let t3 = (rem >= K[3]) as u16; rem = rem.wrapping_sub(t3 * K[3]); out |= (t3 as u8) << 3;
-    let t2 = (rem >= K[2]) as u16; rem = rem.wrapping_sub(t2 * K[2]); out |= (t2 as u8) << 2;
-    let t1 = (rem >= K[1]) as u16; rem = rem.wrapping_sub(t1 * K[1]); out |= (t1 as u8) << 1;
-    let t0 = (rem >= K[0]) as u16; rem = rem.wrapping_sub(t0 * K[0]); out |= (t0 as u8) << 0;
+    let t7 = (rem >= K[7]) as u16;
+    rem = rem.wrapping_sub(t7 * K[7]);
+    out |= (t7 as u8) << 7;
+    let t6 = (rem >= K[6]) as u16;
+    rem = rem.wrapping_sub(t6 * K[6]);
+    out |= (t6 as u8) << 6;
+    let t5 = (rem >= K[5]) as u16;
+    rem = rem.wrapping_sub(t5 * K[5]);
+    out |= (t5 as u8) << 5;
+    let t4 = (rem >= K[4]) as u16;
+    rem = rem.wrapping_sub(t4 * K[4]);
+    out |= (t4 as u8) << 4;
+    let t3 = (rem >= K[3]) as u16;
+    rem = rem.wrapping_sub(t3 * K[3]);
+    out |= (t3 as u8) << 3;
+    let t2 = (rem >= K[2]) as u16;
+    rem = rem.wrapping_sub(t2 * K[2]);
+    out |= (t2 as u8) << 2;
+    let t1 = (rem >= K[1]) as u16;
+    rem = rem.wrapping_sub(t1 * K[1]);
+    out |= (t1 as u8) << 1;
+    let t0 = (rem >= K[0]) as u16;
+    rem = rem.wrapping_sub(t0 * K[0]);
+    out |= (t0 as u8) << 0;
 
     out
 }
@@ -373,31 +492,28 @@ pub use linux::*;
 #[allow(unsafe_code)]
 mod linux {
     use super::*;
-    
+
     #[inline]
     pub fn monotonic_clock_ns() -> u64 {
         unsafe {
             let mut ts: libc::timespec = std::mem::zeroed();
             if libc::clock_gettime(libc::CLOCK_MONOTONIC_RAW, &mut ts) != 0 {
-                panic!("clock_gettime() failed: {}", std::io::Error::last_os_error());
+                panic!(
+                    "clock_gettime() failed: {}",
+                    std::io::Error::last_os_error()
+                );
             }
             (ts.tv_sec as u64) * 1_000_000_000u64 + (ts.tv_nsec as u64)
         }
     }
 
     pub fn setup_and_bind_udp_socket(port: u16) -> SockHandle {
-        let fd = unsafe {
-            libc::socket(
-                libc::AF_INET6,
-                libc::SOCK_DGRAM,
-                libc::IPPROTO_UDP
-            )
-        };
-    
+        let fd = unsafe { libc::socket(libc::AF_INET6, libc::SOCK_DGRAM, libc::IPPROTO_UDP) };
+
         if fd < 0 {
             panic!("socket() failed: {}", std::io::Error::last_os_error());
         }
-        
+
         // Make socket non-blocking
         unsafe {
             let flags = libc::fcntl(fd, libc::F_GETFL);
@@ -408,10 +524,10 @@ mod linux {
                 panic!("fcntl(F_SETFL) failed: {}", std::io::Error::last_os_error());
             }
         }
-    
+
         unsafe {
             let zero: libc::c_int = 0;
-    
+
             // Dual-stack: allow IPv4-mapped IPv6 addresses.
             if libc::setsockopt(
                 fd,
@@ -421,17 +537,20 @@ mod linux {
                 std::mem::size_of_val(&zero) as libc::socklen_t,
             ) != 0
             {
-                panic!("Failed to disable IPV6_V6ONLY: {}", std::io::Error::last_os_error());
+                panic!(
+                    "Failed to disable IPV6_V6ONLY: {}",
+                    std::io::Error::last_os_error()
+                );
             }
         }
-    
+
         // Bind [::]:port
         unsafe {
             let mut addr: libc::sockaddr_in6 = std::mem::zeroed();
             addr.sin6_family = libc::AF_INET6 as _;
             addr.sin6_port = port.to_be();
             addr.sin6_addr = libc::in6_addr { s6_addr: [0; 16] };
-    
+
             if libc::bind(
                 fd,
                 &addr as *const _ as *const libc::sockaddr,
@@ -441,10 +560,10 @@ mod linux {
                 panic!("bind() failed: {}", std::io::Error::last_os_error());
             }
         }
-    
+
         unsafe {
             let one: libc::c_int = 1;
-    
+
             // IPv4 TOS (includes ECN bits) as CMSG on recvmsg
             if libc::setsockopt(
                 fd,
@@ -454,9 +573,12 @@ mod linux {
                 std::mem::size_of_val(&one) as libc::socklen_t,
             ) != 0
             {
-                panic!("Failed to Enable IPv4 TOS, error: {}", std::io::Error::last_os_error());
+                panic!(
+                    "Failed to Enable IPv4 TOS, error: {}",
+                    std::io::Error::last_os_error()
+                );
             }
-    
+
             // IPv6 Traffic Class (includes ECN bits) as CMSG on recvmsg
             if libc::setsockopt(
                 fd,
@@ -466,12 +588,15 @@ mod linux {
                 std::mem::size_of_val(&one) as libc::socklen_t,
             ) != 0
             {
-                panic!("Failed to Enable IPv6 TOS, error: {}", std::io::Error::last_os_error());
+                panic!(
+                    "Failed to Enable IPv6 TOS, error: {}",
+                    std::io::Error::last_os_error()
+                );
             }
         }
         SockHandle::from_native(fd)
     }
-    
+
     /// SEND one UDP packet to (dst_ip6, dst_port) on a dual-stack socket.
     /// - If `dst_ip6` is IPv4-mapped (::ffff:a.b.c.d), it sends to IPv4 using sockaddr_in
     ///   and uses IP_TOS cmsg.
@@ -485,12 +610,12 @@ mod linux {
         dscp: Dscp,
     ) -> std::io::Result<u64> {
         let fd = udp_socket.to_native();
-    
+
         let mut iov = libc::iovec {
             iov_base: payload.as_ptr() as *mut libc::c_void,
             iov_len: payload.len(),
         };
-    
+
         // Decide whether this is IPv4-mapped
         let (mut name_buf, name_len, is_v4) = if let Some(v4) = dst_ip6.to_ipv4_mapped() {
             let mut sin: libc::sockaddr_in = unsafe { std::mem::zeroed() };
@@ -499,7 +624,7 @@ mod linux {
             sin.sin_addr = libc::in_addr {
                 s_addr: u32::from_ne_bytes(v4.octets()).to_be(),
             };
-    
+
             let mut buf = vec![0u8; std::mem::size_of::<libc::sockaddr_in>()];
             unsafe {
                 std::ptr::copy_nonoverlapping(
@@ -514,8 +639,10 @@ mod linux {
             let mut sin6: libc::sockaddr_in6 = unsafe { std::mem::zeroed() };
             sin6.sin6_family = libc::AF_INET6 as _;
             sin6.sin6_port = dst_port.to_be();
-            sin6.sin6_addr = libc::in6_addr { s6_addr: dst_ip6.octets() };
-    
+            sin6.sin6_addr = libc::in6_addr {
+                s6_addr: dst_ip6.octets(),
+            };
+
             let mut buf = vec![0u8; std::mem::size_of::<libc::sockaddr_in6>()];
             unsafe {
                 std::ptr::copy_nonoverlapping(
@@ -527,10 +654,10 @@ mod linux {
             let buf_len = buf.len() as libc::socklen_t;
             (buf, buf_len, false)
         };
-    
+
         // Control buffer
         let mut cbuf = [0u8; 128];
-    
+
         let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
         msg.msg_name = name_buf.as_mut_ptr() as *mut libc::c_void;
         msg.msg_namelen = name_len;
@@ -538,27 +665,38 @@ mod linux {
         msg.msg_iovlen = 1;
         msg.msg_control = cbuf.as_mut_ptr() as *mut libc::c_void;
         msg.msg_controllen = cbuf.len() as u32;
-    
+
         let tclass_byte = ((dscp as u8) << 2) | 0b10; // ecn
-    
+
         unsafe {
             let cmsg = libc::CMSG_FIRSTHDR(&msg as *const _ as *mut _);
             if cmsg.is_null() {
-                return Err(std::io::Error::new(std::io::ErrorKind::Other, "CMSG_FIRSTHDR returned null"));
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "CMSG_FIRSTHDR returned null",
+                ));
             }
-    
+
             // Linux uses int for send cmsg values.
             let val: libc::c_int = tclass_byte as libc::c_int;
-    
-            (*cmsg).cmsg_level = if is_v4 { libc::IPPROTO_IP } else { libc::IPPROTO_IPV6 };
-            (*cmsg).cmsg_type = if is_v4 { libc::IP_TOS } else { libc::IPV6_TCLASS };
+
+            (*cmsg).cmsg_level = if is_v4 {
+                libc::IPPROTO_IP
+            } else {
+                libc::IPPROTO_IPV6
+            };
+            (*cmsg).cmsg_type = if is_v4 {
+                libc::IP_TOS
+            } else {
+                libc::IPV6_TCLASS
+            };
             (*cmsg).cmsg_len = libc::CMSG_LEN(std::mem::size_of::<libc::c_int>() as _) as _;
-    
+
             let data = libc::CMSG_DATA(cmsg) as *mut libc::c_int;
             *data = val;
-    
+
             msg.msg_controllen = libc::CMSG_SPACE(std::mem::size_of::<libc::c_int>() as _) as _;
-    
+
             let timestamp_ns = monotonic_clock_ns();
             let n = libc::sendmsg(fd, &msg as *const _ as *mut _, 0);
             if n < 0 {
@@ -574,7 +712,7 @@ mod linux {
             Ok(timestamp_ns)
         }
     }
-    
+
     /// RECV one UDP packet, returning:
     /// (len, src_ip6, src_port, congested, dscp)
     ///
@@ -586,15 +724,15 @@ mod linux {
         buf: &mut [u8],
     ) -> std::io::Result<(usize, Ipv6Addr, u16, bool, Dscp, u64)> {
         let fd = udp_socket.to_native();
-    
+
         let mut iov = libc::iovec {
             iov_base: buf.as_mut_ptr() as *mut libc::c_void,
             iov_len: buf.len(),
         };
-    
+
         let mut addr_storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
         let mut cbuf = [0u8; 128];
-    
+
         let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
         msg.msg_name = (&mut addr_storage as *mut _) as *mut libc::c_void;
         msg.msg_namelen = std::mem::size_of::<libc::sockaddr_storage>() as _;
@@ -602,20 +740,20 @@ mod linux {
         msg.msg_iovlen = 1;
         msg.msg_control = cbuf.as_mut_ptr() as *mut libc::c_void;
         msg.msg_controllen = cbuf.len() as u32;
-    
+
         let n = unsafe { libc::recvmsg(fd, &mut msg as *mut libc::msghdr, 0) };
         let timestamp_ns = monotonic_clock_ns();
         if n < 0 {
             return Err(std::io::Error::last_os_error());
         }
-        
+
         if (msg.msg_flags & libc::MSG_TRUNC) != 0 {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "UDP datagram truncated (buffer too small)",
             ));
         }
-    
+
         // Peer address -> always return IPv6 (IPv4 becomes v4-mapped IPv6)
         let (src_ip6, src_port) = if (addr_storage.ss_family as i32) == libc::AF_INET {
             let sin: &libc::sockaddr_in =
@@ -630,41 +768,46 @@ mod linux {
             let port = u16::from_be(sin6.sin6_port);
             (ip6, port)
         } else {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "unknown sockaddr family"));
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "unknown sockaddr family",
+            ));
         };
-    
+
         // Defaults if no cmsg
         let mut congested = false;
         let mut dscp = Dscp::BestEffort;
-    
+
         unsafe {
             let mut cmsg_ptr = libc::CMSG_FIRSTHDR(&msg as *const _);
             while !cmsg_ptr.is_null() {
                 let cmsg = &*cmsg_ptr;
-    
+
                 let mut tclass_opt: Option<u8> = None;
-    
+
                 if cmsg.cmsg_level == libc::IPPROTO_IP && cmsg.cmsg_type == libc::IP_TOS {
                     // With IP_RECVTOS, Linux provides 1 byte.
                     let data = libc::CMSG_DATA(cmsg_ptr) as *const u8;
                     tclass_opt = Some(*data);
-                } else if cmsg.cmsg_level == libc::IPPROTO_IPV6 && cmsg.cmsg_type == libc::IPV6_TCLASS {
+                } else if cmsg.cmsg_level == libc::IPPROTO_IPV6
+                    && cmsg.cmsg_type == libc::IPV6_TCLASS
+                {
                     // With IPV6_RECVTCLASS, Linux usually provides an int.
                     let data = libc::CMSG_DATA(cmsg_ptr) as *const libc::c_int;
                     tclass_opt = Some((*data as u8));
                 }
-    
+
                 if let Some(tclass) = tclass_opt {
                     let ecn_bits = tclass & 0b11;
                     congested = ecn_bits == 0b11; // CE
                     dscp = Dscp::from_u8(tclass >> 2);
                     break;
                 }
-    
+
                 cmsg_ptr = libc::CMSG_NXTHDR(&msg as *const _, cmsg_ptr);
             }
         }
-    
+
         Ok((n as usize, src_ip6, src_port, congested, dscp, timestamp_ns))
     }
 }
@@ -674,7 +817,7 @@ pub use windows::*;
 #[cfg(windows)]
 mod windows {
     use super::*;
-    
+
     #[inline]
     pub fn monotonic_clock_ns() -> u64 {
         panic!("Not implemented");
@@ -705,10 +848,14 @@ pub struct SockHandle(u64);
 
 impl SockHandle {
     #[inline]
-    pub fn as_u64(self) -> u64 { self.0 }
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
 
     #[inline]
-    pub fn from_u64(v: u64) -> Self { Self(v) }
+    pub fn from_u64(v: u64) -> Self {
+        Self(v)
+    }
 }
 
 #[cfg(unix)]
@@ -742,9 +889,9 @@ impl SockHandle {
 #[repr(u8)]
 pub enum Dscp {
     BestEffort = 0, // I do not care about this packet. Dropped first.
-    Af11       = 10, // Important but low priority packet. Make more effort to deliver this.
-    Af21       = 18, // Important and high priority packet. High delivery effort and lower latency. QUIC control frames use this.
-    Ef         = 46, // Expedited Forwarding. VoIP. Low Latency or useless. Very heavily policed, must be low bandwidth.
+    Af11 = 10,      // Important but low priority packet. Make more effort to deliver this.
+    Af21 = 18, // Important and high priority packet. High delivery effort and lower latency. QUIC control frames use this.
+    Ef = 46, // Expedited Forwarding. VoIP. Low Latency or useless. Very heavily policed, must be low bandwidth.
 }
 impl Dscp {
     pub fn from_u8(v: u8) -> Dscp {

--- a/tenderlink/src/bandwidth_test.rs
+++ b/tenderlink/src/bandwidth_test.rs
@@ -370,6 +370,7 @@ fn load_u24(buf: &[u8]) -> u32 {
 #[cfg(unix)]
 pub use linux::*;
 #[cfg(unix)]
+#[allow(unsafe_code)]
 mod linux {
     use super::*;
     

--- a/tenderlink/src/lib.rs
+++ b/tenderlink/src/lib.rs
@@ -2,61 +2,68 @@
 #![allow(dead_code)]
 #![allow(unused_parens)]
 #![allow(clippy::never_loop)]
-
 #![allow(clippy::eq_op)]
-const PRINT_PROTOCOL:       bool = 1 == 1;
-const PRINT_PROTOCOL_TAG:   bool = 0 == 1;
-const PRINT_ROSTER:         bool = 0 == 1;
-const PRINT_ROSTER_CMD:     bool = 1 == 1;
-const PRINT_NETWORK_STATS:  bool = 1 == 1;
-const PRINT_PEERS:          bool = 0 == 1;
+const PRINT_PROTOCOL: bool = 1 == 1;
+const PRINT_PROTOCOL_TAG: bool = 0 == 1;
+const PRINT_ROSTER: bool = 0 == 1;
+const PRINT_ROSTER_CMD: bool = 1 == 1;
+const PRINT_NETWORK_STATS: bool = 1 == 1;
+const PRINT_PEERS: bool = 0 == 1;
 const PRINT_VALID_INCOMING: bool = 0 == 1;
-const PRINT_SENDS:          bool = 0 == 1;
-const PRINT_SEND_CS:        bool = 0 == 1;
-const PRINT_RNGS:           bool = 0 == 1;
-const PRINT_SIGN:           bool = 0 == 1;
-const PRINT_BFT_PROPOSAL:   bool = 0 == 1;
-const PRINT_BFT_VOTE:       bool = 1 == 1;
-const PRINT_BFT_UPDATE:     bool = 1 == 1;
-const PRINT_BFT_STATE:      bool = 0 == 1;
+const PRINT_SENDS: bool = 0 == 1;
+const PRINT_SEND_CS: bool = 0 == 1;
+const PRINT_RNGS: bool = 0 == 1;
+const PRINT_SIGN: bool = 0 == 1;
+const PRINT_BFT_PROPOSAL: bool = 0 == 1;
+const PRINT_BFT_VOTE: bool = 1 == 1;
+const PRINT_BFT_UPDATE: bool = 1 == 1;
+const PRINT_BFT_STATE: bool = 0 == 1;
 const PRINT_BFT_CONDITIONS: bool = 1 == 1;
-const PRINT_BFT_TIMEOUTS:   bool = 0 == 1;
-const PRINT_POWLINK:        bool = 1 == 1;
-
+const PRINT_BFT_TIMEOUTS: bool = 0 == 1;
+const PRINT_POWLINK: bool = 1 == 1;
 
 // MTU discovery is an option, but for now we're adopting a very conservative and VPN-friendly fixed-value MTU.
-const ETHERNET_FRAME_SIZE:   usize = 1500;
-const IPV6_HEADER_SIZE:      usize =   40;
-const UDP_HEADER_SIZE:       usize =    8;
-const PPPOE_HEADER_SIZE:     usize =    8;
-const WIREGUARD_HEADER_SIZE: usize =   40;
-const VPN_HEADER_SIZE:       usize =   64; // relatively conservative(?) OpenVPN header overhead size
-const NOISE_NONCE_SIZE:      usize =    8;
-const NOISE_HEADER_SIZE:     usize =   16;
+const ETHERNET_FRAME_SIZE: usize = 1500;
+const IPV6_HEADER_SIZE: usize = 40;
+const UDP_HEADER_SIZE: usize = 8;
+const PPPOE_HEADER_SIZE: usize = 8;
+const WIREGUARD_HEADER_SIZE: usize = 40;
+const VPN_HEADER_SIZE: usize = 64; // relatively conservative(?) OpenVPN header overhead size
+const NOISE_NONCE_SIZE: usize = 8;
+const NOISE_HEADER_SIZE: usize = 16;
 
-const MAX_PATH_HEADERS_SIZE: usize = (IPV6_HEADER_SIZE + UDP_HEADER_SIZE + WIREGUARD_HEADER_SIZE + VPN_HEADER_SIZE + NOISE_NONCE_SIZE + NOISE_HEADER_SIZE);
+const MAX_PATH_HEADERS_SIZE: usize = (IPV6_HEADER_SIZE
+    + UDP_HEADER_SIZE
+    + WIREGUARD_HEADER_SIZE
+    + VPN_HEADER_SIZE
+    + NOISE_NONCE_SIZE
+    + NOISE_HEADER_SIZE);
 
 const PATH_MTU: usize = ETHERNET_FRAME_SIZE - MAX_PATH_HEADERS_SIZE;
 
 // Tweak this!
 const MAX_BANDWIDTH_BYTES_PER_SECOND: usize = 1_000_000;
 
-
-use static_assertions::{const_assert};
-use std::{hash::DefaultHasher, io::{Cursor, Read}, net::{Ipv6Addr, SocketAddr, SocketAddrV6}, sync::{Arc, Mutex}};
 use byteorder::{LittleEndian, ReadBytesExt};
-use ed25519_zebra::{Signature, SigningKey, VerificationKeyBytes, VerificationKey};
-use rand::{seq::{IndexedRandom}, Rng, RngCore, SeedableRng};
+use ed25519_zebra::{Signature, SigningKey, VerificationKey, VerificationKeyBytes};
+use rand::{Rng, RngCore, SeedableRng, seq::IndexedRandom};
 use rand_chacha::ChaCha20Rng;
 use rand_pcg::Lcg128CmDxsm64 as SimRng;
 use snow::resolvers::CryptoResolver;
+use static_assertions::const_assert;
+use std::{
+    hash::DefaultHasher,
+    io::{Cursor, Read},
+    net::{Ipv6Addr, SocketAddr, SocketAddrV6},
+    sync::{Arc, Mutex},
+};
 use tokio::time::Instant;
 
 const TICK_DURATION: std::time::Duration = std::time::Duration::from_millis(300);
 const TIMEOUT_DURATION: std::time::Duration = std::time::Duration::from_millis(10000);
 const NONCE_FORWARD_JUMP_TOLERANCE: u64 = 512;
 
-fn is_timeout(e: std::io::ErrorKind) -> bool{
+fn is_timeout(e: std::io::ErrorKind) -> bool {
     e == std::io::ErrorKind::WouldBlock || e == std::io::ErrorKind::TimedOut
 }
 
@@ -116,7 +123,7 @@ struct AcknowledgedSentPacket {
 #[derive(Debug, Default, Copy, Clone)]
 struct Slot<T> {
     index: usize,
-    value: T
+    value: T,
 }
 
 #[derive(Debug)]
@@ -154,7 +161,6 @@ impl<T: Default, const N: usize> RingStream<T, N> {
     }
 }
 
-
 struct TMVote {
     approve: bool,
     todo_sign_bytes: [u8; 96],
@@ -163,8 +169,12 @@ struct TMVote {
 #[derive(Clone, PartialEq, Debug)]
 pub struct BlockValue(pub Vec<u8>); // NOTE (azmr): currently exactly-divided by chunk size for simplicity
 impl BlockValue {
-    fn id_from_value(&self, hash_keys: &HashKeys) -> ValueId { ValueId(hash_keys.value_id.hash(&self.0)) }
-    fn chunks_n(&self) -> usize { self.0.len().div_ceil(PROPOSAL_CHUNK_DATA_SIZE) }
+    fn id_from_value(&self, hash_keys: &HashKeys) -> ValueId {
+        ValueId(hash_keys.value_id.hash(&self.0))
+    }
+    fn chunks_n(&self) -> usize {
+        self.0.len().div_ceil(PROPOSAL_CHUNK_DATA_SIZE)
+    }
     fn chunk_o_size(&self, chunk_i: usize) -> (usize, usize) {
         let o = chunk_i * PROPOSAL_CHUNK_DATA_SIZE;
         (o, usize::min(PROPOSAL_CHUNK_DATA_SIZE, self.0.len() - o))
@@ -172,55 +182,162 @@ impl BlockValue {
 }
 
 #[derive(Clone)]
-pub struct ClosureToProposeNewBlock(pub Arc<dyn Fn() -> core::pin::Pin<Box<dyn Future<Output = Option<BlockValue>> + Send>> + Send + Sync + 'static>);
+pub struct ClosureToProposeNewBlock(
+    pub  Arc<
+        dyn Fn() -> core::pin::Pin<Box<dyn Future<Output = Option<BlockValue>> + Send>>
+            + Send
+            + Sync
+            + 'static,
+    >,
+);
 impl std::fmt::Debug for ClosureToProposeNewBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str("ClosureToProposeNewBlock(..)") }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ClosureToProposeNewBlock(..)")
+    }
 }
 #[derive(Clone)]
-pub struct ClosureToValidateProposedBlock(pub Arc<dyn for<'a> Fn(&'a BlockValue)-> core::pin::Pin<Box<dyn Future<Output = (TMStatus, TMStatusReason)> + Send + 'a>> + Send + Sync + 'static>);
+pub struct ClosureToValidateProposedBlock(
+    pub  Arc<
+        dyn for<'a> Fn(
+                &'a BlockValue,
+            ) -> core::pin::Pin<
+                Box<dyn Future<Output = (TMStatus, TMStatusReason)> + Send + 'a>,
+            > + Send
+            + Sync
+            + 'static,
+    >,
+);
 impl std::fmt::Debug for ClosureToValidateProposedBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str("ClosureToValidateProposedBlock(..)") }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ClosureToValidateProposedBlock(..)")
+    }
 }
 #[derive(Clone)]
-pub struct ClosureToPushDecidedBlock(pub Arc<dyn Fn(BlockValue, FatPointerToBftBlock3, Vec<TMSig>)-> core::pin::Pin<Box<dyn Future<Output = Vec<SortedRosterMember>> + Send>> + Send + Sync + 'static>);
+pub struct ClosureToPushDecidedBlock(
+    pub  Arc<
+        dyn Fn(
+                BlockValue,
+                FatPointerToBftBlock3,
+                Vec<TMSig>,
+            )
+                -> core::pin::Pin<Box<dyn Future<Output = Vec<SortedRosterMember>> + Send>>
+            + Send
+            + Sync
+            + 'static,
+    >,
+);
 impl std::fmt::Debug for ClosureToPushDecidedBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str("ClosureToPushDecidedBlock(..)") }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ClosureToPushDecidedBlock(..)")
+    }
 }
 #[derive(Clone)]
-pub struct ClosureToGetHistoricalBlock(pub Arc<dyn Fn(u64)-> core::pin::Pin<Box<dyn Future<Output = (BlockValue, FatPointerToBftBlock3)> + Send>> + Send + Sync + 'static>);
+pub struct ClosureToGetHistoricalBlock(
+    pub  Arc<
+        dyn Fn(
+                u64,
+            ) -> core::pin::Pin<
+                Box<dyn Future<Output = (BlockValue, FatPointerToBftBlock3)> + Send>,
+            > + Send
+            + Sync
+            + 'static,
+    >,
+);
 impl std::fmt::Debug for ClosureToGetHistoricalBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str("ClosureToGetHistoricalBlock(..)") }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ClosureToGetHistoricalBlock(..)")
+    }
 }
 #[derive(Clone)]
-pub struct ClosureToGetPow(pub Arc<dyn Fn([u8; 32])-> core::pin::Pin<Box<dyn Future<Output = Option<Vec<u8>>> + Send>> + Send + Sync + 'static>); // @Phillip
+pub struct ClosureToGetPow(
+    pub  Arc<
+        dyn Fn([u8; 32]) -> core::pin::Pin<Box<dyn Future<Output = Option<Vec<u8>>> + Send>>
+            + Send
+            + Sync
+            + 'static,
+    >,
+); // @Phillip
 impl std::fmt::Debug for ClosureToGetPow {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str("ClosureToGetPow(..)") }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ClosureToGetPow(..)")
+    }
 }
 #[derive(Clone)]
-pub struct ClosureToParsePow(pub Arc<dyn Fn([u8; 32], Vec<u8>)-> core::pin::Pin<Box<dyn Future<Output =     Option<Arc<zebra_chain::block::Block>>     > + Send>> + Send + Sync + 'static>); // @Phillip
+pub struct ClosureToParsePow(
+    pub  Arc<
+        dyn Fn(
+                [u8; 32],
+                Vec<u8>,
+            ) -> core::pin::Pin<
+                Box<dyn Future<Output = Option<Arc<zebra_chain::block::Block>>> + Send>,
+            > + Send
+            + Sync
+            + 'static,
+    >,
+); // @Phillip
 impl std::fmt::Debug for ClosureToParsePow {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str("ClosureToParsePow(..)") }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ClosureToParsePow(..)")
+    }
 }
 #[derive(Clone)]
-pub struct ClosureIsPoWInChain(pub Arc<dyn Fn([u8; 32])-> core::pin::Pin<Box<dyn Future<Output = bool> + Send>> + Send + Sync + 'static>); // @Phillip
+pub struct ClosureIsPoWInChain(
+    pub  Arc<
+        dyn Fn([u8; 32]) -> core::pin::Pin<Box<dyn Future<Output = bool> + Send>>
+            + Send
+            + Sync
+            + 'static,
+    >,
+); // @Phillip
 impl std::fmt::Debug for ClosureIsPoWInChain {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str("ClosureIsPoWInChain(..)") }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ClosureIsPoWInChain(..)")
+    }
 }
 #[derive(Clone)]
-pub struct ClosureToPushPow(pub Arc<dyn Fn(Arc<zebra_chain::block::Block>)-> core::pin::Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync + 'static>); // @Phillip
+pub struct ClosureToPushPow(
+    pub  Arc<
+        dyn Fn(
+                Arc<zebra_chain::block::Block>,
+            ) -> core::pin::Pin<Box<dyn Future<Output = ()> + Send>>
+            + Send
+            + Sync
+            + 'static,
+    >,
+); // @Phillip
 impl std::fmt::Debug for ClosureToPushPow {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str("ClosureToPushPow(..)") }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ClosureToPushPow(..)")
+    }
 }
 #[derive(Clone)]
-pub struct ClosureToUpdateRosterCmd(pub Arc<dyn Fn(Option<String>)-> core::pin::Pin<Box<dyn Future<Output = Option<String>> + Send>> + Send + Sync + 'static>);
+pub struct ClosureToUpdateRosterCmd(
+    pub  Arc<
+        dyn Fn(Option<String>) -> core::pin::Pin<Box<dyn Future<Output = Option<String>> + Send>>
+            + Send
+            + Sync
+            + 'static,
+    >,
+);
 impl std::fmt::Debug for ClosureToUpdateRosterCmd {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str("ClosureToUpdateRosterCmd(..)") }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ClosureToUpdateRosterCmd(..)")
+    }
 }
 
 #[derive(Clone)]
-pub struct ClosureToUpdatePeers(pub Arc<dyn Fn(Vec<PeerInfo>) -> core::pin::Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync + 'static>);
+pub struct ClosureToUpdatePeers(
+    pub  Arc<
+        dyn Fn(Vec<PeerInfo>) -> core::pin::Pin<Box<dyn Future<Output = ()> + Send>>
+            + Send
+            + Sync
+            + 'static,
+    >,
+);
 impl std::fmt::Debug for ClosureToUpdatePeers {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str("ClosureToUpdatePeers(..)") }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ClosureToUpdatePeers(..)")
+    }
 }
 
 /*
@@ -273,7 +390,10 @@ impl std::fmt::Display for FatPointerToBftBlock3 {
     }
 }
 
-fn round_data_to_fat_pointer(round_data: &RoundData, roster: &[SortedRosterMember]) -> FatPointerToBftBlock3 {
+fn round_data_to_fat_pointer(
+    round_data: &RoundData,
+    roster: &[SortedRosterMember],
+) -> FatPointerToBftBlock3 {
     let vote_for_block_without_finalizer_public_key: [u8; 76 - 32];
     {
         let mut sign_data = [0; 76 - 32];
@@ -285,7 +405,8 @@ fn round_data_to_fat_pointer(round_data: &RoundData, roster: &[SortedRosterMembe
 
     FatPointerToBftBlock3 {
         vote_for_block_without_finalizer_public_key,
-        signatures: round_data.msg_val_sigs
+        signatures: round_data
+            .msg_val_sigs
             .iter()
             .map(|x| &x[1])
             .enumerate()
@@ -295,7 +416,9 @@ fn round_data_to_fat_pointer(round_data: &RoundData, roster: &[SortedRosterMembe
                         public_key: roster[roster_i].pub_key.0,
                         vote_signature: commit_signature.0,
                     })
-                } else { None }
+                } else {
+                    None
+                }
             })
             .collect(),
     }
@@ -366,35 +489,73 @@ pub enum TMStatus {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 pub enum TMStatusReason {
-    #[default] None,
+    #[default]
+    None,
     NeedsBlock {
-        hash: [u8; 32]
+        hash: [u8; 32],
     },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ValueId(pub [u8; 32]);
-impl ValueId { pub const NIL: Self = Self([0; 32]); }
-impl std::fmt::Display for ValueId { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { fmt_byte_str(f, &self.0) } }
-impl std::fmt::Debug   for ValueId { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { fmt_prefixed_byte_str(f, "VId{", &self.0)?; write!(f, "}}") } }
+impl ValueId {
+    pub const NIL: Self = Self([0; 32]);
+}
+impl std::fmt::Display for ValueId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_byte_str(f, &self.0)
+    }
+}
+impl std::fmt::Debug for ValueId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_prefixed_byte_str(f, "VId{", &self.0)?;
+        write!(f, "}}")
+    }
+}
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PubKeyID(pub [u8; 32]);
-impl PubKeyID { const NIL: Self = Self([0; 32]); }
-impl std::fmt::Display for PubKeyID { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { fmt_byte_str_rev(f, &self.0) } }
-impl std::fmt::Debug   for PubKeyID { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { fmt_prefixed_byte_str_rev(f, "Pub{", &self.0[..2])?; write!(f, "}}") } }
+impl PubKeyID {
+    const NIL: Self = Self([0; 32]);
+}
+impl std::fmt::Display for PubKeyID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_byte_str_rev(f, &self.0)
+    }
+}
+impl std::fmt::Debug for PubKeyID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_prefixed_byte_str_rev(f, "Pub{", &self.0[..2])?;
+        write!(f, "}}")
+    }
+}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct TMSig(pub [u8; 64]);
 impl TMSig {
     pub const NIL: Self = Self([0; 64]);
-    fn verify(&self, pub_key: PubKeyID, signed_data: &[u8]) -> Result<(), (ed25519_zebra::Error, &str)> {
+    fn verify(
+        &self,
+        pub_key: PubKeyID,
+        signed_data: &[u8],
+    ) -> Result<(), (ed25519_zebra::Error, &str)> {
         let signature = Signature::from_bytes(&self.0);
-        let vk = match VerificationKey::try_from(pub_key.0) { Ok(v)=>v,       Err(err)=>{ return Err((err, "invalid public key")) }};
-        match vk.verify(&signature, signed_data)            { Ok(())=>Ok(()), Err(err)=>{ Err((err, "invalid signature")) }}
+        let vk = match VerificationKey::try_from(pub_key.0) {
+            Ok(v) => v,
+            Err(err) => return Err((err, "invalid public key")),
+        };
+        match vk.verify(&signature, signed_data) {
+            Ok(()) => Ok(()),
+            Err(err) => Err((err, "invalid signature")),
+        }
     }
 }
-impl std::fmt::Debug for TMSig { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { fmt_prefixed_byte_str(f, "Sig{", &self.0[..2])?; write!(f, "}}") } }
+impl std::fmt::Debug for TMSig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_prefixed_byte_str(f, "Sig{", &self.0[..2])?;
+        write!(f, "}}")
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct RoundData {
@@ -438,7 +599,7 @@ impl RoundData {
         counts: ConsensusCounts::ZERO,
 
         active_timeout: None,
-        timeout_triggered: [false;2],
+        timeout_triggered: [false; 2],
     };
 
     fn has_full_proposal(&self) -> bool {
@@ -448,7 +609,10 @@ impl RoundData {
         self.proposal_is_faulty || self.has_full_proposal()
     }
     // auto-caching
-    async fn proposal_is_valid(&mut self, validate_closure: ClosureToValidateProposedBlock) -> TMStatus {
+    async fn proposal_is_valid(
+        &mut self,
+        validate_closure: ClosureToValidateProposedBlock,
+    ) -> TMStatus {
         // TODO: may want to start doing some of these on < proposal_chunks_n, i.e. shortcut known-invalid
         if self.proposal_checked_validity.0 == TMStatus::Indeterminate {
             if self.proposal_is_faulty {
@@ -496,11 +660,11 @@ impl std::ops::Add for ConsensusCounts {
     type Output = Self;
     fn add(self, rhs: ConsensusCounts) -> ConsensusCounts {
         ConsensusCounts {
-            anys:           self.anys           + rhs.anys,
-            prevotes:       self.prevotes       + rhs.prevotes,
-            nil_prevotes:   self.nil_prevotes   + rhs.nil_prevotes,
-            yes_prevotes:   self.yes_prevotes   + rhs.yes_prevotes,
-            precommits:     self.precommits     + rhs.precommits,
+            anys: self.anys + rhs.anys,
+            prevotes: self.prevotes + rhs.prevotes,
+            nil_prevotes: self.nil_prevotes + rhs.nil_prevotes,
+            yes_prevotes: self.yes_prevotes + rhs.yes_prevotes,
+            precommits: self.precommits + rhs.precommits,
             yes_precommits: self.yes_precommits + rhs.yes_precommits,
         }
     }
@@ -509,11 +673,11 @@ impl std::ops::Sub for ConsensusCounts {
     type Output = Self;
     fn sub(self, rhs: ConsensusCounts) -> ConsensusCounts {
         ConsensusCounts {
-            anys:           self.anys           - rhs.anys,
-            prevotes:       self.prevotes       - rhs.prevotes,
-            nil_prevotes:   self.nil_prevotes   - rhs.nil_prevotes,
-            yes_prevotes:   self.yes_prevotes   - rhs.yes_prevotes,
-            precommits:     self.precommits     - rhs.precommits,
+            anys: self.anys - rhs.anys,
+            prevotes: self.prevotes - rhs.prevotes,
+            nil_prevotes: self.nil_prevotes - rhs.nil_prevotes,
+            yes_prevotes: self.yes_prevotes - rhs.yes_prevotes,
+            precommits: self.precommits - rhs.precommits,
             yes_precommits: self.yes_precommits - rhs.yes_precommits,
         }
     }
@@ -521,10 +685,13 @@ impl std::ops::Sub for ConsensusCounts {
 impl From<&([(ValueId, TMSig); 2], u64)> for ConsensusCounts {
     fn from(val: &([(ValueId, TMSig); 2], u64)) -> ConsensusCounts {
         let (val, stake) = val;
-        let has_sigs     = [(val[0].1 != TMSig::NIL) as usize, (val[1].1 != TMSig::NIL) as usize];
+        let has_sigs = [
+            (val[0].1 != TMSig::NIL) as usize,
+            (val[1].1 != TMSig::NIL) as usize,
+        ];
         let has_any_sigs = has_sigs[0] | has_sigs[1]; // TODO: confirm prevote + precommit from the same person counts as 1
 
-        let mut status = [[0,0], [0,0]];
+        let mut status = [[0, 0], [0, 0]];
         status[0][(val[0].0 != ValueId::NIL) as usize] = has_sigs[0];
         status[1][(val[1].0 != ValueId::NIL) as usize] = has_sigs[1];
 
@@ -540,7 +707,9 @@ impl From<&([(ValueId, TMSig); 2], u64)> for ConsensusCounts {
 }
 impl std::fmt::Debug for ConsensusCounts {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Counts {{ a:{}  v:{} (nv:{} yv:{})  c:{} (yc:{}) }}",
+        write!(
+            f,
+            "Counts {{ a:{}  v:{} (nv:{} yv:{})  c:{} (yc:{}) }}",
             self.anys,
             self.prevotes,
             self.nil_prevotes,
@@ -551,39 +720,57 @@ impl std::fmt::Debug for ConsensusCounts {
     }
 }
 
-
 fn roster_i_from_pub_key(roster: &[SortedRosterMember], pub_key: PubKeyID) -> Option<usize> {
     roster.iter().position(|m| m.pub_key == pub_key)
 }
 
 #[derive(Debug, Clone)]
-pub struct Timeout { time: Instant, height: u64, round: u32, step: TMStep }
+pub struct Timeout {
+    time: Instant,
+    height: u64,
+    round: u32,
+    step: TMStep,
+}
 impl Timeout {
     fn new(now: Instant, height: u64, round: u32, step: TMStep) -> Timeout {
         use std::time::Duration;
         let timeout = match step {
             // Note(Sam): These timeout should be tuned to match the maximum network load block time. An additional
             // virtue of a short block time that I had not considered is that it hides round stalls better.
-            TMStep::Propose   => Duration::from_millis(2000) + round * Duration::from_millis(500),
-            TMStep::Prevote   => Duration::from_millis(2000) + round * Duration::from_millis(500),
+            TMStep::Propose => Duration::from_millis(2000) + round * Duration::from_millis(500),
+            TMStep::Prevote => Duration::from_millis(2000) + round * Duration::from_millis(500),
             TMStep::Precommit => Duration::from_millis(2000) + round * Duration::from_millis(500),
         };
 
-        Timeout{ time: now + timeout, height, round, step }
+        Timeout {
+            time: now + timeout,
+            height,
+            round,
+            step,
+        }
     }
 }
 
-
 const ROSTER_MAX_N: usize = 100;
-fn active_roster_len(roster: &[SortedRosterMember]) -> usize { usize::min(ROSTER_MAX_N, roster.len()) }
-fn total_roster_len(roster: &[SortedRosterMember])  -> usize { roster.len() }
+fn active_roster_len(roster: &[SortedRosterMember]) -> usize {
+    usize::min(ROSTER_MAX_N, roster.len())
+}
+fn total_roster_len(roster: &[SortedRosterMember]) -> usize {
+    roster.len()
+}
 
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub struct HashKey(pub [u8; 32]);
-impl HashKey { const NIL: Self = Self([0;32]); }
 impl HashKey {
-    fn hasher(&self)            -> blake3::Hasher { blake3::Hasher::new_keyed(&self.0) }
-    fn hash(&self, data: &[u8]) -> [u8; 32]       { *blake3::keyed_hash(&self.0, data).as_bytes() }
+    const NIL: Self = Self([0; 32]);
+}
+impl HashKey {
+    fn hasher(&self) -> blake3::Hasher {
+        blake3::Hasher::new_keyed(&self.0)
+    }
+    fn hash(&self, data: &[u8]) -> [u8; 32] {
+        *blake3::keyed_hash(&self.0, data).as_bytes()
+    }
 }
 
 #[derive(Debug)]
@@ -596,10 +783,26 @@ pub struct HashKeys {
 impl Default for HashKeys {
     fn default() -> Self {
         Self {
-            proposer:           HashKey(blake3::Hasher::new_derive_key("BFT Proposer")          .finalize().into()),
-            value_id:           HashKey(blake3::Hasher::new_derive_key("BFT Value ID")          .finalize().into()),
-            connect_contention: HashKey(blake3::Hasher::new_derive_key("BFT Connect Contention").finalize().into()), // NOTE(azmr): skipping update
-            proposal_sig:       HashKey(blake3::Hasher::new_derive_key("BFT Proposal Signature").finalize().into()),
+            proposer: HashKey(
+                blake3::Hasher::new_derive_key("BFT Proposer")
+                    .finalize()
+                    .into(),
+            ),
+            value_id: HashKey(
+                blake3::Hasher::new_derive_key("BFT Value ID")
+                    .finalize()
+                    .into(),
+            ),
+            connect_contention: HashKey(
+                blake3::Hasher::new_derive_key("BFT Connect Contention")
+                    .finalize()
+                    .into(),
+            ), // NOTE(azmr): skipping update
+            proposal_sig: HashKey(
+                blake3::Hasher::new_derive_key("BFT Proposal Signature")
+                    .finalize()
+                    .into(),
+            ),
         }
     }
 }
@@ -644,7 +847,9 @@ struct TMState {
 }
 impl TMState {
     fn init(
-        my_signing_key: SigningKey, my_pub_key: PubKeyID, my_port: u16,
+        my_signing_key: SigningKey,
+        my_pub_key: PubKeyID,
+        my_port: u16,
         propose_closure: ClosureToProposeNewBlock,
         validate_closure: ClosureToValidateProposedBlock,
         push_block_closure: ClosureToPushDecidedBlock,
@@ -688,15 +893,25 @@ impl TMState {
     }
 
     // NOTE: we just add our info to our round data & have it become equivalent to everyone else's...
-    fn broadcast(&mut self, roster: &[SortedRosterMember], round_i: usize, msg: TMMsgData) -> TMStep {
+    fn broadcast(
+        &mut self,
+        roster: &[SortedRosterMember],
+        round_i: usize,
+        msg: TMMsgData,
+    ) -> TMStep {
         // TODO: can we get away with not signing the step or separately signing the step?
         let mut buf = [0u8; 2048];
         // TODO: send to self
         // TODO: send to (some) others
-        let height   = self.rounds_data[round_i].height;
-        let round    = self.rounds_data[round_i].round;
-        let Some(roster_i) = roster_i_from_pub_key(&roster[..active_roster_len(roster)], self.my_pub_key) else {
-            eprintln!("{} \x1b[91mBFT ERROR\x1b[0m: failed to find my own public key in the roster", self.ctx_str(roster));
+        let height = self.rounds_data[round_i].height;
+        let round = self.rounds_data[round_i].round;
+        let Some(roster_i) =
+            roster_i_from_pub_key(&roster[..active_roster_len(roster)], self.my_pub_key)
+        else {
+            eprintln!(
+                "{} \x1b[91mBFT ERROR\x1b[0m: failed to find my own public key in the roster",
+                self.ctx_str(roster)
+            );
             return self.step;
         };
         match msg {
@@ -708,7 +923,8 @@ impl TMState {
                     valid_round,
                 };
 
-                for chunk_i in 0..proposal.chunks_n() { // NOTE: excluding packet_type // TODO: check this
+                for chunk_i in 0..proposal.chunks_n() {
+                    // NOTE: excluding packet_type // TODO: check this
                     hdr.chunk_i = chunk_i as u32;
                     let mut o = 0;
                     o += hdr.write_to(&mut buf[0..]);
@@ -719,12 +935,22 @@ impl TMState {
                     // NOTE: we *DON'T* want to write it immediately to our proper store because it
                     // will confuse check_and_incorporate_msg
                     let sig = TMSig(self.my_signing_key.sign(&buf[..o]).to_bytes());
-                    if PRINT_SIGN { println!("{}: signed proposal with {:?}", self.ctx_str(roster), sig) };
+                    if PRINT_SIGN {
+                        println!("{}: signed proposal with {:?}", self.ctx_str(roster), sig)
+                    };
 
                     // NOTE: we're faulty if we give our pub key for this if it's not our proposal
                     self.check_and_incorporate_msg(
-                        height, round, chunk_i, hdr.proposal_id, hdr.valid_round,
-                        roster, roster_i, PACKET_TYPE_PROPOSAL_CHUNK, &buf[..o], sig
+                        height,
+                        round,
+                        chunk_i,
+                        hdr.proposal_id,
+                        hdr.valid_round,
+                        roster,
+                        roster_i,
+                        PACKET_TYPE_PROPOSAL_CHUNK,
+                        &buf[..o],
+                        sig,
                     );
                 }
 
@@ -732,32 +958,74 @@ impl TMState {
             }
 
             TMMsgData::Prevote(value_id) | TMMsgData::Precommit(value_id) => {
-                let is_precommit: u8 = if let TMMsgData::Precommit(..) = msg { 1 } else { 0 };
-                if PRINT_BFT_VOTE { println!("{} {} on {}", self.ctx_str(roster), ["prevoting", "precommitting"][is_precommit as usize], value_id); }
+                let is_precommit: u8 = if let TMMsgData::Precommit(..) = msg {
+                    1
+                } else {
+                    0
+                };
+                if PRINT_BFT_VOTE {
+                    println!(
+                        "{} {} on {}",
+                        self.ctx_str(roster),
+                        ["prevoting", "precommitting"][is_precommit as usize],
+                        value_id
+                    );
+                }
                 let packet_type = PACKET_TYPE_PREVOTE_SIGNATURES + is_precommit;
-                let signed_data = make_vote_sign_datas(roster[roster_i].pub_key.0, is_precommit != 0, height, round, value_id)[1];
-                let sig         = TMSig(self.my_signing_key.sign(&signed_data).to_bytes());
-                if PRINT_SIGN { println!("{} signed {} with {:?}", self.ctx_str(roster), ["prevote", "precommit"][is_precommit as usize], sig) };
+                let signed_data = make_vote_sign_datas(
+                    roster[roster_i].pub_key.0,
+                    is_precommit != 0,
+                    height,
+                    round,
+                    value_id,
+                )[1];
+                let sig = TMSig(self.my_signing_key.sign(&signed_data).to_bytes());
+                if PRINT_SIGN {
+                    println!(
+                        "{} signed {} with {:?}",
+                        self.ctx_str(roster),
+                        ["prevote", "precommit"][is_precommit as usize],
+                        sig
+                    )
+                };
 
                 self.check_and_incorporate_msg(
-                    height, round, 0, value_id, -2,
-                    roster, roster_i, packet_type, &signed_data, sig
+                    height,
+                    round,
+                    0,
+                    value_id,
+                    -2,
+                    roster,
+                    roster_i,
+                    packet_type,
+                    &signed_data,
+                    sig,
                 );
 
                 [TMStep::Prevote, TMStep::Precommit][is_precommit as usize]
-            },
+            }
         }
     }
 
     /// Deterministic weighted round robin (hash & mod total zec on cumulative list)
-    fn proposer_from_height_round(hash_keys: &HashKeys, roster: &[SortedRosterMember], height: u64, round: u32) -> (Option<usize>, PubKeyID) {
+    fn proposer_from_height_round(
+        hash_keys: &HashKeys,
+        roster: &[SortedRosterMember],
+        height: u64,
+        round: u32,
+    ) -> (Option<usize>, PubKeyID) {
         if roster.len() == 0 {
             eprintln!("\x1b[91mBFT ERROR\x1b[0m: trying to get proposer from empty roster");
             return (None, PubKeyID::NIL); // TODO: is a fixed value here exploitable? Presumably nobody can sign for it?
         }
 
         // NOTE(azmr): this 32-byte crypto-hashing is almost certainly overkill!
-        let hash = hash_keys.proposer.hasher().update(&u64::to_le_bytes(height)).update(&u32::to_le_bytes(round)).finalize();
+        let hash = hash_keys
+            .proposer
+            .hasher()
+            .update(&u64::to_le_bytes(height))
+            .update(&u32::to_le_bytes(round))
+            .finalize();
 
         let mut hash_stake_bytes = [0; 8];
         hash.as_bytes()[..8].write_to(&mut hash_stake_bytes);
@@ -770,7 +1038,6 @@ impl TMState {
             return (None, PubKeyID::NIL); // TODO: is a fixed value here exploitable? Presumably nobody can sign for it?
         }
 
-
         let proposer_stake = hash_stake % total_included_stake;
 
         let roster_i = roster.partition_point(|m| m.cumulative_stake <= proposer_stake);
@@ -778,15 +1045,23 @@ impl TMState {
         (Some(roster_i), roster[roster_i].pub_key)
     }
 
-    fn insert_round(&mut self, insert_i: usize, round: u32, roster: &[SortedRosterMember]) -> usize {
+    fn insert_round(
+        &mut self,
+        insert_i: usize,
+        round: u32,
+        roster: &[SortedRosterMember],
+    ) -> usize {
         let roster_n = active_roster_len(roster);
-        self.rounds_data.insert(insert_i, RoundData {
-            height: self.height,
-            round,
-            msg_val_sigs: vec![[(ValueId::NIL, TMSig::NIL); 2]; roster_n], // TODO: just use ROSTER_MAX_N?
-            roster: roster.to_vec(),
-            ..RoundData::EMPTY
-        });
+        self.rounds_data.insert(
+            insert_i,
+            RoundData {
+                height: self.height,
+                round,
+                msg_val_sigs: vec![[(ValueId::NIL, TMSig::NIL); 2]; roster_n], // TODO: just use ROSTER_MAX_N?
+                roster: roster.to_vec(),
+                ..RoundData::EMPTY
+            },
+        );
         insert_i
     }
 
@@ -794,41 +1069,82 @@ impl TMState {
         self.round = round;
         // self.active_proposal_value_round = (None, -1);
 
-        let round_i = match self.rounds_data.binary_search_by_key(&(self.height, round), |el| (el.height, el.round)) {
-            Ok(round_i)  => round_i,
-            Err(round_i) => self.insert_round(round_i, round, roster)
+        let round_i = match self
+            .rounds_data
+            .binary_search_by_key(&(self.height, round), |el| (el.height, el.round))
+        {
+            Ok(round_i) => round_i,
+            Err(round_i) => self.insert_round(round_i, round, roster),
         };
 
-        if Self::proposer_from_height_round(&self.hash_keys, roster, self.height, round).1 == self.my_pub_key {
+        if Self::proposer_from_height_round(&self.hash_keys, roster, self.height, round).1
+            == self.my_pub_key
+        {
             let proposal = if let Some(valid_value) = self.valid_value_round.0.clone() {
                 Some(valid_value)
             } else {
                 let ret = self.propose_closure.0().await;
-                if PRINT_BFT_PROPOSAL { if ret.is_none() { println!("{} propose closure returned None.", self.ctx_str(roster)); } }
+                if PRINT_BFT_PROPOSAL {
+                    if ret.is_none() {
+                        println!("{} propose closure returned None.", self.ctx_str(roster));
+                    }
+                }
                 ret
             };
-            if PRINT_BFT_PROPOSAL { if let Some(proposal) = &proposal { println!("{} about to propose with status '{:?}': {:?}", self.ctx_str(roster), self.validate_closure.0(&proposal).await, proposal); } }
+            if PRINT_BFT_PROPOSAL {
+                if let Some(proposal) = &proposal {
+                    println!(
+                        "{} about to propose with status '{:?}': {:?}",
+                        self.ctx_str(roster),
+                        self.validate_closure.0(&proposal).await,
+                        proposal
+                    );
+                }
+            }
 
             // TODO: simple approach: send proposal messages to self when broadcasting
             // self.active_proposal_value_round = (Some(proposal), self.valid_value_round.1);
             if let Some(proposal) = proposal {
-                self.step = self.broadcast(roster, round_i, TMMsgData::Proposal(proposal, self.valid_value_round.1));
+                self.step = self.broadcast(
+                    roster,
+                    round_i,
+                    TMMsgData::Proposal(proposal, self.valid_value_round.1),
+                );
             } else {
                 self.step = TMStep::Propose;
             }
         } else {
             self.step = TMStep::Propose;
         }
-        self.rounds_data[round_i].active_timeout = Some(Timeout::new(now, self.height, self.round, TMStep::Propose));
+        self.rounds_data[round_i].active_timeout =
+            Some(Timeout::new(now, self.height, self.round, TMStep::Propose));
     }
 
     fn f_from_n(n: u64) -> u64 {
         (n - 1) / 3
     }
 
-    fn check_and_incorporate_msg(&mut self, height: u64, round: u32, chunk_i: usize, value_id: ValueId, valid_round: i64, roster: &[SortedRosterMember], roster_i: usize, packet_type: u8, signed_data: &[u8], sig: TMSig) -> TMStatus {
-        let me_str  = self.ctx_str(roster);
-        let pkt_str = format!("{:20} {}.{}.{}", packet_name_from_tag(packet_type), height, round, chunk_i);
+    fn check_and_incorporate_msg(
+        &mut self,
+        height: u64,
+        round: u32,
+        chunk_i: usize,
+        value_id: ValueId,
+        valid_round: i64,
+        roster: &[SortedRosterMember],
+        roster_i: usize,
+        packet_type: u8,
+        signed_data: &[u8],
+        sig: TMSig,
+    ) -> TMStatus {
+        let me_str = self.ctx_str(roster);
+        let pkt_str = format!(
+            "{:20} {}.{}.{}",
+            packet_name_from_tag(packet_type),
+            height,
+            round,
+            chunk_i
+        );
 
         if height != self.height {
             // eprintln!("{}: BFT: received [{}] when we're at height {}", me_str, pkt_str, self.height);
@@ -837,28 +1153,49 @@ impl TMState {
 
         // check if in (active) roster
         if roster_i >= active_roster_len(roster) {
-            eprintln!("{} [{}]: \x1b[91mBFT FAULT\x1b[0m: {} is not in the active roster.", me_str, pkt_str, roster_i);
+            eprintln!(
+                "{} [{}]: \x1b[91mBFT FAULT\x1b[0m: {} is not in the active roster.",
+                me_str, pkt_str, roster_i
+            );
             return TMStatus::Fail;
         }
 
         let from_pub_key = roster[roster_i].pub_key;
 
         // pkt_str += &format!(" from {} ({})", roster_i, from_pub_key);
-        let ctx_str = format!("{} [{} from {} {:?}]", me_str, pkt_str, roster_i, from_pub_key);
+        let ctx_str = format!(
+            "{} [{} from {} {:?}]",
+            me_str, pkt_str, roster_i, from_pub_key
+        );
 
         // check if data was signed by pub key
-        match sig.verify(from_pub_key, signed_data) { Ok(())=>{}, Err((err, str))=> {
-            eprintln!("{}: \x1b[91mBFT FAULT\x1b[0m: {} [..{}]: for {} {}", ctx_str, str, signed_data.len(), value_id, err);
-            return TMStatus::Fail;
-        }};
+        match sig.verify(from_pub_key, signed_data) {
+            Ok(()) => {}
+            Err((err, str)) => {
+                eprintln!(
+                    "{}: \x1b[91mBFT FAULT\x1b[0m: {} [..{}]: for {} {}",
+                    ctx_str,
+                    str,
+                    signed_data.len(),
+                    value_id,
+                    err
+                );
+                return TMStatus::Fail;
+            }
+        };
 
-        if PRINT_VALID_INCOMING { eprintln!("{}: valid signature for value id: {}", ctx_str, value_id); }
+        if PRINT_VALID_INCOMING {
+            eprintln!("{}: valid signature for value id: {}", ctx_str, value_id);
+        }
 
         // TODO: other checks
         // - data size check if we're doing network stuff
 
-        let (is_prev_seen_round, round_i) = match self.rounds_data.binary_search_by_key(&(height, round), |el| (el.height, el.round)) {
-            Ok(round_i)  => (true,  round_i),
+        let (is_prev_seen_round, round_i) = match self
+            .rounds_data
+            .binary_search_by_key(&(height, round), |el| (el.height, el.round))
+        {
+            Ok(round_i) => (true, round_i),
             Err(round_i) => (false, self.insert_round(round_i, round, roster)),
         };
         let round_data = &mut self.rounds_data[round_i];
@@ -891,52 +1228,81 @@ impl TMState {
         match packet_type {
             PACKET_TYPE_PROPOSAL_CHUNK => {
                 let Ok(hdr) = PacketProposalChunkHeader::read_from(signed_data) else {
-                    return TMStatus::Fail
+                    return TMStatus::Fail;
                 };
 
                 // "have they previously proposed a different value?"
                 if is_prev_seen_round && round_data.proposal_sigs_n > 0 {
-                    if is_my_proposal &&
-                      (round_data.proposal.0.len() != hdr.proposal_size as usize ||
-                       round_data.proposal_id != value_id ||
-                       round_data.proposal_valid_round != valid_round) { // Amnesiac Proposer's Dilemma
+                    if is_my_proposal
+                        && (round_data.proposal.0.len() != hdr.proposal_size as usize
+                            || round_data.proposal_id != value_id
+                            || round_data.proposal_valid_round != valid_round)
+                    {
+                        // Amnesiac Proposer's Dilemma
                         // Flush proposal id/votes. @Robustness @Duplicate: how to tersely flush the round?
                         let roster_n = active_roster_len(roster);
                         *round_data = RoundData {
-                            height:               round_data.height,
-                            round:                round_data.round,
-                            proposal_id:          value_id,
+                            height: round_data.height,
+                            round: round_data.round,
+                            proposal_id: value_id,
                             proposal_valid_round: valid_round,
-                            msg_val_sigs:         vec![[(ValueId::NIL, TMSig::NIL); 2]; roster_n], // TODO: just use ROSTER_MAX_N?
-                            roster:               Vec::from(&roster[0..roster_n]),
-                            active_timeout:       round_data.active_timeout.clone(),
-                            timeout_triggered:    round_data.timeout_triggered,
+                            msg_val_sigs: vec![[(ValueId::NIL, TMSig::NIL); 2]; roster_n], // TODO: just use ROSTER_MAX_N?
+                            roster: Vec::from(&roster[0..roster_n]),
+                            active_timeout: round_data.active_timeout.clone(),
+                            timeout_triggered: round_data.timeout_triggered,
                             ..RoundData::EMPTY
                         };
-                        round_data.proposal.0    = vec![0;          hdr.proposal_size as usize];
+                        round_data.proposal.0 = vec![0; hdr.proposal_size as usize];
                         round_data.proposal_sigs = vec![TMSig::NIL; round_data.proposal.chunks_n()];
-                        eprintln!("{}: \x1b[93mAMNESIAC PROPOSER\x1b[0m at {}.{}.{}: Flushing proposal...", ctx_str, height, round, chunk_i);
+                        eprintln!(
+                            "{}: \x1b[93mAMNESIAC PROPOSER\x1b[0m at {}.{}.{}: Flushing proposal...",
+                            ctx_str, height, round, chunk_i
+                        );
                     } else {
                         if round_data.proposal.0.len() != hdr.proposal_size as usize {
-                            eprintln!("{}: \x1b[91mBFT FAULT\x1b[0m at {}.{}.{}: proposer {} proposed 2 different-size values ({:?}, {:?}). Ignoring latest...",
-                            ctx_str, height, round, chunk_i, roster_i, round_data.proposal.0.len(), hdr.proposal_size);
+                            eprintln!(
+                                "{}: \x1b[91mBFT FAULT\x1b[0m at {}.{}.{}: proposer {} proposed 2 different-size values ({:?}, {:?}). Ignoring latest...",
+                                ctx_str,
+                                height,
+                                round,
+                                chunk_i,
+                                roster_i,
+                                round_data.proposal.0.len(),
+                                hdr.proposal_size
+                            );
                             return TMStatus::Fail;
                         }
                         if round_data.proposal_id != value_id {
                             // TODO: immediately class both as invalid?
-                            eprintln!("{}: \x1b[91mBFT FAULT\x1b[0m at {}.{}.{}: proposer {} proposed 2 different values ({:?}, {:?}). Ignoring latest...",
-                            ctx_str, height, round, chunk_i, roster_i, round_data.proposal_id, value_id);
+                            eprintln!(
+                                "{}: \x1b[91mBFT FAULT\x1b[0m at {}.{}.{}: proposer {} proposed 2 different values ({:?}, {:?}). Ignoring latest...",
+                                ctx_str,
+                                height,
+                                round,
+                                chunk_i,
+                                roster_i,
+                                round_data.proposal_id,
+                                value_id
+                            );
                             return TMStatus::Fail;
                         }
                         if round_data.proposal_valid_round != valid_round {
                             // TODO: immediately class both as invalid
-                            eprintln!("{}: \x1b[91mBFT FAULT\x1b[0m at {}.{}.{}: proposer {} proposed 2 different valid rounds ({}, {}). Ignoring latest...",
-                            ctx_str, height, round, chunk_i, roster_i, round_data.proposal_valid_round, valid_round);
+                            eprintln!(
+                                "{}: \x1b[91mBFT FAULT\x1b[0m at {}.{}.{}: proposer {} proposed 2 different valid rounds ({}, {}). Ignoring latest...",
+                                ctx_str,
+                                height,
+                                round,
+                                chunk_i,
+                                roster_i,
+                                round_data.proposal_valid_round,
+                                valid_round
+                            );
                             return TMStatus::Fail;
                         }
                     }
                 } else {
-                    round_data.proposal.0    = vec![0;          hdr.proposal_size as usize];
+                    round_data.proposal.0 = vec![0; hdr.proposal_size as usize];
                     round_data.proposal_sigs = vec![TMSig::NIL; round_data.proposal.chunks_n()];
                 }
 
@@ -944,35 +1310,50 @@ impl TMState {
 
                 // TODO: check expected proposer here if not above
                 let (chunk_o, chunk_size) = round_data.proposal.chunk_o_size(chunk_i);
-                let packet_chunk_o        = PacketProposalChunkHeader::SERIALIZED_SIZE;
-                let chunk_data            = &signed_data[packet_chunk_o..packet_chunk_o + chunk_size];
+                let packet_chunk_o = PacketProposalChunkHeader::SERIALIZED_SIZE;
+                let chunk_data = &signed_data[packet_chunk_o..packet_chunk_o + chunk_size];
 
-                if round_data.proposal_sigs[chunk_i] == TMSig::NIL { // value chunk not seen before
-                    chunk_data.write_to(&mut round_data.proposal.0[chunk_o..chunk_o+chunk_size]);
+                if round_data.proposal_sigs[chunk_i] == TMSig::NIL {
+                    // value chunk not seen before
+                    chunk_data.write_to(&mut round_data.proposal.0[chunk_o..chunk_o + chunk_size]);
                     round_data.proposal_sigs[chunk_i] = sig;
-                    round_data.proposal_sigs_n       += 1;
-                    round_data.proposal_valid_round   = valid_round;
-                    if round_data.proposal_id == ValueId::NIL { // first time we've seen any proposal chunks
+                    round_data.proposal_sigs_n += 1;
+                    round_data.proposal_valid_round = valid_round;
+                    if round_data.proposal_id == ValueId::NIL {
+                        // first time we've seen any proposal chunks
                         round_data.proposal_id = value_id;
 
                         let mut prev_sig_had_fault = false;
                         // check whether speculative adds to round data were for the actual proposal
                         for roster_i in 0..round_data.msg_val_sigs.len() {
-                            let msg_val: &mut [(ValueId, TMSig); 2] = &mut round_data.msg_val_sigs[roster_i];
+                            let msg_val: &mut [(ValueId, TMSig); 2] =
+                                &mut round_data.msg_val_sigs[roster_i];
                             for is_precommit in 0..2 {
-                                if msg_val[is_precommit].0 != ValueId::NIL && msg_val[is_precommit].0 != value_id {
+                                if msg_val[is_precommit].0 != ValueId::NIL
+                                    && msg_val[is_precommit].0 != value_id
+                                {
                                     prev_sig_had_fault = true;
-                                    eprintln!("{}: \x1b[91mBFT FAULT\x1b[0m at {}.{}: finalizer {} {} on non-proposed value {}. Ignoring...", ctx_str, height, round, roster_i, ["prevoted","precommitted"][is_precommit], value_id);
+                                    eprintln!(
+                                        "{}: \x1b[91mBFT FAULT\x1b[0m at {}.{}: finalizer {} {} on non-proposed value {}. Ignoring...",
+                                        ctx_str,
+                                        height,
+                                        round,
+                                        roster_i,
+                                        ["prevoted", "precommitted"][is_precommit],
+                                        value_id
+                                    );
                                     msg_val[is_precommit] = (ValueId::NIL, TMSig::NIL);
                                 }
                             }
                         }
 
-                        if prev_sig_had_fault { // recompute from scratch
+                        if prev_sig_had_fault {
+                            // recompute from scratch
                             // NOTE: this does NOT imply the current packet/proposal is faulty, so we should continue with it
                             let mut check_counts = ConsensusCounts::ZERO;
                             for (_, sig) in round_data.msg_val_sigs.iter().enumerate() {
-                                check_counts = check_counts + ConsensusCounts::from(&(*sig, roster[roster_i].stake));
+                                check_counts = check_counts
+                                    + ConsensusCounts::from(&(*sig, roster[roster_i].stake));
                             }
                             round_data.counts = check_counts;
                         }
@@ -982,37 +1363,55 @@ impl TMState {
                         let check_value_id = round_data.proposal.id_from_value(&self.hash_keys);
                         if round_data.proposal_id != check_value_id {
                             round_data.proposal_is_faulty = true;
-                            eprintln!("{}: \x1b[91mBFT FAULT\x1b[0m: proposer's value_id does not match our calculation: {} != {}",
-                                ctx_str, round_data.proposal_id, check_value_id);
+                            eprintln!(
+                                "{}: \x1b[91mBFT FAULT\x1b[0m: proposer's value_id does not match our calculation: {} != {}",
+                                ctx_str, round_data.proposal_id, check_value_id
+                            );
                             return TMStatus::Fail;
                         }
                     }
 
-                    if PRINT_BFT_UPDATE { println!("{}: update to {}/{} proposal chunks on {}", ctx_str, round_data.proposal_sigs_n, round_data.proposal_sigs.len(), round_data.proposal_id); }
+                    if PRINT_BFT_UPDATE {
+                        println!(
+                            "{}: update to {}/{} proposal chunks on {}",
+                            ctx_str,
+                            round_data.proposal_sigs_n,
+                            round_data.proposal_sigs.len(),
+                            round_data.proposal_id
+                        );
+                    }
 
                     // TODO: include signed prevote & precommit for self?
-                } else if round_data.proposal_sigs[chunk_i] != sig { // TODO: check value/sig conformance
-                    if is_my_proposal { // Amnesiac Proposer's Dilemma
+                } else if round_data.proposal_sigs[chunk_i] != sig {
+                    // TODO: check value/sig conformance
+                    if is_my_proposal {
+                        // Amnesiac Proposer's Dilemma
                         // Flush proposal id/votes. @Robustness @Duplicate: how to tersely flush the round?
                         let roster_n = active_roster_len(roster);
                         *round_data = RoundData {
-                            height:               round_data.height,
-                            round:                round_data.round,
-                            proposal_id:          value_id,
+                            height: round_data.height,
+                            round: round_data.round,
+                            proposal_id: value_id,
                             proposal_valid_round: valid_round,
-                            msg_val_sigs:         vec![[(ValueId::NIL, TMSig::NIL); 2]; roster_n], // TODO: just use ROSTER_MAX_N?
-                            roster:               Vec::from(&roster[0..roster_n]),
-                            active_timeout:       round_data.active_timeout.clone(),
-                            timeout_triggered:    round_data.timeout_triggered,
+                            msg_val_sigs: vec![[(ValueId::NIL, TMSig::NIL); 2]; roster_n], // TODO: just use ROSTER_MAX_N?
+                            roster: Vec::from(&roster[0..roster_n]),
+                            active_timeout: round_data.active_timeout.clone(),
+                            timeout_triggered: round_data.timeout_triggered,
                             ..RoundData::EMPTY
                         };
-                        round_data.proposal.0    = vec![0;          hdr.proposal_size as usize];
+                        round_data.proposal.0 = vec![0; hdr.proposal_size as usize];
                         round_data.proposal_sigs = vec![TMSig::NIL; round_data.proposal.chunks_n()];
-                        eprintln!("{}: \x1b[93mAMNESIAC PROPOSER\x1b[0m at {}.{}.{}: Flushing proposal...", ctx_str, height, round, chunk_i);
+                        eprintln!(
+                            "{}: \x1b[93mAMNESIAC PROPOSER\x1b[0m at {}.{}.{}: Flushing proposal...",
+                            ctx_str, height, round, chunk_i
+                        );
                     } else {
                         // TODO: treat this as a failed is_valid & early out before awaiting full proposal
                         round_data.proposal_is_faulty = true;
-                        eprintln!("{}: \x1b[91mBFT FAULT\x1b[0m: proposer signed 2 different values. Ignoring latest...", ctx_str);
+                        eprintln!(
+                            "{}: \x1b[91mBFT FAULT\x1b[0m: proposer signed 2 different values. Ignoring latest...",
+                            ctx_str
+                        );
                         return TMStatus::Fail;
                     }
                 } else {
@@ -1022,18 +1421,21 @@ impl TMState {
                 TMStatus::Pass
             }
 
-
             PACKET_TYPE_PREVOTE_SIGNATURES | PACKET_TYPE_PRECOMMIT_SIGNATURES => {
                 // TODO: check if this person has previously voted differently; is this covered later?
                 let is_precommit = (packet_type - PACKET_TYPE_PREVOTE_SIGNATURES) as usize;
 
-                let status = if value_id == ValueId::NIL { // always legal (except for duplicate checked later)
+                let status = if value_id == ValueId::NIL {
+                    // always legal (except for duplicate checked later)
                     TMStatus::Pass
                 } else if round_data.proposal_sigs_n == 0 {
                     // if we don't have a real proposal yet we can't check for validity
                     TMStatus::Indeterminate
                 } else if round_data.proposal_id != value_id {
-                    eprintln!("{}: \x1b[91mBFT FAULT\x1b[0m at {}.{}: finalizer {} voted on non-proposed value {}. Ignoring...", ctx_str, height, round, roster_i, value_id);
+                    eprintln!(
+                        "{}: \x1b[91mBFT FAULT\x1b[0m at {}.{}: finalizer {} voted on non-proposed value {}. Ignoring...",
+                        ctx_str, height, round, roster_i, value_id
+                    );
                     return TMStatus::Fail;
                 } else {
                     TMStatus::Pass
@@ -1045,44 +1447,64 @@ impl TMState {
                 let new_val_sig = (value_id, sig);
                 if old_val_sig.1 != TMSig::NIL && new_val_sig != old_val_sig {
                     // TODO: do we want to allow for NIL updating to valid?
-                    eprintln!("{}: \x1b[91mBFT FAULT\x1b[0m at {}.{}: finalizer {} voted on 2 different values ({:?}, {:?}). Ignoring latest...", ctx_str, height, round, roster_i, new_val_sig, old_val_sig);
+                    eprintln!(
+                        "{}: \x1b[91mBFT FAULT\x1b[0m at {}.{}: finalizer {} voted on 2 different values ({:?}, {:?}). Ignoring latest...",
+                        ctx_str, height, round, roster_i, new_val_sig, old_val_sig
+                    );
                     return TMStatus::Fail;
                 }
                 // Checks now finished //////////////////////////
 
                 // Add the signature to the list & update counts
-                let old_cs = ConsensusCounts::from(&(round_data.msg_val_sigs[roster_i], roster[roster_i].stake));
+                let old_cs = ConsensusCounts::from(&(
+                    round_data.msg_val_sigs[roster_i],
+                    roster[roster_i].stake,
+                ));
                 round_data.msg_val_sigs[roster_i][is_precommit] = new_val_sig;
-                let new_cs = ConsensusCounts::from(&(round_data.msg_val_sigs[roster_i], roster[roster_i].stake));
+                let new_cs = ConsensusCounts::from(&(
+                    round_data.msg_val_sigs[roster_i],
+                    roster[roster_i].stake,
+                ));
                 let d = new_cs - old_cs; // add 1 to counts that have been updated by this message
                 round_data.counts = round_data.counts + d;
 
-                if PRINT_BFT_UPDATE && (
-                    d.anys           |
-                    d.prevotes       |
-                    d.precommits     |
-                    d.yes_prevotes   |
-                    d.yes_precommits |
-                    d.nil_prevotes) != 0 {
-                    println!("{}: update to {:?} (d: {:?})", ctx_str, round_data.counts, d);
+                if PRINT_BFT_UPDATE
+                    && (d.anys
+                        | d.prevotes
+                        | d.precommits
+                        | d.yes_prevotes
+                        | d.yes_precommits
+                        | d.nil_prevotes)
+                        != 0
+                {
+                    println!(
+                        "{}: update to {:?} (d: {:?})",
+                        ctx_str, round_data.counts, d
+                    );
                 }
 
                 if true {
                     let mut check_counts = ConsensusCounts::ZERO;
                     for (i, sig) in round_data.msg_val_sigs.iter().enumerate() {
-                        check_counts = check_counts + ConsensusCounts::from(&(*sig, roster[i].stake));
+                        check_counts =
+                            check_counts + ConsensusCounts::from(&(*sig, roster[i].stake));
                     }
                     if check_counts != round_data.counts {
-                        eprintln!("{}: \x1b[91mBFT ERROR\x1b[0m: counts don't match: incremental: {:?}, absolute: {:?}", ctx_str, round_data.counts, check_counts);
+                        eprintln!(
+                            "{}: \x1b[91mBFT ERROR\x1b[0m: counts don't match: incremental: {:?}, absolute: {:?}",
+                            ctx_str, round_data.counts, check_counts
+                        );
                     }
                 }
 
                 status
             }
 
-
             _ => {
-                eprintln!("{}: \x1b[91mBFT ERROR\x1b[0m: unexpected case: {}", ctx_str, packet_type);
+                eprintln!(
+                    "{}: \x1b[91mBFT ERROR\x1b[0m: unexpected case: {}",
+                    ctx_str, packet_type
+                );
                 TMStatus::Fail
             }
         }
@@ -1095,10 +1517,23 @@ impl TMState {
 
     fn ctx_str(&self, roster: &[SortedRosterMember]) -> String {
         // format!("{:?} {:05}-{:?}-{:?}.{:3}.{:3}.{:9}", roster.into_iter().map(|m| m.pub_key).collect::<Vec<_>>(), self.my_port, self.my_pub_key, roster_i_from_pub_key(roster, self.my_pub_key), self.height, self.round, format!("{:?}", self.step))
-        format!("{:05}-{:?}-{:>8}.{:3}.{:3}.{:9}", self.my_port, self.my_pub_key, format!("{:?}", roster_i_from_pub_key(roster, self.my_pub_key)), self.height, self.round, format!("{:?}", self.step))
+        format!(
+            "{:05}-{:?}-{:>8}.{:3}.{:3}.{:9}",
+            self.my_port,
+            self.my_pub_key,
+            format!("{:?}", roster_i_from_pub_key(roster, self.my_pub_key)),
+            self.height,
+            self.round,
+            format!("{:?}", self.step)
+        )
     }
     fn name_str_other(roster: &[SortedRosterMember], peer: &Peer) -> String {
-        format!("{:05}-{:?}-{:?}", peer.endpoint.unwrap_or_default().port, PubKeyID(peer.root_public_bft_key), roster_i_from_pub_key(roster, PubKeyID(peer.root_public_bft_key)))
+        format!(
+            "{:05}-{:?}-{:?}",
+            peer.endpoint.unwrap_or_default().port,
+            PubKeyID(peer.root_public_bft_key),
+            roster_i_from_pub_key(roster, PubKeyID(peer.root_public_bft_key))
+        )
     }
 
     async fn bft_update(&mut self, roster: &mut Vec<SortedRosterMember>) {
@@ -1115,30 +1550,41 @@ impl TMState {
             big_threshold = total_active_stake;
             small_threshold = total_active_stake;
         } else {
-            big_threshold = 2*f+1;
-            small_threshold = f+1;
+            big_threshold = 2 * f + 1;
+            small_threshold = f + 1;
         }
         let ctx_str = self.ctx_str(roster);
 
         // NOTE: binary search to {current height, round 0} to avoid looping through data for unneeded decided heights
-        let current_height_start_i = self.rounds_data.binary_search_by_key(&(self.height, 0), |el| (el.height, el.round)).unwrap_or(0);
+        let current_height_start_i = self
+            .rounds_data
+            .binary_search_by_key(&(self.height, 0), |el| (el.height, el.round))
+            .unwrap_or(0);
 
         for i in current_height_start_i..self.rounds_data.len() {
-            let on_roster = roster_i_from_pub_key(&roster[..active_roster_len(roster)], self.my_pub_key).is_some();
+            let on_roster =
+                roster_i_from_pub_key(&roster[..active_roster_len(roster)], self.my_pub_key)
+                    .is_some();
             let counts = self.rounds_data[i].counts.clone();
-            let has_enough_info_to_determine_validity = self.rounds_data[i].has_enough_info_to_determine_validity();
+            let has_enough_info_to_determine_validity =
+                self.rounds_data[i].has_enough_info_to_determine_validity();
 
             // TODO: don't spam "while" messages repeatedly
-            let is_current_height_and_round = (self.height, self.round) == (self.rounds_data[i].height, self.rounds_data[i].round);
+            let is_current_height_and_round = (self.height, self.round)
+                == (self.rounds_data[i].height, self.rounds_data[i].round);
             // println!("{:#?}", self);
             if PRINT_BFT_STATE {
-                println!("{} {}={}.{}, {}/{}, {}", ctx_str,
-                    ["!","="][is_current_height_and_round as usize],
-                    self.rounds_data[i].height, self.rounds_data[i].round,
-                    self.rounds_data[i].proposal_sigs_n, self.rounds_data[i].proposal_sigs.len(),
+                println!(
+                    "{} {}={}.{}, {}/{}, {}",
+                    ctx_str,
+                    ["!", "="][is_current_height_and_round as usize],
+                    self.rounds_data[i].height,
+                    self.rounds_data[i].round,
+                    self.rounds_data[i].proposal_sigs_n,
+                    self.rounds_data[i].proposal_sigs.len(),
                     self.rounds_data[i].proposal_valid_round
                 );
-             }
+            }
 
             // line 11: init proposal period
             // (done elsewhere)
@@ -1155,14 +1601,32 @@ impl TMState {
             {
                 // TODO: do we want to prevote NIL on currently-indeterminate?
                 // ALT: send NIL then later override with time-tagged message
-                if self.rounds_data[i].proposal_is_valid(self.validate_closure.clone()).await == TMStatus::Pass && (
-                    self.locked_value_round.1 == -1 ||
-                    self.locked_value_round.0 == Some(self.rounds_data[i].proposal.clone())) // TODO(perf): use (previously-checked) ids for easier comparison?
+                if self.rounds_data[i]
+                    .proposal_is_valid(self.validate_closure.clone())
+                    .await
+                    == TMStatus::Pass
+                    && (self.locked_value_round.1 == -1
+                        || self.locked_value_round.0 == Some(self.rounds_data[i].proposal.clone()))
+                // TODO(perf): use (previously-checked) ids for easier comparison?
                 {
-                    if PRINT_BFT_CONDITIONS { println!("{}: in condition 22-0: receive first proposal this height", ctx_str); }
-                    self.step = self.broadcast(roster, i, TMMsgData::Prevote(self.rounds_data[i].proposal_id));
+                    if PRINT_BFT_CONDITIONS {
+                        println!(
+                            "{}: in condition 22-0: receive first proposal this height",
+                            ctx_str
+                        );
+                    }
+                    self.step = self.broadcast(
+                        roster,
+                        i,
+                        TMMsgData::Prevote(self.rounds_data[i].proposal_id),
+                    );
                 } else {
-                    if PRINT_BFT_CONDITIONS { println!("{}: in condition 22-1: receive first proposal this height", ctx_str); }
+                    if PRINT_BFT_CONDITIONS {
+                        println!(
+                            "{}: in condition 22-1: receive first proposal this height",
+                            ctx_str
+                        );
+                    }
                     self.step = self.broadcast(roster, i, TMMsgData::Prevote(ValueId::NIL));
                 }
             }
@@ -1170,21 +1634,34 @@ impl TMState {
             // line 28: received 2f+1 prevotes: prevote
             // > upon <PROPOSAL, h_p, round_p, v, vr> from proposer(h_p, round_p) AND 2f+1 <PREVOTE, h_p, vr, id(v)>
             // > while step_p = propose && (0 <= vr && vr < round_p)
-            if (on_roster &&
-                is_current_height_and_round &&
-                has_enough_info_to_determine_validity &&
-                big_threshold <= counts.yes_prevotes &&
-                self.step == TMStep::Propose &&
-                0 <= self.rounds_data[i].proposal_valid_round && self.rounds_data[i].proposal_valid_round < self.round as i64) // we have received the proposal value
+            if (on_roster
+                && is_current_height_and_round
+                && has_enough_info_to_determine_validity
+                && big_threshold <= counts.yes_prevotes
+                && self.step == TMStep::Propose
+                && 0 <= self.rounds_data[i].proposal_valid_round
+                && self.rounds_data[i].proposal_valid_round < self.round as i64)
+            // we have received the proposal value
             {
-                if self.rounds_data[i].proposal_is_valid(self.validate_closure.clone()).await == TMStatus::Pass && (
-                    self.locked_value_round.1 <= self.rounds_data[i].proposal_valid_round ||
-                    self.locked_value_round.0 == Some(self.rounds_data[i].proposal.clone()))
+                if self.rounds_data[i]
+                    .proposal_is_valid(self.validate_closure.clone())
+                    .await
+                    == TMStatus::Pass
+                    && (self.locked_value_round.1 <= self.rounds_data[i].proposal_valid_round
+                        || self.locked_value_round.0 == Some(self.rounds_data[i].proposal.clone()))
                 {
-                    if PRINT_BFT_CONDITIONS { println!("{}: in condition 28-0: received 2f+1 prevotes", ctx_str); }
-                    self.step = self.broadcast(roster, i, TMMsgData::Prevote(self.rounds_data[i].proposal_id));
+                    if PRINT_BFT_CONDITIONS {
+                        println!("{}: in condition 28-0: received 2f+1 prevotes", ctx_str);
+                    }
+                    self.step = self.broadcast(
+                        roster,
+                        i,
+                        TMMsgData::Prevote(self.rounds_data[i].proposal_id),
+                    );
                 } else {
-                    if PRINT_BFT_CONDITIONS { println!("{}: in condition 28-1: received 2f+1 prevotes", ctx_str); }
+                    if PRINT_BFT_CONDITIONS {
+                        println!("{}: in condition 28-1: received 2f+1 prevotes", ctx_str);
+                    }
                     self.step = self.broadcast(roster, i, TMMsgData::Prevote(ValueId::NIL));
                 }
             }
@@ -1196,54 +1673,91 @@ impl TMState {
                 // don't need the proposal itself
                 big_threshold <= counts.prevotes &&
                 self.step == TMStep::Prevote &&
-                !self.rounds_data[i].timeout_triggered[0]) // "for the first time" // ALT: round.timeout_step != TMStep::Prevote
+                !self.rounds_data[i].timeout_triggered[0])
+            // "for the first time" // ALT: round.timeout_step != TMStep::Prevote
             {
-                if PRINT_BFT_CONDITIONS { println!("{}: in condition 34: last orders on prevote period", ctx_str); }
+                if PRINT_BFT_CONDITIONS {
+                    println!(
+                        "{}: in condition 34: last orders on prevote period",
+                        ctx_str
+                    );
+                }
                 self.rounds_data[i].timeout_triggered[0] = true;
-                self.rounds_data[i].active_timeout = Some(Timeout::new(now, self.height, self.round, TMStep::Prevote));
+                self.rounds_data[i].active_timeout =
+                    Some(Timeout::new(now, self.height, self.round, TMStep::Prevote));
             }
 
             // line 36: seen 2f+1 valid prevotes: lock, valid, precommit
             // > upon <PROPOSAL, h_p, round_p, v, ∗> from proposer(h_p, round_p) AND 2f+1 <PREVOTE, h_p, round_p, id(v)>
             // > while valid(v) && step_p >= prevote for the first time do
-            if (on_roster &&
-                is_current_height_and_round &&
-                has_enough_info_to_determine_validity &&
-                big_threshold <= counts.yes_prevotes &&
-                self.rounds_data[i].proposal_is_valid(self.validate_closure.clone()).await == TMStatus::Pass &&
-                (self.step == TMStep::Prevote || self.step == TMStep::Precommit)) // TODO: "for the first time"
+            if (on_roster
+                && is_current_height_and_round
+                && has_enough_info_to_determine_validity
+                && big_threshold <= counts.yes_prevotes
+                && self.rounds_data[i]
+                    .proposal_is_valid(self.validate_closure.clone())
+                    .await
+                    == TMStatus::Pass
+                && (self.step == TMStep::Prevote || self.step == TMStep::Precommit))
+            // TODO: "for the first time"
             {
-                if PRINT_BFT_CONDITIONS { println!("{}: in condition 36: seen 2f+1 valid prevotes", ctx_str); }
-                if self.step == TMStep::Prevote {
-                    if PRINT_BFT_CONDITIONS { println!("{}: in condition 36-0: seen 2f+1 valid prevotes", ctx_str); }
-                    self.locked_value_round = (Some(self.rounds_data[i].proposal.clone()), self.round as i64);
-                    self.step = self.broadcast(roster, i, TMMsgData::Precommit(self.rounds_data[i].proposal_id));
+                if PRINT_BFT_CONDITIONS {
+                    println!("{}: in condition 36: seen 2f+1 valid prevotes", ctx_str);
                 }
-                self.valid_value_round = (Some(self.rounds_data[i].proposal.clone()), self.round as i64);
+                if self.step == TMStep::Prevote {
+                    if PRINT_BFT_CONDITIONS {
+                        println!("{}: in condition 36-0: seen 2f+1 valid prevotes", ctx_str);
+                    }
+                    self.locked_value_round = (
+                        Some(self.rounds_data[i].proposal.clone()),
+                        self.round as i64,
+                    );
+                    self.step = self.broadcast(
+                        roster,
+                        i,
+                        TMMsgData::Precommit(self.rounds_data[i].proposal_id),
+                    );
+                }
+                self.valid_value_round = (
+                    Some(self.rounds_data[i].proposal.clone()),
+                    self.round as i64,
+                );
             }
 
             // line 44: seen 2f+1 nil prevotes: precommit nil
             // > upon 2f+1 <PREVOTE, h_p, round_p, nil>
             // > while step_p = prevote do
-            if (on_roster &&
-                is_current_height_and_round &&
-                big_threshold <= counts.nil_prevotes &&
-                self.step == TMStep::Prevote)
+            if (on_roster
+                && is_current_height_and_round
+                && big_threshold <= counts.nil_prevotes
+                && self.step == TMStep::Prevote)
             {
-                if PRINT_BFT_CONDITIONS { println!("{}: in condition 44: seen 2f+1 nil prevotes", ctx_str); }
+                if PRINT_BFT_CONDITIONS {
+                    println!("{}: in condition 44: seen 2f+1 nil prevotes", ctx_str);
+                }
                 self.step = self.broadcast(roster, i, TMMsgData::Precommit(ValueId::NIL));
             }
 
             // line 47: last orders on precommit period
             // > upon 2f+1 <PRECOMMIT, h_p, round_p, ∗> for the first time do
-            if (on_roster &&
-                is_current_height_and_round &&
-                big_threshold <= counts.precommits &&
-                !self.rounds_data[i].timeout_triggered[1])
+            if (on_roster
+                && is_current_height_and_round
+                && big_threshold <= counts.precommits
+                && !self.rounds_data[i].timeout_triggered[1])
             {
-                if PRINT_BFT_CONDITIONS { println!("{}: in condition 47: last orders on precommit period", ctx_str); }
+                if PRINT_BFT_CONDITIONS {
+                    println!(
+                        "{}: in condition 47: last orders on precommit period",
+                        ctx_str
+                    );
+                }
                 self.rounds_data[i].timeout_triggered[1] = true;
-                self.rounds_data[i].active_timeout = Some(Timeout::new(now, self.height, self.round, TMStep::Precommit));
+                self.rounds_data[i].active_timeout = Some(Timeout::new(
+                    now,
+                    self.height,
+                    self.round,
+                    TMStep::Precommit,
+                ));
             }
 
             // line 49: value decided
@@ -1255,12 +1769,22 @@ impl TMState {
                 big_threshold <= counts.yes_precommits &&
                 self.rounds_data[i].proposal_is_valid(self.validate_closure.clone()).await == TMStatus::Pass)
             {
-                if PRINT_BFT_CONDITIONS { println!("{}: in condition 49: value decided", ctx_str); }
-                let new_roster = self.push_block_closure.0(self.rounds_data[i].proposal.clone(), round_data_to_fat_pointer(&self.rounds_data[i], roster), self.rounds_data[i].proposal_sigs.clone()).await;
-                if PRINT_ROSTER { println!("{} new roster: {:?}", ctx_str, new_roster); }
+                if PRINT_BFT_CONDITIONS {
+                    println!("{}: in condition 49: value decided", ctx_str);
+                }
+                let new_roster = self.push_block_closure.0(
+                    self.rounds_data[i].proposal.clone(),
+                    round_data_to_fat_pointer(&self.rounds_data[i], roster),
+                    self.rounds_data[i].proposal_sigs.clone(),
+                )
+                .await;
+                if PRINT_ROSTER {
+                    println!("{} new roster: {:?}", ctx_str, new_roster);
+                }
                 *roster = new_roster;
                 self.height += 1;
-                self.recent_commit_round_cache.push(self.rounds_data[i].clone());
+                self.recent_commit_round_cache
+                    .push(self.rounds_data[i].clone());
                 self.rounds_data.retain(|r| r.height < self.height);
                 self.locked_value_round = (None, -1);
                 self.valid_value_round = (None, -1);
@@ -1269,39 +1793,52 @@ impl TMState {
 
             // line 55: round catchup
             // > upon f+1 <∗, h_p, round, ∗, ∗> with round > round_p do
-            if (on_roster &&
-                self.height == self.rounds_data[i].height &&
-                self.round    <  self.rounds_data[i].round  &&
-                small_threshold <= counts.anys)
+            if (on_roster
+                && self.height == self.rounds_data[i].height
+                && self.round < self.rounds_data[i].round
+                && small_threshold <= counts.anys)
             {
-                if PRINT_BFT_CONDITIONS { println!("{}: in condition 55: round catchup", ctx_str); }
-                self.start_round(roster, now, self.rounds_data[i].round).await
+                if PRINT_BFT_CONDITIONS {
+                    println!("{}: in condition 55: round catchup", ctx_str);
+                }
+                self.start_round(roster, now, self.rounds_data[i].round)
+                    .await
             }
 
             // timeouts
-            if let Some(timeout) = &self.rounds_data[i].active_timeout &&
-                timeout.time <= now &&
-                self.height  == timeout.height &&
-                self.round   == timeout.round &&
-                on_roster
+            if let Some(timeout) = &self.rounds_data[i].active_timeout
+                && timeout.time <= now
+                && self.height == timeout.height
+                && self.round == timeout.round
+                && on_roster
             {
                 // TODO(code): can we just use *our* step or is there a possible sequence issue? (from the presence of step checks, probably not)
                 match timeout.step {
-                    TMStep::Propose => if self.step == TMStep::Propose {
-                        if PRINT_BFT_TIMEOUTS { println!("{}: hit timeout propose", ctx_str); }
-                        self.step = self.broadcast(roster, i, TMMsgData::Prevote(ValueId::NIL));
-                    },
-                    TMStep::Prevote => if self.step == TMStep::Prevote {
-                        if PRINT_BFT_TIMEOUTS { println!("{}: hit timeout prevote", ctx_str); }
-                        self.step = self.broadcast(roster, i, TMMsgData::Precommit(ValueId::NIL));
-                    },
+                    TMStep::Propose => {
+                        if self.step == TMStep::Propose {
+                            if PRINT_BFT_TIMEOUTS {
+                                println!("{}: hit timeout propose", ctx_str);
+                            }
+                            self.step = self.broadcast(roster, i, TMMsgData::Prevote(ValueId::NIL));
+                        }
+                    }
+                    TMStep::Prevote => {
+                        if self.step == TMStep::Prevote {
+                            if PRINT_BFT_TIMEOUTS {
+                                println!("{}: hit timeout prevote", ctx_str);
+                            }
+                            self.step =
+                                self.broadcast(roster, i, TMMsgData::Precommit(ValueId::NIL));
+                        }
+                    }
                     TMStep::Precommit => {
-                        if PRINT_BFT_TIMEOUTS { println!("{}: hit timeout precommit", ctx_str); }
+                        if PRINT_BFT_TIMEOUTS {
+                            println!("{}: hit timeout precommit", ctx_str);
+                        }
                         self.start_round(roster, now, self.round + 1).await
-                    },
+                    }
                 }
             }
-
 
             // If this value would have been decided, but we can't validate it because we need its PoW block, let's mark this hash as required
             if (self.height == self.rounds_data[i].height &&
@@ -1316,10 +1853,20 @@ impl TMState {
                             self.pow_submit_block_queue.truncate(0);
 
                             let len = self.pow_submit_block_queue.len() + 1;
-                            if PRINT_POWLINK { println!("{}: PowLink: \x1b[93mBLOCK NEEDED\x1b[0m hash: {:?}...", ctx_str, hash); }
-                            if PRINT_POWLINK { println!("{}: PowLink: \x1b[93mBLOCK NEEDED\x1b[0m count: {:?}...", ctx_str, len); }
+                            if PRINT_POWLINK {
+                                println!(
+                                    "{}: PowLink: \x1b[93mBLOCK NEEDED\x1b[0m hash: {:?}...",
+                                    ctx_str, hash
+                                );
+                            }
+                            if PRINT_POWLINK {
+                                println!(
+                                    "{}: PowLink: \x1b[93mBLOCK NEEDED\x1b[0m count: {:?}...",
+                                    ctx_str, len
+                                );
+                            }
                         }
-                    },
+                    }
                     _ => {
                         self.current_powlink = None;
                         self.pow_submit_block_queue.truncate(0);
@@ -1335,8 +1882,8 @@ struct PeerTransport {
     ack_latest: u64,
     ack_field: u64,
     nonce: u64,
-    sent_packets:              RingStream<SentPacket, 1024>,
-    received_packets:          RingStream<ReceivedPacket, 1024>,
+    sent_packets: RingStream<SentPacket, 1024>,
+    received_packets: RingStream<ReceivedPacket, 1024>,
     acknowledged_sent_packets: RingStream<AcknowledgedSentPacket, 1024>,
 }
 impl Default for PeerTransport {
@@ -1345,8 +1892,8 @@ impl Default for PeerTransport {
             ack_latest: 0,
             ack_field: 0,
             nonce: 0,
-            sent_packets:              RingStream::<SentPacket, 1024>::default(),
-            received_packets:          RingStream::<ReceivedPacket, 1024>::default(),
+            sent_packets: RingStream::<SentPacket, 1024>::default(),
+            received_packets: RingStream::<ReceivedPacket, 1024>::default(),
             acknowledged_sent_packets: RingStream::<AcknowledgedSentPacket, 1024>::default(),
         }
     }
@@ -1354,7 +1901,8 @@ impl Default for PeerTransport {
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ConnectionKnowledge {
-    #[default] Known,
+    #[default]
+    Known,
     Unknown,
 }
 
@@ -1418,14 +1966,45 @@ pub struct PeerInfo {
 }
 
 // NOTE: buf can be open-ended
-trait SliceWrite         { fn write_to(&self, buf: &mut [u8]) -> usize; }
-impl SliceWrite for u64  { fn write_to(&self, buf: &mut [u8]) -> usize { buf[0..8].copy_from_slice(&u64::to_le_bytes(*self)); 8 } }
-impl SliceWrite for i64  { fn write_to(&self, buf: &mut [u8]) -> usize { buf[0..8].copy_from_slice(&i64::to_le_bytes(*self)); 8 } }
-impl SliceWrite for u32  { fn write_to(&self, buf: &mut [u8]) -> usize { buf[0..4].copy_from_slice(&u32::to_le_bytes(*self)); 4 } }
-impl SliceWrite for u16  { fn write_to(&self, buf: &mut [u8]) -> usize { buf[0..2].copy_from_slice(&u16::to_le_bytes(*self)); 2 } }
-impl SliceWrite for u8   { fn write_to(&self, buf: &mut [u8]) -> usize { buf[0] = *self;                                      1 } }
-impl SliceWrite for [u8] { fn write_to(&self, buf: &mut [u8]) -> usize { buf[0..self.len()].copy_from_slice(self);   self.len() } }
-
+trait SliceWrite {
+    fn write_to(&self, buf: &mut [u8]) -> usize;
+}
+impl SliceWrite for u64 {
+    fn write_to(&self, buf: &mut [u8]) -> usize {
+        buf[0..8].copy_from_slice(&u64::to_le_bytes(*self));
+        8
+    }
+}
+impl SliceWrite for i64 {
+    fn write_to(&self, buf: &mut [u8]) -> usize {
+        buf[0..8].copy_from_slice(&i64::to_le_bytes(*self));
+        8
+    }
+}
+impl SliceWrite for u32 {
+    fn write_to(&self, buf: &mut [u8]) -> usize {
+        buf[0..4].copy_from_slice(&u32::to_le_bytes(*self));
+        4
+    }
+}
+impl SliceWrite for u16 {
+    fn write_to(&self, buf: &mut [u8]) -> usize {
+        buf[0..2].copy_from_slice(&u16::to_le_bytes(*self));
+        2
+    }
+}
+impl SliceWrite for u8 {
+    fn write_to(&self, buf: &mut [u8]) -> usize {
+        buf[0] = *self;
+        1
+    }
+}
+impl SliceWrite for [u8] {
+    fn write_to(&self, buf: &mut [u8]) -> usize {
+        buf[0..self.len()].copy_from_slice(self);
+        self.len()
+    }
+}
 
 #[derive(Clone, Copy)]
 pub struct StaticDHKeyPair {
@@ -1441,7 +2020,11 @@ pub struct SecureUdpEndpoint {
 }
 impl Default for SecureUdpEndpoint {
     fn default() -> SecureUdpEndpoint {
-        SecureUdpEndpoint { public_key: [0_u8; 32], ip_address: [0_u8; 16], port: 0 }
+        SecureUdpEndpoint {
+            public_key: [0_u8; 32],
+            ip_address: [0_u8; 16],
+            port: 0,
+        }
     }
 }
 
@@ -1449,8 +2032,8 @@ impl SecureUdpEndpoint {
     fn write_to(&self, buf: &mut [u8]) -> usize {
         self.public_key.write_to(&mut buf[..]);
         self.ip_address.write_to(&mut buf[32..]);
-        self.port      .write_to(&mut buf[32+16..]);
-        32+16+2
+        self.port.write_to(&mut buf[32 + 16..]);
+        32 + 16 + 2
     }
 
     pub fn read_from<R: Read>(mut r: R) -> std::io::Result<Self> {
@@ -1469,13 +2052,16 @@ pub struct EndpointEvidence {
 }
 impl Default for EndpointEvidence {
     fn default() -> EndpointEvidence {
-        EndpointEvidence { endpoint: SecureUdpEndpoint::default(), root_public_bft_key: [0_u8; 32] }
+        EndpointEvidence {
+            endpoint: SecureUdpEndpoint::default(),
+            root_public_bft_key: [0_u8; 32],
+        }
     }
 }
 impl EndpointEvidence {
     pub fn write_to(&self, buf: &mut [u8]) -> usize {
         let mut o = 0;
-        o += self.endpoint       .write_to(&mut buf[o..]);
+        o += self.endpoint.write_to(&mut buf[o..]);
         o += self.root_public_bft_key.write_to(&mut buf[o..]);
         o
     }
@@ -1484,28 +2070,43 @@ impl EndpointEvidence {
         let endpoint = SecureUdpEndpoint::read_from(&mut r)?;
         let mut key_bytes = [0_u8; 32];
         r.read_exact(&mut key_bytes)?;
-        Ok(EndpointEvidence { endpoint, root_public_bft_key: key_bytes })
+        Ok(EndpointEvidence {
+            endpoint,
+            root_public_bft_key: key_bytes,
+        })
     }
 }
 
 fn fmt_byte_str(f: &mut std::fmt::Formatter<'_>, bytes: &[u8]) -> std::fmt::Result {
     let n = usize::min(bytes.len(), f.precision().unwrap_or(bytes.len()));
-    for i in 0..n { write!(f, "{:02x}", bytes[i])?; }
+    for i in 0..n {
+        write!(f, "{:02x}", bytes[i])?;
+    }
     Ok(())
 }
 
 fn fmt_byte_str_rev(f: &mut std::fmt::Formatter<'_>, bytes: &[u8]) -> std::fmt::Result {
     let n = usize::min(bytes.len(), f.precision().unwrap_or(bytes.len()));
-    for i in 0..n { write!(f, "{:02x}", bytes[n-(i+1)])?; }
+    for i in 0..n {
+        write!(f, "{:02x}", bytes[n - (i + 1)])?;
+    }
     Ok(())
 }
 
-fn fmt_prefixed_byte_str(f: &mut std::fmt::Formatter<'_>, pre: &str, bytes: &[u8]) -> std::fmt::Result {
+fn fmt_prefixed_byte_str(
+    f: &mut std::fmt::Formatter<'_>,
+    pre: &str,
+    bytes: &[u8],
+) -> std::fmt::Result {
     write!(f, "{}", pre)?;
     fmt_byte_str(f, bytes)
 }
 
-fn fmt_prefixed_byte_str_rev(f: &mut std::fmt::Formatter<'_>, pre: &str, bytes: &[u8]) -> std::fmt::Result {
+fn fmt_prefixed_byte_str_rev(
+    f: &mut std::fmt::Formatter<'_>,
+    pre: &str,
+    bytes: &[u8],
+) -> std::fmt::Result {
     write!(f, "{}", pre)?;
     fmt_byte_str_rev(f, bytes)
 }
@@ -1513,7 +2114,7 @@ fn fmt_prefixed_byte_str_rev(f: &mut std::fmt::Formatter<'_>, pre: &str, bytes: 
 impl std::fmt::Debug for StaticDHKeyPair {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         fmt_prefixed_byte_str(f, "StaticDHKeyPair { private: \"", &self.private)?;
-        fmt_prefixed_byte_str(f, "\", public: \"",                &self.public)?;
+        fmt_prefixed_byte_str(f, "\", public: \"", &self.public)?;
         write!(f, "\" }}")
     }
 }
@@ -1530,7 +2131,7 @@ impl std::fmt::Debug for EndpointEvidence {
 impl std::fmt::Debug for SecureUdpEndpoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         fmt_prefixed_byte_str(f, "SecureUdpEndpoint { public_key: \"", &self.public_key)?;
-        fmt_prefixed_byte_str(f, "\", ip_address: \"",                 &self.ip_address)?;
+        fmt_prefixed_byte_str(f, "\", ip_address: \"", &self.ip_address)?;
         write!(f, "\", port: {:05} }}", self.port)
     }
 }
@@ -1538,24 +2139,42 @@ impl std::fmt::Debug for SecureUdpEndpoint {
 // returns true if a is initiator
 fn contended_noise_is_initiator(hash_keys: &HashKeys, a: &[u8; 32], b: &[u8; 32]) -> bool {
     // TODO: do we want a fast insecure hash for this kind of thing?
-    let a_to_b_hash = hash_keys.connect_contention.hasher().update(a).update(b).finalize();
-    let b_to_a_hash = hash_keys.connect_contention.hasher().update(b).update(a).finalize();
+    let a_to_b_hash = hash_keys
+        .connect_contention
+        .hasher()
+        .update(a)
+        .update(b)
+        .finalize();
+    let b_to_a_hash = hash_keys
+        .connect_contention
+        .hasher()
+        .update(b)
+        .update(a)
+        .finalize();
     a_to_b_hash.as_bytes() < b_to_a_hash.as_bytes()
 }
 
-fn nonce_is_ok2(nonce: u64, ack_latest: u64, ack_field: u64) -> bool {(
-    ack_latest <= nonce + 64 && // TODO: do we want to completely drop these or just exclude from heartbeat
+fn nonce_is_ok2(nonce: u64, ack_latest: u64, ack_field: u64) -> bool {
+    (ack_latest <= nonce + 64 && // TODO: do we want to completely drop these or just exclude from heartbeat
     nonce != ack_latest &&
     nonce <= ack_latest + NONCE_FORWARD_JUMP_TOLERANCE &&
-    (ack_latest < nonce || ack_field >> (ack_latest - nonce) & 1 == 0)
-)}
+    (ack_latest < nonce || ack_field >> (ack_latest - nonce) & 1 == 0))
+}
 
 fn nonce_is_ok(nonce: u64, ack_latest: u64, ack_field: u64) -> bool {
-    if nonce > ack_latest && nonce > ack_latest + NONCE_FORWARD_JUMP_TOLERANCE { return false; }
-    if nonce == ack_latest                                                     { return false; }
-    if nonce + 64 < ack_latest                                                 { return false; }
+    if nonce > ack_latest && nonce > ack_latest + NONCE_FORWARD_JUMP_TOLERANCE {
+        return false;
+    }
+    if nonce == ack_latest {
+        return false;
+    }
+    if nonce + 64 < ack_latest {
+        return false;
+    }
     // NOTE: this shift can overflow if we don't return before
-    if nonce < ack_latest && ack_field >> (ack_latest - nonce) & 1 != 0        { return false; }
+    if nonce < ack_latest && ack_field >> (ack_latest - nonce) & 1 != 0 {
+        return false;
+    }
     true
 }
 
@@ -1577,7 +2196,13 @@ fn nonce_update(nonce: u64, ack_latest: &mut u64, ack_field: &mut u64) {
     }
 }
 
-fn make_vote_sign_datas(pub_key: [u8; 32], is_precommit: bool, height: u64, round: u32, value_id: ValueId) -> [[u8; 76]; 2] {
+fn make_vote_sign_datas(
+    pub_key: [u8; 32],
+    is_precommit: bool,
+    height: u64,
+    round: u32,
+    value_id: ValueId,
+) -> [[u8; 76]; 2] {
     let mut sign_data_no = [0; 76];
     sign_data_no[0..32].copy_from_slice(&pub_key[..]);
     height.write_to(&mut sign_data_no[64..]);
@@ -1588,24 +2213,26 @@ fn make_vote_sign_datas(pub_key: [u8; 32], is_precommit: bool, height: u64, roun
 }
 
 pub fn gen_mostly_empty_rngs<F: Fn(usize) -> bool>(n: usize, f: F) -> Vec<[usize; 2]> {
-    let mut rngs: Vec<[usize;2]> = Vec::with_capacity(n);
+    let mut rngs: Vec<[usize; 2]> = Vec::with_capacity(n);
     let mut filled_c = 0; // consecutive fills
     let mut rng = [0, 0];
     // TODO(perf): these can be split arbitrarily & merged if we wanted to go wide
     for i in 0..n {
         if f(i) {
-            rng[1] = i+1;
+            rng[1] = i + 1;
             filled_c = 0; // consecutive only, could also consider occupancy
-        } else if rng[0] == rng[1] { // skip over leading fills
-            rng[0] = i+1;
-            rng[1] = i+1;
+        } else if rng[0] == rng[1] {
+            // skip over leading fills
+            rng[0] = i + 1;
+            rng[1] = i + 1;
         } else {
             filled_c += 1;
-            if filled_c > 1 { // 2 in a row
+            if filled_c > 1 {
+                // 2 in a row
                 rngs.push(rng);
                 filled_c = 0;
-                rng[0] = i+1;
-                rng[1] = i+1;
+                rng[0] = i + 1;
+                rng[1] = i + 1;
             }
         }
     }
@@ -1625,7 +2252,7 @@ async fn instance(
     maybe_seed: Option<u128>,
 ) -> std::io::Result<()> {
     let block_rng = Arc::new(Mutex::new({
-        let seed : u128 = maybe_seed.clone().unwrap_or_else(|| {
+        let seed: u128 = maybe_seed.clone().unwrap_or_else(|| {
             let mut seed_rng = rand::rng();
             ((seed_rng.next_u64() as u128) << 64) | seed_rng.next_u64() as u128
         });
@@ -1640,107 +2267,125 @@ async fn instance(
     let roster2 = roster.clone();
     let pub_key = PubKeyID(VerificationKeyBytes::from(&my_root_private_key.clone()).into());
 
-    entry_point(my_root_private_key, my_static_keypair, my_endpoint, roster, roster_endpoint_evidence, maybe_seed,
+    entry_point(
+        my_root_private_key,
+        my_static_keypair,
+        my_endpoint,
+        roster,
+        roster_endpoint_evidence,
+        maybe_seed,
         ClosureToProposeNewBlock(Arc::new(move || {
             let block_rng = Arc::clone(&block_rng);
             Box::pin(async move {
                 let mut buf = vec![0; 6000]; // TODO: replace with real data
                 block_rng.lock().unwrap().fill_bytes(&mut buf);
-                if should_propose_bad_value_sometimes == false { buf[0] = 0; }
+                if should_propose_bad_value_sometimes == false {
+                    buf[0] = 0;
+                }
                 Some(BlockValue(buf))
             })
         })),
         ClosureToValidateProposedBlock(Arc::new(move |block| {
             Box::pin(async move {
-                if block.0.len() == 0 { (TMStatus::Fail, TMStatusReason::None) }
-                else if block.0[0] % 2 == 0 { (TMStatus::Pass, TMStatusReason::None) }
+                if block.0.len() == 0 {
+                    (TMStatus::Fail, TMStatusReason::None)
+                } else if block.0[0] % 2 == 0 {
+                    (TMStatus::Pass, TMStatusReason::None)
+                }
                 //else if block.0[0] % 3 == 1 { (TMStatus::Indeterminate, TMStatusReason::None) }
-                else { (TMStatus::Fail, TMStatusReason::None) }
+                else {
+                    (TMStatus::Fail, TMStatusReason::None)
+                }
             })
         })),
-        ClosureToPushDecidedBlock(Arc::new(move |block, fat_pointer, _tender_proposal_sigs| {
-            let decisions = Arc::clone(&decisions);
-            let roster2 = roster2.clone();
-            Box::pin(async move {
-                decisions.lock().unwrap().push((block, fat_pointer));
-                let mut ret = roster2.clone();
-                ret.truncate(3 + decisions.lock().unwrap().len() % 2);
-                ret
-            })
-        })),
+        ClosureToPushDecidedBlock(Arc::new(
+            move |block, fat_pointer, _tender_proposal_sigs| {
+                let decisions = Arc::clone(&decisions);
+                let roster2 = roster2.clone();
+                Box::pin(async move {
+                    decisions.lock().unwrap().push((block, fat_pointer));
+                    let mut ret = roster2.clone();
+                    ret.truncate(3 + decisions.lock().unwrap().len() % 2);
+                    ret
+                })
+            },
+        )),
         ClosureToGetHistoricalBlock(Arc::new(move |height| {
             let decisions = Arc::clone(&decisions2);
-            Box::pin(async move {
-                decisions.lock().unwrap()[height as usize].clone()
-            })
+            Box::pin(async move { decisions.lock().unwrap()[height as usize].clone() })
         })),
-        ClosureToGetPow(Arc::new(move |hash| { // @Phillip
-            Box::pin(async move {
-                None
-            })
+        ClosureToGetPow(Arc::new(move |hash| {
+            // @Phillip
+            Box::pin(async move { None })
         })),
-        ClosureToParsePow(Arc::new(move |hash, bytes| { // @Phillip
-            Box::pin(async move {
-                None
-            })
+        ClosureToParsePow(Arc::new(move |hash, bytes| {
+            // @Phillip
+            Box::pin(async move { None })
         })),
-        ClosureIsPoWInChain(Arc::new(move |block| { // @Phillip
-            Box::pin(async move {
-                true
-            })
+        ClosureIsPoWInChain(Arc::new(move |block| {
+            // @Phillip
+            Box::pin(async move { true })
         })),
-        ClosureToPushPow(Arc::new(move |block| { // @Phillip
-            Box::pin(async move {
-            })
+        ClosureToPushPow(Arc::new(move |block| {
+            // @Phillip
+            Box::pin(async move {})
         })),
-        ClosureToUpdateRosterCmd(Arc::new(move |_str| { Box::pin(async move {
-            Some(format!("{:?}", pub_key))
-        })})),
-        ClosureToUpdatePeers(Arc::new(move |_all_peers| { Box::pin(async move {
-        })})),
-
+        ClosureToUpdateRosterCmd(Arc::new(move |_str| {
+            Box::pin(async move { Some(format!("{:?}", pub_key)) })
+        })),
+        ClosureToUpdatePeers(Arc::new(move |_all_peers| Box::pin(async move {}))),
         Vec::new(),
-    ).await
+    )
+    .await
 }
 
-pub async fn entry_point(my_root_private_key: SigningKey,
-                         my_static_keypair: Option<StaticDHKeyPair>,
-                         my_endpoint: Option<SecureUdpEndpoint>,
-                         mut roster: Vec<SortedRosterMember>,
-                         mut roster_endpoint_evidence: Vec<EndpointEvidence>,
-                         maybe_seed: Option<u128>,
-                         propose_closure: ClosureToProposeNewBlock,
-                         validate_closure: ClosureToValidateProposedBlock,
-                         push_block_closure: ClosureToPushDecidedBlock,
-                         get_block_closure: ClosureToGetHistoricalBlock,
-                         get_pow_closure: ClosureToGetPow,
-                         parse_pow_closure: ClosureToParsePow,
-                         is_pow_in_chain_closure: ClosureIsPoWInChain,
-                         push_pow_closure: ClosureToPushPow,
-                         roster_cmd_closure: ClosureToUpdateRosterCmd,
-                         peer_cmd_closure: ClosureToUpdatePeers,
-                         ingest_startup_data: Vec<RoundData>,
-                        ) -> std::io::Result<()> {
+pub async fn entry_point(
+    my_root_private_key: SigningKey,
+    my_static_keypair: Option<StaticDHKeyPair>,
+    my_endpoint: Option<SecureUdpEndpoint>,
+    mut roster: Vec<SortedRosterMember>,
+    mut roster_endpoint_evidence: Vec<EndpointEvidence>,
+    maybe_seed: Option<u128>,
+    propose_closure: ClosureToProposeNewBlock,
+    validate_closure: ClosureToValidateProposedBlock,
+    push_block_closure: ClosureToPushDecidedBlock,
+    get_block_closure: ClosureToGetHistoricalBlock,
+    get_pow_closure: ClosureToGetPow,
+    parse_pow_closure: ClosureToParsePow,
+    is_pow_in_chain_closure: ClosureIsPoWInChain,
+    push_pow_closure: ClosureToPushPow,
+    roster_cmd_closure: ClosureToUpdateRosterCmd,
+    peer_cmd_closure: ClosureToUpdatePeers,
+    ingest_startup_data: Vec<RoundData>,
+) -> std::io::Result<()> {
     hook_fail_on_panic();
     let mut base_rng = {
-        let seed : u128 = maybe_seed.unwrap_or_else(|| {
+        let seed: u128 = maybe_seed.unwrap_or_else(|| {
             let mut seed_rng = rand::rng();
             ((seed_rng.next_u64() as u128) << 64) | seed_rng.next_u64() as u128
         });
         SimRng::new(seed, 0)
     };
 
-    let noise_params: snow::params::NoiseParams = "Noise_IK_25519_ChaChaPoly_BLAKE2s".parse().unwrap();
+    let noise_params: snow::params::NoiseParams =
+        "Noise_IK_25519_ChaChaPoly_BLAKE2s".parse().unwrap();
     let my_root_public_bft_key = VerificationKeyBytes::from(&my_root_private_key);
     {
-        let key : &[u8; 32] = &my_root_public_bft_key.into();
+        let key: &[u8; 32] = &my_root_public_bft_key.into();
         print!("My root public key is \"");
-        for i in 0..key.len() { print!("{:02x}", key[i]); }
+        for i in 0..key.len() {
+            print!("{:02x}", key[i]);
+        }
         println!("\"");
     }
     let my_static_keypair = my_static_keypair.unwrap_or_else(|| {
-        let kp = snow::Builder::new(noise_params.clone()).generate_keypair().unwrap();
-        StaticDHKeyPair { private: kp.private.try_into().unwrap(), public: kp.public.try_into().unwrap(), }
+        let kp = snow::Builder::new(noise_params.clone())
+            .generate_keypair()
+            .unwrap();
+        StaticDHKeyPair {
+            private: kp.private.try_into().unwrap(),
+            public: kp.public.try_into().unwrap(),
+        }
     });
 
     let sock = {
@@ -1748,21 +2393,46 @@ pub async fn entry_point(my_root_private_key: SigningKey,
         let socket = Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP)).unwrap();
         socket.set_nonblocking(true).unwrap();
         socket.set_only_v6(false).unwrap(); // Sets IPV6_V6ONLY to 0 for dual-stack (required for win32)
-        socket.bind(&SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, my_endpoint.map(|e|e.port).unwrap_or(0), 0, 0).into()).unwrap();
+        socket
+            .bind(
+                &SocketAddrV6::new(
+                    Ipv6Addr::UNSPECIFIED,
+                    my_endpoint.map(|e| e.port).unwrap_or(0),
+                    0,
+                    0,
+                )
+                .into(),
+            )
+            .unwrap();
         tokio::net::UdpSocket::from_std(socket.into()).unwrap()
     };
 
     let my_port = sock.local_addr().unwrap().port();
 
-    let mut peers : Vec<Peer> = roster.iter().filter(|m| m.pub_key.0 != my_root_public_bft_key.as_ref())
-        .map(|m| Peer { root_public_bft_key: m.pub_key.0, ..Peer::default() }).collect();
+    let mut peers: Vec<Peer> = roster
+        .iter()
+        .filter(|m| m.pub_key.0 != my_root_public_bft_key.as_ref())
+        .map(|m| Peer {
+            root_public_bft_key: m.pub_key.0,
+            ..Peer::default()
+        })
+        .collect();
 
     for evidence in &roster_endpoint_evidence {
-        if let Some(i) = peers.iter().position(|p| p.root_public_bft_key == evidence.root_public_bft_key) {
+        if let Some(i) = peers
+            .iter()
+            .position(|p| p.root_public_bft_key == evidence.root_public_bft_key)
+        {
             peers[i].endpoint = Some(evidence.endpoint);
         }
     }
-    if PRINT_PROTOCOL { println!("socket port={:05}, peers endpoints={:?}", my_port, peers.iter().map(|p|p.endpoint).collect::<Vec<_>>()); }
+    if PRINT_PROTOCOL {
+        println!(
+            "socket port={:05}, peers endpoints={:?}",
+            my_port,
+            peers.iter().map(|p| p.endpoint).collect::<Vec<_>>()
+        );
+    }
 
     // TODO: only convert private to public in 1 location
     let mut bft_state = TMState::init(
@@ -1786,10 +2456,16 @@ pub async fn entry_point(my_root_private_key: SigningKey,
 
     bft_state.start_round(&roster, Instant::now(), 0).await;
 
-    let mut my_endpoint_evidence = if let Some(i) = roster_endpoint_evidence.iter().position(|e| &e.root_public_bft_key == my_root_public_bft_key.as_ref()) {
+    let mut my_endpoint_evidence = if let Some(i) = roster_endpoint_evidence
+        .iter()
+        .position(|e| &e.root_public_bft_key == my_root_public_bft_key.as_ref())
+    {
         Some(roster_endpoint_evidence[i])
     } else {
-        my_endpoint.map(|endpoint| EndpointEvidence { endpoint, root_public_bft_key: my_root_public_bft_key.into() })
+        my_endpoint.map(|endpoint| EndpointEvidence {
+            endpoint,
+            root_public_bft_key: my_root_public_bft_key.into(),
+        })
     };
 
     let mut unknown_peers: Vec<Peer> = Vec::new();
@@ -1814,10 +2490,12 @@ pub async fn entry_point(my_root_private_key: SigningKey,
             bft_state.update_peers_cmd_closure.0(peers).await;
         }
 
-        fn read_header_and_maybe_status(msg: &[u8]) -> std::io::Result<(PacketHeader, Option<PacketStatus>, usize)> {
-            let mut o   = 0;
+        fn read_header_and_maybe_status(
+            msg: &[u8],
+        ) -> std::io::Result<(PacketHeader, Option<PacketStatus>, usize)> {
+            let mut o = 0;
             let mut cur = Cursor::new(&msg[o..]);
-            let header  = PacketHeader::read_from(&mut cur)?;
+            let header = PacketHeader::read_from(&mut cur)?;
 
             print_packet_tag_recv(header);
 
@@ -1830,9 +2508,20 @@ pub async fn entry_point(my_root_private_key: SigningKey,
             Ok((header, status, o))
         }
 
-        fn write_header_and_maybe_status(header_: PacketHeader, include_status: bool, bft_state: &TMState, roster: &[SortedRosterMember], send_buf1: &mut [u8], peer_random: u64) -> usize {
+        fn write_header_and_maybe_status(
+            header_: PacketHeader,
+            include_status: bool,
+            bft_state: &TMState,
+            roster: &[SortedRosterMember],
+            send_buf1: &mut [u8],
+            peer_random: u64,
+        ) -> usize {
             let mut header = header_;
-            header.tag_and_ack |= if include_status { PACKET_TAG_STATUS_FLAG as u64 } else { 0 };
+            header.tag_and_ack |= if include_status {
+                PACKET_TAG_STATUS_FLAG as u64
+            } else {
+                0
+            };
 
             let mut o = 0;
             o += header.write_to(&mut send_buf1[o..]);
@@ -1853,29 +2542,44 @@ pub async fn entry_point(my_root_private_key: SigningKey,
                     }
                 }
 
-
                 // TODO: scope down required ranges
                 // TODO: probably generate these ranges once per tick/incrementally update & pull from it
                 // TODO: weight by stake? (easily determined by cumulative stake)
-                if let Ok(current_round_i) = bft_state.rounds_data.binary_search_by_key(&(status.height, status.round), |el| (el.height, el.round))
+                if let Ok(current_round_i) = bft_state
+                    .rounds_data
+                    .binary_search_by_key(&(status.height, status.round), |el| {
+                        (el.height, el.round)
+                    })
                 {
-
                     let round_data = &bft_state.rounds_data[current_round_i];
 
-                    let proposal_chunk_rngs = gen_mostly_empty_rngs(round_data.proposal_sigs.len(), |i| round_data.proposal_sigs[i] == TMSig::NIL);
+                    let proposal_chunk_rngs =
+                        gen_mostly_empty_rngs(round_data.proposal_sigs.len(), |i| {
+                            round_data.proposal_sigs[i] == TMSig::NIL
+                        });
                     if proposal_chunk_rngs.len() > 0 {
                         let mut random_i = peer_random;
                         for dst_rng in &mut status.need_proposal_chunk_rngs {
-                            let rng = proposal_chunk_rngs[random_i as usize % proposal_chunk_rngs.len()];
+                            let rng =
+                                proposal_chunk_rngs[random_i as usize % proposal_chunk_rngs.len()];
                             *dst_rng = [rng[0].try_into().unwrap(), rng[1].try_into().unwrap()];
                             random_i = random_i.wrapping_add(1610612741); // large prime
                             // TODO: "with removal"
                         }
                     }
-                    if PRINT_RNGS { println!("{} request proposal  chunks {:?} from {:?}", bft_state.ctx_str(roster), status.need_proposal_chunk_rngs, proposal_chunk_rngs); }
+                    if PRINT_RNGS {
+                        println!(
+                            "{} request proposal  chunks {:?} from {:?}",
+                            bft_state.ctx_str(roster),
+                            status.need_proposal_chunk_rngs,
+                            proposal_chunk_rngs
+                        );
+                    }
 
                     for is_precommit in 0..2 {
-                        let vote_rngs = gen_mostly_empty_rngs(active_roster_len(roster), |i| round_data.msg_val_sigs[i][is_precommit].1 == TMSig::NIL);
+                        let vote_rngs = gen_mostly_empty_rngs(active_roster_len(roster), |i| {
+                            round_data.msg_val_sigs[i][is_precommit].1 == TMSig::NIL
+                        });
                         if vote_rngs.len() > 0 {
                             let mut random_i = peer_random;
                             for dst_rng in &mut status.need_vote_rngs[is_precommit] {
@@ -1885,16 +2589,30 @@ pub async fn entry_point(my_root_private_key: SigningKey,
                                 // TODO: "with removal"
                             }
                         }
-                        if PRINT_RNGS { println!("{} request {:9} chunks {:?} from {:?}", bft_state.ctx_str(roster), ["prevote", "precommit"][is_precommit], status.need_vote_rngs[is_precommit], vote_rngs); }
+                        if PRINT_RNGS {
+                            println!(
+                                "{} request {:9} chunks {:?} from {:?}",
+                                bft_state.ctx_str(roster),
+                                ["prevote", "precommit"][is_precommit],
+                                status.need_vote_rngs[is_precommit],
+                                vote_rngs
+                            );
+                        }
                     }
-
                 }
 
                 o += status.write_to(&mut send_buf1[o..]);
             }
             o
         }
-        fn send_sock_msg(ctx_str: &str, transport: &mut PeerTransport, sock: &tokio::net::UdpSocket, peer_endpoint: SecureUdpEndpoint, msg: &[u8], stats: &mut NetworkStats) {
+        fn send_sock_msg(
+            ctx_str: &str,
+            transport: &mut PeerTransport,
+            sock: &tokio::net::UdpSocket,
+            peer_endpoint: SecureUdpEndpoint,
+            msg: &[u8],
+            stats: &mut NetworkStats,
+        ) {
             // TODO(phil) move this code
             let bytes_in_flight = {
                 let mut bytes_in_flight = 0;
@@ -1906,24 +2624,28 @@ pub async fn entry_point(my_root_private_key: SigningKey,
 
             let (_, mean_rtt) = {
                 let mut bytes_acknowledged = 0;
-                let mut rtt_sum   = 0.0;
+                let mut rtt_sum = 0.0;
                 let mut rtt_sum_n = 0.0;
                 for slot_i in 0..transport.acknowledged_sent_packets.slots.len() {
                     let packet = transport.acknowledged_sent_packets.slots[slot_i].value;
                     bytes_acknowledged += packet.bytes;
                     if packet.rtt > 0.0 {
-                        rtt_sum   += packet.rtt;
+                        rtt_sum += packet.rtt;
                         rtt_sum_n += 1.0;
                     }
                 }
-                if rtt_sum_n <= 0.0 { rtt_sum_n = 1.0; }
+                if rtt_sum_n <= 0.0 {
+                    rtt_sum_n = 1.0;
+                }
                 (bytes_acknowledged, rtt_sum / rtt_sum_n)
             };
 
             // TODO(phil): Compute real bandwidth using sliding congestion windows, TCP-style
             // const BANDWIDTH_SAFETY_MARGIN: f64 =     0.8;
 
-            let target_bytes_in_flight = ((MAX_BANDWIDTH_BYTES_PER_SECOND as f64 * mean_rtt.max(0.01)) as usize).max(PATH_MTU);
+            let target_bytes_in_flight = ((MAX_BANDWIDTH_BYTES_PER_SECOND as f64
+                * mean_rtt.max(0.01)) as usize)
+                .max(PATH_MTU);
 
             // NOTE(phil) probabilistically lerp down towards 0 likelihood of sending a packet as we approach bandwidth limit
             let rand_t = bytes_in_flight as f64 / target_bytes_in_flight as f64;
@@ -1933,41 +2655,75 @@ pub async fn entry_point(my_root_private_key: SigningKey,
             }
 
             // println!("Packet: {} bytes", msg.len());
-            let addr = SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::from(peer_endpoint.ip_address), peer_endpoint.port, 0, 0));
+            let addr = SocketAddr::V6(SocketAddrV6::new(
+                Ipv6Addr::from(peer_endpoint.ip_address),
+                peer_endpoint.port,
+                0,
+                0,
+            ));
             match sock.try_send_to(msg, addr) {
                 Ok(_) => {
                     stats.packets_sent += 1;
                     stats.bytes_sent += msg.len();
 
                     // println!("Packet sent! Nonce: {}! {} bytes!", transport.nonce, msg.len());
-                    transport.sent_packets.set(SentPacket { bytes: msg.len(), time_sent: Instant::now() }, transport.nonce as usize);
+                    transport.sent_packets.set(
+                        SentPacket {
+                            bytes: msg.len(),
+                            time_sent: Instant::now(),
+                        },
+                        transport.nonce as usize,
+                    );
 
                     ()
-                },
+                }
                 Err(ref e) if e.kind() == tokio::io::ErrorKind::WouldBlock => (), // not writable, drop
-                Err(error) => eprintln!("{} Socket error: {:?} sending to addr: {:?}", ctx_str, error, addr),
+                Err(error) => eprintln!(
+                    "{} Socket error: {:?} sending to addr: {:?}",
+                    ctx_str, error, addr
+                ),
             }
         }
-        fn send_noise_msg(ctx_str: &str, transport: &mut PeerTransport, snow_state: &mut snow::StatelessTransportState, sock: &tokio::net::UdpSocket, peer_endpoint: SecureUdpEndpoint, send_buf2: &mut [u8], msg: &[u8], stats: &mut NetworkStats) {
+        fn send_noise_msg(
+            ctx_str: &str,
+            transport: &mut PeerTransport,
+            snow_state: &mut snow::StatelessTransportState,
+            sock: &tokio::net::UdpSocket,
+            peer_endpoint: SecureUdpEndpoint,
+            send_buf2: &mut [u8],
+            msg: &[u8],
+            stats: &mut NetworkStats,
+        ) {
             let mut o = 0;
-            o += transport.nonce.write_to(                           &mut send_buf2[o..]);
-            o += snow_state     .write_message(transport.nonce, msg, &mut send_buf2[o..]).unwrap();
-            send_sock_msg(ctx_str, transport, sock, peer_endpoint, &send_buf2[..o], stats);
+            o += transport.nonce.write_to(&mut send_buf2[o..]);
+            o += snow_state
+                .write_message(transport.nonce, msg, &mut send_buf2[o..])
+                .unwrap();
+            send_sock_msg(
+                ctx_str,
+                transport,
+                sock,
+                peer_endpoint,
+                &send_buf2[..o],
+                stats,
+            );
 
             transport.nonce += 1;
         }
 
-        async fn powlink_peer(bft_state: &TMState, // @Phillip
-                              ctx_str: &str,
-                              stats: &mut NetworkStats,
-                              send_buf1: &mut [u8],
-                              send_buf2: &mut [u8],
-                              sock: &tokio::net::UdpSocket,
-                              peer_transport: &mut PeerTransport,
-                              peer_endpoint: SecureUdpEndpoint,
-                              peer_snow_state: &mut snow::StatelessTransportState,
-                              hash: BlockHash,
-                              chunk_needed_i: u16) -> std::io::Result<()> {
+        async fn powlink_peer(
+            bft_state: &TMState, // @Phillip
+            ctx_str: &str,
+            stats: &mut NetworkStats,
+            send_buf1: &mut [u8],
+            send_buf2: &mut [u8],
+            sock: &tokio::net::UdpSocket,
+            peer_transport: &mut PeerTransport,
+            peer_endpoint: SecureUdpEndpoint,
+            peer_snow_state: &mut snow::StatelessTransportState,
+            hash: BlockHash,
+            chunk_needed_i: u16,
+        ) -> std::io::Result<()> {
             let chunk_needed_i = chunk_needed_i as usize;
 
             if hash == BlockHash::NIL {
@@ -1990,24 +2746,45 @@ pub async fn entry_point(my_root_private_key: SigningKey,
             }
 
             let block_size = bytes.len().try_into().unwrap();
-            let bytes      = &bytes[..];
+            let bytes = &bytes[..];
 
             for chunk_i in chunk_needed_i..(chunk_needed_i + 2).min(chunks_n) {
                 let (chunk_o, chunk_size) = powlink_chunk_o_size(bytes.len(), chunk_i);
-                let chunk_i: u16          = chunk_i.try_into().unwrap();
-                let chunk                 = PacketPowlinkChunkHeader { hash, block_size, chunk_i };
-                let data                  = &bytes[chunk_o..chunk_o + chunk_size];
+                let chunk_i: u16 = chunk_i.try_into().unwrap();
+                let chunk = PacketPowlinkChunkHeader {
+                    hash,
+                    block_size,
+                    chunk_i,
+                };
+                let data = &bytes[chunk_o..chunk_o + chunk_size];
 
-                let header = PacketHeader::new::<PACKET_TYPE_POWLINK_CHUNK>(peer_transport.ack_latest, peer_transport.ack_field); // @TodoHeaderAndStatus
+                let header = PacketHeader::new::<PACKET_TYPE_POWLINK_CHUNK>(
+                    peer_transport.ack_latest,
+                    peer_transport.ack_field,
+                ); // @TodoHeaderAndStatus
 
-                let mut o  = 0;
+                let mut o = 0;
                 o += header.write_to(&mut send_buf1[o..]);
-                o += chunk .write_to(&mut send_buf1[o..]);
-                o += data  .write_to(&mut send_buf1[o..]);
+                o += chunk.write_to(&mut send_buf1[o..]);
+                o += data.write_to(&mut send_buf1[o..]);
 
-                if PRINT_POWLINK { eprintln!("{} PowLink: sending PoW block hash {:?} chunk {} to {:?}", ctx_str, hash, chunk_i, peer_endpoint); }
+                if PRINT_POWLINK {
+                    eprintln!(
+                        "{} PowLink: sending PoW block hash {:?} chunk {} to {:?}",
+                        ctx_str, hash, chunk_i, peer_endpoint
+                    );
+                }
                 print_packet_tag_send(header);
-                send_noise_msg(&ctx_str, peer_transport, peer_snow_state, &sock, peer_endpoint, send_buf2, &mut send_buf1[..o], stats);
+                send_noise_msg(
+                    &ctx_str,
+                    peer_transport,
+                    peer_snow_state,
+                    &sock,
+                    peer_endpoint,
+                    send_buf2,
+                    &mut send_buf1[..o],
+                    stats,
+                );
             }
 
             Ok(())
@@ -2023,14 +2800,23 @@ pub async fn entry_point(my_root_private_key: SigningKey,
 
             // TODO(Phil): figure out the off-by-one situation here...
             if ack >= 64 {
-                for i in ack-64..ack+1 {
+                for i in ack - 64..ack + 1 {
                     let is_acknowledged = (ack_field >> 63) & 1 != 0;
                     ack_field <<= 1;
-                    if !is_acknowledged { continue; }
+                    if !is_acknowledged {
+                        continue;
+                    }
 
-                    if let Some(sent_packet) = transport.sent_packets.at(i) &&
-                                sent_packet.bytes > 0 {
-                        transport.acknowledged_sent_packets.set(AcknowledgedSentPacket { bytes: sent_packet.bytes, rtt: now.duration_since(sent_packet.time_sent).as_secs_f64() }, i);
+                    if let Some(sent_packet) = transport.sent_packets.at(i)
+                        && sent_packet.bytes > 0
+                    {
+                        transport.acknowledged_sent_packets.set(
+                            AcknowledgedSentPacket {
+                                bytes: sent_packet.bytes,
+                                rtt: now.duration_since(sent_packet.time_sent).as_secs_f64(),
+                            },
+                            i,
+                        );
 
                         // println!("Packet acked!: {} bytes! {}", sent_packet.bytes, i + 64 - ack);
 
@@ -2054,69 +2840,147 @@ pub async fn entry_point(my_root_private_key: SigningKey,
                 // TICK CODE
                 unknown_peers.retain(|peer| {
                     if peer.watch_dog.elapsed() > TIMEOUT_DURATION {
-                        if PRINT_PROTOCOL { println!("{:05}: Disconnected from unknown peer {:?}", my_port, peer.endpoint); }
+                        if PRINT_PROTOCOL {
+                            println!(
+                                "{:05}: Disconnected from unknown peer {:?}",
+                                my_port, peer.endpoint
+                            );
+                        }
                         false
-                    } else { true }
+                    } else {
+                        true
+                    }
                 });
                 for peer in &mut peers {
                     if peer.watch_dog.elapsed() > TIMEOUT_DURATION {
                         if peer.snow_state.is_some() {
-                            if PRINT_PROTOCOL { println!("{:05}: Disconnected from peer {:?}", my_port, peer.endpoint); }
+                            if PRINT_PROTOCOL {
+                                println!(
+                                    "{:05}: Disconnected from peer {:?}",
+                                    my_port, peer.endpoint
+                                );
+                            }
                         }
-                        peer.outgoing_handshake_state       = None;
-                        peer.pending_client_ack_snow_state  = None;
-                        peer.snow_state                     = None;
-                        peer.watch_dog                      = Instant::now();
-                        peer.latest_status_request_height   = None;
-                        peer.latest_status_request_powlink  = None;
-                        peer.latest_status                  = None;
+                        peer.outgoing_handshake_state = None;
+                        peer.pending_client_ack_snow_state = None;
+                        peer.snow_state = None;
+                        peer.watch_dog = Instant::now();
+                        peer.latest_status_request_height = None;
+                        peer.latest_status_request_powlink = None;
+                        peer.latest_status = None;
                     }
 
-                    if let (Some(peer_endpoint), Some(snow_state)) = (peer.endpoint, &mut peer.snow_state) {
+                    if let (Some(peer_endpoint), Some(snow_state)) =
+                        (peer.endpoint, &mut peer.snow_state)
+                    {
                         if peer.connection_knowledge == ConnectionKnowledge::Unknown {
                             // Gossip evidence in order to trigger upgrade
                             if let Some(evidence) = my_endpoint_evidence {
-                                let header = PacketHeader::new::<PACKET_TYPE_ENDPOINT_EVIDENCE>(peer.transport.ack_latest, peer.transport.ack_field); // @TodoHeaderAndStatus
-                                let mut o  = 0;
-                                o += header  .write_to(&mut send_buf1[o..]);
+                                let header = PacketHeader::new::<PACKET_TYPE_ENDPOINT_EVIDENCE>(
+                                    peer.transport.ack_latest,
+                                    peer.transport.ack_field,
+                                ); // @TodoHeaderAndStatus
+                                let mut o = 0;
+                                o += header.write_to(&mut send_buf1[o..]);
                                 o += evidence.write_to(&mut send_buf1[o..]);
                                 print_packet_tag_send(header);
-                                send_noise_msg(&ctx_str, &mut peer.transport, snow_state, &sock, peer_endpoint, &mut send_buf2, &send_buf1[..o], &mut net_stats);
+                                send_noise_msg(
+                                    &ctx_str,
+                                    &mut peer.transport,
+                                    snow_state,
+                                    &sock,
+                                    peer_endpoint,
+                                    &mut send_buf2,
+                                    &send_buf1[..o],
+                                    &mut net_stats,
+                                );
                             }
                         }
-                        let header = PacketHeader::new::<PACKET_TYPE_EMPTY>(peer.transport.ack_latest, peer.transport.ack_field);
-                        let mut o  = 0;
-                        o += write_header_and_maybe_status(header, true, &bft_state, &roster, &mut send_buf1[..], peer.transport.nonce);
+                        let header = PacketHeader::new::<PACKET_TYPE_EMPTY>(
+                            peer.transport.ack_latest,
+                            peer.transport.ack_field,
+                        );
+                        let mut o = 0;
+                        o += write_header_and_maybe_status(
+                            header,
+                            true,
+                            &bft_state,
+                            &roster,
+                            &mut send_buf1[..],
+                            peer.transport.nonce,
+                        );
                         print_packet_tag_send(header);
-                        send_noise_msg(&ctx_str, &mut peer.transport, snow_state, &sock, peer_endpoint, &mut send_buf2, &send_buf1[..o], &mut net_stats);
+                        send_noise_msg(
+                            &ctx_str,
+                            &mut peer.transport,
+                            snow_state,
+                            &sock,
+                            peer_endpoint,
+                            &mut send_buf2,
+                            &send_buf1[..o],
+                            &mut net_stats,
+                        );
                     }
                 }
                 for peer in &mut peers {
                     if let Some(peer_endpoint) = peer.endpoint {
-                        if peer.snow_state.is_none() && peer.outgoing_handshake_state.is_none() && peer.pending_client_ack_snow_state.is_none() {
-                            let mut outgoing_state: snow::HandshakeState = snow::Builder::new(noise_params.clone())
-                                .local_private_key(&my_static_keypair.private).unwrap()
-                                .remote_public_key(&peer_endpoint.public_key).unwrap()
-                                .build_initiator().unwrap();
+                        if peer.snow_state.is_none()
+                            && peer.outgoing_handshake_state.is_none()
+                            && peer.pending_client_ack_snow_state.is_none()
+                        {
+                            let mut outgoing_state: snow::HandshakeState =
+                                snow::Builder::new(noise_params.clone())
+                                    .local_private_key(&my_static_keypair.private)
+                                    .unwrap()
+                                    .remote_public_key(&peer_endpoint.public_key)
+                                    .unwrap()
+                                    .build_initiator()
+                                    .unwrap();
                             peer.transport = PeerTransport::default();
-                            let header = PacketHeader::new::<PACKET_TYPE_CLIENT_HELLO>(peer.transport.ack_latest, peer.transport.ack_field); // @TodoHeaderAndStatus
+                            let header = PacketHeader::new::<PACKET_TYPE_CLIENT_HELLO>(
+                                peer.transport.ack_latest,
+                                peer.transport.ack_field,
+                            ); // @TodoHeaderAndStatus
                             let mut o = 0;
                             o += header.write_to(&mut send_buf1[o..]);
-                            let n = outgoing_state.write_message(&send_buf1[..o], &mut send_buf2).unwrap();
+                            let n = outgoing_state
+                                .write_message(&send_buf1[..o], &mut send_buf2)
+                                .unwrap();
                             // TODO: no nonce?
                             print_packet_tag_send(header);
-                            send_sock_msg(&ctx_str, &mut peer.transport, &sock, peer_endpoint, &send_buf2[..n], &mut net_stats);
+                            send_sock_msg(
+                                &ctx_str,
+                                &mut peer.transport,
+                                &sock,
+                                peer_endpoint,
+                                &send_buf2[..n],
+                                &mut net_stats,
+                            );
                             peer.outgoing_handshake_state = Some(outgoing_state);
                         }
 
-                        if let (Some(snow_state), Some(evidence)) =
-                            (&mut peer.snow_state, roster_endpoint_evidence.choose(&mut base_rng)) {
-                            let header = PacketHeader::new::<PACKET_TYPE_ENDPOINT_EVIDENCE>(peer.transport.ack_latest, peer.transport.ack_field); // @TodoHeaderAndStatus
+                        if let (Some(snow_state), Some(evidence)) = (
+                            &mut peer.snow_state,
+                            roster_endpoint_evidence.choose(&mut base_rng),
+                        ) {
+                            let header = PacketHeader::new::<PACKET_TYPE_ENDPOINT_EVIDENCE>(
+                                peer.transport.ack_latest,
+                                peer.transport.ack_field,
+                            ); // @TodoHeaderAndStatus
                             let mut o = 0;
-                            o += header  .write_to(&mut send_buf1[o..]);
+                            o += header.write_to(&mut send_buf1[o..]);
                             o += evidence.write_to(&mut send_buf1[o..]);
                             print_packet_tag_send(header);
-                            send_noise_msg(&ctx_str, &mut peer.transport, snow_state, &sock, peer_endpoint, &mut send_buf2, &send_buf1[..o], &mut net_stats);
+                            send_noise_msg(
+                                &ctx_str,
+                                &mut peer.transport,
+                                snow_state,
+                                &sock,
+                                peer_endpoint,
+                                &mut send_buf2,
+                                &send_buf1[..o],
+                                &mut net_stats,
+                            );
                         }
                     }
                 }
@@ -2128,47 +2992,48 @@ pub async fn entry_point(my_root_private_key: SigningKey,
                 // Note(Sam): I am going to emulate the future production p2p network by always adding the two ShieldedLabs servers as known validator peers with zero voting power if they are not
                 // already in the roster.
 
+                fn parse_to_ipv6_bytes(
+                    s: &str,
+                ) -> Result<([u8; 16], u16), std::net::AddrParseError> {
+                    let sa: SocketAddr = s.parse()?;
 
-fn parse_to_ipv6_bytes(s: &str) -> Result<([u8; 16], u16), std::net::AddrParseError> {
-    let sa: SocketAddr = s.parse()?;
+                    let (ip6, port) = match sa {
+                        SocketAddr::V4(v4) => {
+                            // Map IPv4 to IPv6-mapped ::ffff:a.b.c.d
+                            (v4.ip().to_ipv6_mapped(), v4.port())
+                            // (Alternatively on newer Rust: (v4.ip().to_ipv6_mapped(), v4.port()))
+                        }
+                        SocketAddr::V6(v6) => (*v6.ip(), v6.port()),
+                    };
 
-    let (ip6, port) = match sa {
-        SocketAddr::V4(v4) => {
-            // Map IPv4 to IPv6-mapped ::ffff:a.b.c.d
-            (v4.ip().to_ipv6_mapped(), v4.port())
-            // (Alternatively on newer Rust: (v4.ip().to_ipv6_mapped(), v4.port()))
-        }
-        SocketAddr::V6(v6) => (*v6.ip(), v6.port()),
-    };
+                    Ok((ip6.octets(), port))
+                }
+                fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint) {
+                    use std::hash::Hasher;
+                    let mut hasher = DefaultHasher::new();
+                    hasher.write(addr.as_bytes());
+                    let seed = hasher.finish();
 
-    Ok((ip6.octets(), port))
-}
-fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint) {
-    use std::hash::Hasher;
-    let mut hasher = DefaultHasher::new();
-    hasher.write(addr.as_bytes());
-    let seed = hasher.finish();
-
-    let kp = snow::Builder::with_resolver(
-        "Noise_IK_25519_ChaChaPoly_BLAKE2s".parse().unwrap(),
-        Box::new(SnowRngResolver::seed_from_u64(seed)),
-    )
-    .generate_keypair()
-    .unwrap();
-    let static_keypair = StaticDHKeyPair {
-        private: kp.private.try_into().unwrap(),
-        public: kp.public.try_into().unwrap(),
-    };
-    let (ip, port) = parse_to_ipv6_bytes(addr).unwrap();
-    (
-        static_keypair,
-        SecureUdpEndpoint {
-            public_key: static_keypair.public,
-            ip_address: ip,
-            port,
-        },
-    )
-}
+                    let kp = snow::Builder::with_resolver(
+                        "Noise_IK_25519_ChaChaPoly_BLAKE2s".parse().unwrap(),
+                        Box::new(SnowRngResolver::seed_from_u64(seed)),
+                    )
+                    .generate_keypair()
+                    .unwrap();
+                    let static_keypair = StaticDHKeyPair {
+                        private: kp.private.try_into().unwrap(),
+                        public: kp.public.try_into().unwrap(),
+                    };
+                    let (ip, port) = parse_to_ipv6_bytes(addr).unwrap();
+                    (
+                        static_keypair,
+                        SecureUdpEndpoint {
+                            public_key: static_keypair.public,
+                            ip_address: ip,
+                            port,
+                        },
+                    )
+                }
 
                 let server_a_pub_key = {
                     let mut bytes = [0u8; 32];
@@ -2182,12 +3047,25 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                     bytes
                 };
 
-                if peers.iter().position(|p| p.root_public_bft_key == server_a_pub_key).is_none() && server_a_pub_key != my_root_private_key.as_ref() {
+                if peers
+                    .iter()
+                    .position(|p| p.root_public_bft_key == server_a_pub_key)
+                    .is_none()
+                    && server_a_pub_key != my_root_private_key.as_ref()
+                {
                     let (a, b) = goofy_addr_string_to_stuff("45.76.30.90:8234");
-                    let evidence = EndpointEvidence { endpoint: b, root_public_bft_key: server_a_pub_key };
-                    roster_endpoint_evidence.retain(|e| e.root_public_bft_key != evidence.root_public_bft_key);
+                    let evidence = EndpointEvidence {
+                        endpoint: b,
+                        root_public_bft_key: server_a_pub_key,
+                    };
+                    roster_endpoint_evidence
+                        .retain(|e| e.root_public_bft_key != evidence.root_public_bft_key);
                     roster_endpoint_evidence.push(evidence);
-                    peers.push(Peer { root_public_bft_key: server_a_pub_key, endpoint: Some(evidence.endpoint), ..Peer::default() });
+                    peers.push(Peer {
+                        root_public_bft_key: server_a_pub_key,
+                        endpoint: Some(evidence.endpoint),
+                        ..Peer::default()
+                    });
                 }
 
                 let server_b_pub_key = {
@@ -2202,22 +3080,53 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                     bytes
                 };
 
-                if peers.iter().position(|p| p.root_public_bft_key == server_b_pub_key).is_none() && server_b_pub_key != my_root_private_key.as_ref() {
+                if peers
+                    .iter()
+                    .position(|p| p.root_public_bft_key == server_b_pub_key)
+                    .is_none()
+                    && server_b_pub_key != my_root_private_key.as_ref()
+                {
                     let (a, b) = goofy_addr_string_to_stuff("70.34.201.202:8234");
-                    let evidence = EndpointEvidence { endpoint: b, root_public_bft_key: server_b_pub_key };
-                    roster_endpoint_evidence.retain(|e| e.root_public_bft_key != evidence.root_public_bft_key);
+                    let evidence = EndpointEvidence {
+                        endpoint: b,
+                        root_public_bft_key: server_b_pub_key,
+                    };
+                    roster_endpoint_evidence
+                        .retain(|e| e.root_public_bft_key != evidence.root_public_bft_key);
                     roster_endpoint_evidence.push(evidence);
-                    peers.push(Peer { root_public_bft_key: server_b_pub_key, endpoint: Some(evidence.endpoint), ..Peer::default() });
+                    peers.push(Peer {
+                        root_public_bft_key: server_b_pub_key,
+                        endpoint: Some(evidence.endpoint),
+                        ..Peer::default()
+                    });
                 }
 
                 {
                     let active_roster = &roster[..active_roster_len(&roster)];
                     // Drop those who are not in the active roster. And not the backup p2p servers.
-                    peers.retain(|p| p.root_public_bft_key == server_a_pub_key || p.root_public_bft_key == server_b_pub_key || active_roster.iter().position(|rp| rp.pub_key.0 == p.root_public_bft_key).is_some());
+                    peers.retain(|p| {
+                        p.root_public_bft_key == server_a_pub_key
+                            || p.root_public_bft_key == server_b_pub_key
+                            || active_roster
+                                .iter()
+                                .position(|rp| rp.pub_key.0 == p.root_public_bft_key)
+                                .is_some()
+                    });
                     for rp in active_roster {
-                        if peers.iter().position(|p| p.root_public_bft_key == rp.pub_key.0).is_none() && rp.pub_key.0 != my_root_private_key.as_ref() {
-                            let mut peer = Peer { root_public_bft_key: rp.pub_key.0, ..Peer::default() };
-                            if let Some(evidence) = roster_endpoint_evidence.iter().find(|evidence| evidence.root_public_bft_key == rp.pub_key.0) {
+                        if peers
+                            .iter()
+                            .position(|p| p.root_public_bft_key == rp.pub_key.0)
+                            .is_none()
+                            && rp.pub_key.0 != my_root_private_key.as_ref()
+                        {
+                            let mut peer = Peer {
+                                root_public_bft_key: rp.pub_key.0,
+                                ..Peer::default()
+                            };
+                            if let Some(evidence) = roster_endpoint_evidence
+                                .iter()
+                                .find(|evidence| evidence.root_public_bft_key == rp.pub_key.0)
+                            {
                                 peer.endpoint = Some(evidence.endpoint);
                             }
                             peers.push(peer);
@@ -2225,17 +3134,37 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                     }
                 }
 
-                fn send_round_data_to_peer(bft_state: &TMState, should_send_prevotes: bool, round_data: &RoundData, ctx_str: &str, send_buf1: &mut [u8], send_buf2: &mut [u8], peer_transport: &mut PeerTransport, peer_endpoint: SecureUdpEndpoint, peer_snow_state: &mut snow::StatelessTransportState, peer_root_public_bft_key: [u8; 32], sock: &tokio::net::UdpSocket, stats: &mut NetworkStats) {
+                fn send_round_data_to_peer(
+                    bft_state: &TMState,
+                    should_send_prevotes: bool,
+                    round_data: &RoundData,
+                    ctx_str: &str,
+                    send_buf1: &mut [u8],
+                    send_buf2: &mut [u8],
+                    peer_transport: &mut PeerTransport,
+                    peer_endpoint: SecureUdpEndpoint,
+                    peer_snow_state: &mut snow::StatelessTransportState,
+                    peer_root_public_bft_key: [u8; 32],
+                    sock: &tokio::net::UdpSocket,
+                    stats: &mut NetworkStats,
+                ) {
                     let height = round_data.height;
-                    let round  = round_data.round;
+                    let round = round_data.round;
 
                     let mut chunk_hdr = PacketProposalChunkHeader {
-                        height, round, chunk_i: 0,
+                        height,
+                        round,
+                        chunk_i: 0,
                         proposal_size: round_data.proposal.0.len().try_into().unwrap(),
                         proposal_id: round_data.proposal_id,
                         valid_round: round_data.proposal_valid_round,
                     };
-                    let (_, proposer_pub_key) = TMState::proposer_from_height_round(&bft_state.hash_keys, &round_data.roster, height, round);
+                    let (_, proposer_pub_key) = TMState::proposer_from_height_round(
+                        &bft_state.hash_keys,
+                        &round_data.roster,
+                        height,
+                        round,
+                    );
 
                     let mut sent_chunk_cs = 0;
                     let mut sent_c: [usize; 2] = [0; 2];
@@ -2246,72 +3175,137 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                             if round_data.proposal_sigs[chunk_i] != TMSig::NIL {
                                 chunk_hdr.chunk_i = chunk_i as u32;
 
-                                let header = PacketHeader::new::<PACKET_TYPE_PROPOSAL_CHUNK>(peer_transport.ack_latest, peer_transport.ack_field); // @TodoHeaderAndStatus
+                                let header = PacketHeader::new::<PACKET_TYPE_PROPOSAL_CHUNK>(
+                                    peer_transport.ack_latest,
+                                    peer_transport.ack_field,
+                                ); // @TodoHeaderAndStatus
 
                                 let mut o = 0;
-                                o += header   .write_to(&mut send_buf1[o..]);
+                                o += header.write_to(&mut send_buf1[o..]);
                                 o += chunk_hdr.write_to(&mut send_buf1[o..]);
 
-                                let (chunk_o, chunk_size) = round_data.proposal.chunk_o_size(chunk_i);
-                                o += round_data.proposal.0[chunk_o..chunk_o + chunk_size].write_to(&mut send_buf1[o..]);
+                                let (chunk_o, chunk_size) =
+                                    round_data.proposal.chunk_o_size(chunk_i);
+                                o += round_data.proposal.0[chunk_o..chunk_o + chunk_size]
+                                    .write_to(&mut send_buf1[o..]);
                                 let sig_o = o;
-                                o += round_data.proposal_sigs[chunk_i].0.write_to(&mut send_buf1[o..]);
+                                o += round_data.proposal_sigs[chunk_i]
+                                    .0
+                                    .write_to(&mut send_buf1[o..]);
 
                                 #[cfg(debug_assertions)] // self-check signatures as sanity check
-                                match round_data.proposal_sigs[chunk_i].verify(proposer_pub_key, &send_buf1[PACKET_HEADER_SIZE..sig_o]) {
+                                match round_data.proposal_sigs[chunk_i]
+                                    .verify(proposer_pub_key, &send_buf1[PACKET_HEADER_SIZE..sig_o])
+                                {
                                     Ok(_) => {}
                                     Err((err, str)) => {
-                                        eprintln!("{ctx_str}: \x1b[91mBFT FAULT\x1b[0m: {str} [..{}]: for proposal from {proposer_pub_key:?} {height}.{round}.{chunk_i}: {} {err}", sig_o-1, chunk_hdr.proposal_id);
+                                        eprintln!(
+                                            "{ctx_str}: \x1b[91mBFT FAULT\x1b[0m: {str} [..{}]: for proposal from {proposer_pub_key:?} {height}.{round}.{chunk_i}: {} {err}",
+                                            sig_o - 1,
+                                            chunk_hdr.proposal_id
+                                        );
                                         continue;
                                     }
                                 }
 
-                                if PRINT_SENDS { eprintln!("{} sending proposal chunk {} to {:?}", ctx_str, chunk_i, peer_root_public_bft_key); }
+                                if PRINT_SENDS {
+                                    eprintln!(
+                                        "{} sending proposal chunk {} to {:?}",
+                                        ctx_str, chunk_i, peer_root_public_bft_key
+                                    );
+                                }
                                 sent_chunk_cs += 1;
                                 print_packet_tag_send(header);
-                                send_noise_msg(&ctx_str, peer_transport, peer_snow_state, &sock, peer_endpoint, send_buf2, &mut send_buf1[..o], stats);
+                                send_noise_msg(
+                                    &ctx_str,
+                                    peer_transport,
+                                    peer_snow_state,
+                                    &sock,
+                                    peer_endpoint,
+                                    send_buf2,
+                                    &mut send_buf1[..o],
+                                    stats,
+                                );
                             }
                         }
                     }
 
                     let vote_start: u8 = if should_send_prevotes { 0 } else { 1 };
                     for is_precommit in vote_start..2 {
-                        if  (is_precommit == 0 && round_data.counts.prevotes   == 0) ||
-                            (is_precommit == 1 && round_data.counts.precommits == 0)
+                        if (is_precommit == 0 && round_data.counts.prevotes == 0)
+                            || (is_precommit == 1 && round_data.counts.precommits == 0)
                         {
                             continue;
                         }
 
-                        let header = PacketHeader::new_(PACKET_TYPE_PREVOTE_SIGNATURES + is_precommit, peer_transport.ack_latest, peer_transport.ack_field); // @TodoHeaderAndStatus
+                        let header = PacketHeader::new_(
+                            PACKET_TYPE_PREVOTE_SIGNATURES + is_precommit,
+                            peer_transport.ack_latest,
+                            peer_transport.ack_field,
+                        ); // @TodoHeaderAndStatus
                         let mut packet = PacketVotes {
-                            height, round,
+                            height,
+                            round,
                             value_id: round_data.proposal_id,
-                            no_votes_n: 0, yes_votes_n: 0,
-                            votes: [ PubKeySig::NIL; 18 ],
+                            no_votes_n: 0,
+                            yes_votes_n: 0,
+                            votes: [PubKeySig::NIL; 18],
                         };
 
-                        fn dbg_check_votes(ctx_str: &str, roster: &[SortedRosterMember], is_precommit: usize, packet: &PacketVotes) {
+                        fn dbg_check_votes(
+                            ctx_str: &str,
+                            roster: &[SortedRosterMember],
+                            is_precommit: usize,
+                            packet: &PacketVotes,
+                        ) {
                             #[cfg(debug_assertions)] // self-check signatures as sanity check
                             for i in 0..(packet.no_votes_n + packet.yes_votes_n) as usize {
-                                let (roster_i, sig) = (packet.votes[i].roster_i as usize, &packet.votes[i].sig);
+                                let (roster_i, sig) =
+                                    (packet.votes[i].roster_i as usize, &packet.votes[i].sig);
                                 let Some(member) = roster.get(roster_i) else {
-                                    eprintln!("{ctx_str}: \x1b[91mBFT ERROR\x1b[0m: {} from {roster_i} - not in roster {}.{}: {}", ["prevote", "precommit"][is_precommit], packet.height, packet.round, packet.value_id);
+                                    eprintln!(
+                                        "{ctx_str}: \x1b[91mBFT ERROR\x1b[0m: {} from {roster_i} - not in roster {}.{}: {}",
+                                        ["prevote", "precommit"][is_precommit],
+                                        packet.height,
+                                        packet.round,
+                                        packet.value_id
+                                    );
                                     return;
                                 };
                                 let pub_key = member.pub_key;
-                                let sign_datas = make_vote_sign_datas(pub_key.0, is_precommit != 0, packet.height, packet.round, packet.value_id);
-                                let sign_data  = &sign_datas[(i >= packet.no_votes_n as usize) as usize];
-                                match sig.verify(pub_key, sign_data) { Ok(_)=>{} Err((err, str)) => {
-                                    eprintln!("{ctx_str}: \x1b[91mBFT FAULT\x1b[0m: {str} [..{}]: for {} from {roster_i}-{pub_key:?} {}.{}: {} {err}",
-                                        sign_data.len(), ["prevote", "precommit"][is_precommit], packet.height, packet.round, packet.value_id);
-                                }}
+                                let sign_datas = make_vote_sign_datas(
+                                    pub_key.0,
+                                    is_precommit != 0,
+                                    packet.height,
+                                    packet.round,
+                                    packet.value_id,
+                                );
+                                let sign_data =
+                                    &sign_datas[(i >= packet.no_votes_n as usize) as usize];
+                                match sig.verify(pub_key, sign_data) {
+                                    Ok(_) => {}
+                                    Err((err, str)) => {
+                                        eprintln!(
+                                            "{ctx_str}: \x1b[91mBFT FAULT\x1b[0m: {str} [..{}]: for {} from {roster_i}-{pub_key:?} {}.{}: {} {err}",
+                                            sign_data.len(),
+                                            ["prevote", "precommit"][is_precommit],
+                                            packet.height,
+                                            packet.round,
+                                            packet.value_id
+                                        );
+                                    }
+                                }
                             }
                         }
 
                         for roster_i in 0..round_data.msg_val_sigs.len() {
-                            let (value_id, sig) = round_data.msg_val_sigs[roster_i][is_precommit as usize];
+                            let (value_id, sig) =
+                                round_data.msg_val_sigs[roster_i][is_precommit as usize];
                             if sig != TMSig::NIL {
-                                let pub_key_sig = PubKeySig{ roster_i: roster_i.try_into().unwrap(), sig };
+                                let pub_key_sig = PubKeySig {
+                                    roster_i: roster_i.try_into().unwrap(),
+                                    sig,
+                                };
                                 // println!("{} {}: packing in sig from {}", ctx_str, PubKeyID(my_root_public_bft_key.into()), pub_key_sig.pub_key);
 
                                 if packet.value_id == ValueId::NIL {
@@ -2319,7 +3313,10 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                                     packet.value_id = value_id;
                                 }
                                 if value_id != ValueId::NIL && value_id != packet.value_id {
-                                    eprintln!("{}: \x1b[91mBFT FAULT\x1b[0m: local mismatch: {:?} vs {:?}", ctx_str, packet.value_id, value_id);
+                                    eprintln!(
+                                        "{}: \x1b[91mBFT FAULT\x1b[0m: local mismatch: {:?} vs {:?}",
+                                        ctx_str, packet.value_id, value_id
+                                    );
                                     continue;
                                 }
 
@@ -2329,111 +3326,303 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                                     packet.no_votes_n += 1;
                                 } else {
                                     packet.yes_votes_n += 1; // *intentionally* pre-decrement because we're indexing from end
-                                    packet.votes[packet.votes.len() - packet.yes_votes_n as usize] = pub_key_sig;
+                                    packet.votes
+                                        [packet.votes.len() - packet.yes_votes_n as usize] =
+                                        pub_key_sig;
                                 };
 
-
-                                if (packet.no_votes_n + packet.yes_votes_n) as usize == packet.votes.len() {
-                                    sent_c[is_precommit as usize] += (packet.no_votes_n + packet.yes_votes_n) as usize;
+                                if (packet.no_votes_n + packet.yes_votes_n) as usize
+                                    == packet.votes.len()
+                                {
+                                    sent_c[is_precommit as usize] +=
+                                        (packet.no_votes_n + packet.yes_votes_n) as usize;
                                     // full evidence block; send it
-                                    if PRINT_SENDS { println!("{}: sending full {} block: {:#?}", ctx_str, ["prevote", "precommit"][is_precommit as usize], packet); }
-                                    dbg_check_votes(ctx_str, &round_data.roster, is_precommit as usize, &packet);
+                                    if PRINT_SENDS {
+                                        println!(
+                                            "{}: sending full {} block: {:#?}",
+                                            ctx_str,
+                                            ["prevote", "precommit"][is_precommit as usize],
+                                            packet
+                                        );
+                                    }
+                                    dbg_check_votes(
+                                        ctx_str,
+                                        &round_data.roster,
+                                        is_precommit as usize,
+                                        &packet,
+                                    );
 
                                     let mut o = 0;
                                     o += header.write_to(&mut send_buf1[o..]);
                                     o += packet.write_to(&mut send_buf1[o..]);
-                                    send_noise_msg(ctx_str, peer_transport, peer_snow_state, sock, peer_endpoint, send_buf2, &send_buf1[..o], stats);
+                                    send_noise_msg(
+                                        ctx_str,
+                                        peer_transport,
+                                        peer_snow_state,
+                                        sock,
+                                        peer_endpoint,
+                                        send_buf2,
+                                        &send_buf1[..o],
+                                        stats,
+                                    );
 
-                                    packet.no_votes_n  = 0;
+                                    packet.no_votes_n = 0;
                                     packet.yes_votes_n = 0;
-                                    packet.votes       = [PubKeySig::NIL; 18];
+                                    packet.votes = [PubKeySig::NIL; 18];
                                 }
                             }
                         }
 
                         // send any half-filled vote blocks
                         if (packet.no_votes_n + packet.yes_votes_n) > 0 {
-                            sent_c[is_precommit as usize] += (packet.no_votes_n + packet.yes_votes_n) as usize;
+                            sent_c[is_precommit as usize] +=
+                                (packet.no_votes_n + packet.yes_votes_n) as usize;
                             // println!("{}: half-filled block pre-gap-close: {:#?}", ctx_str, packet);
                             // move items from end to fill gap
-                            for gap_i in 0..packet.votes.len() - (packet.no_votes_n + packet.yes_votes_n) as usize {
-                                packet.votes[packet.no_votes_n as usize + gap_i] = packet.votes[packet.votes.len() - 1 - gap_i];
+                            for gap_i in 0..packet.votes.len()
+                                - (packet.no_votes_n + packet.yes_votes_n) as usize
+                            {
+                                packet.votes[packet.no_votes_n as usize + gap_i] =
+                                    packet.votes[packet.votes.len() - 1 - gap_i];
                             }
 
-                            if PRINT_SENDS { println!("{}: half-filled block post-gap-close: {:#?}", ctx_str, packet); }
-                            dbg_check_votes(ctx_str, &round_data.roster, is_precommit as usize, &packet);
+                            if PRINT_SENDS {
+                                println!(
+                                    "{}: half-filled block post-gap-close: {:#?}",
+                                    ctx_str, packet
+                                );
+                            }
+                            dbg_check_votes(
+                                ctx_str,
+                                &round_data.roster,
+                                is_precommit as usize,
+                                &packet,
+                            );
 
                             let mut o = 0;
                             o += header.write_to(&mut send_buf1[o..]);
                             o += packet.write_to(&mut send_buf1[o..]);
                             // TODO: maybe status
                             print_packet_tag_send(header);
-                            send_noise_msg(ctx_str, peer_transport, peer_snow_state, sock, peer_endpoint, send_buf2, &send_buf1[..o], stats);
+                            send_noise_msg(
+                                ctx_str,
+                                peer_transport,
+                                peer_snow_state,
+                                sock,
+                                peer_endpoint,
+                                send_buf2,
+                                &send_buf1[..o],
+                                stats,
+                            );
                         }
                     }
 
-                    if PRINT_SEND_CS && sent_chunk_cs > 0 { eprintln!("{} sent {} proposal chunks", ctx_str, sent_chunk_cs); }
-                    if PRINT_SEND_CS && sent_c[0]     > 0 { eprintln!("{} sent {} prevotes",        ctx_str, sent_c[0]);     }
-                    if PRINT_SEND_CS && sent_c[1]     > 0 { eprintln!("{} sent {} precommits",      ctx_str, sent_c[1]);     }
+                    if PRINT_SEND_CS && sent_chunk_cs > 0 {
+                        eprintln!("{} sent {} proposal chunks", ctx_str, sent_chunk_cs);
+                    }
+                    if PRINT_SEND_CS && sent_c[0] > 0 {
+                        eprintln!("{} sent {} prevotes", ctx_str, sent_c[0]);
+                    }
+                    if PRINT_SEND_CS && sent_c[1] > 0 {
+                        eprintln!("{} sent {} precommits", ctx_str, sent_c[1]);
+                    }
                 }
 
-                if PRINT_PEERS { println!("{} {:?}", ctx_str, peers.iter().map(|p|
-                    (PubKeyID(p.root_public_bft_key), p.latest_status.clone(), p.connection_knowledge)
-                ).collect::<Vec<_>>()); }
+                if PRINT_PEERS {
+                    println!(
+                        "{} {:?}",
+                        ctx_str,
+                        peers
+                            .iter()
+                            .map(|p| (
+                                PubKeyID(p.root_public_bft_key),
+                                p.latest_status.clone(),
+                                p.connection_knowledge
+                            ))
+                            .collect::<Vec<_>>()
+                    );
+                }
 
-                if let Some(cmd) = &bft_state.roster_cmd && PRINT_ROSTER_CMD { eprintln!("{ctx_str} recv roster cmd: \"{}\"", cmd); }
-                let roster_cmd = bft_state.update_roster_cmd_closure.0(bft_state.roster_cmd.take()).await;
-                if let Some(cmd) = &roster_cmd && PRINT_ROSTER_CMD { eprintln!("{ctx_str} send roster cmd: \"{}\"", cmd); }
+                if let Some(cmd) = &bft_state.roster_cmd
+                    && PRINT_ROSTER_CMD
+                {
+                    eprintln!("{ctx_str} recv roster cmd: \"{}\"", cmd);
+                }
+                let roster_cmd =
+                    bft_state.update_roster_cmd_closure.0(bft_state.roster_cmd.take()).await;
+                if let Some(cmd) = &roster_cmd
+                    && PRINT_ROSTER_CMD
+                {
+                    eprintln!("{ctx_str} send roster cmd: \"{}\"", cmd);
+                }
 
                 for peer_i in 0..peers.len() {
                     let peer = &mut peers[peer_i];
-                    if peer.endpoint.is_none() || peer.snow_state.is_none() { continue; }
-                    if let Some(height) = peer.latest_status_request_height && height < bft_state.height {
-                        peer.latest_status_request_height = None;
-                        send_round_data_to_peer(&bft_state, false, &bft_state.recent_commit_round_cache[height as usize], &ctx_str, &mut send_buf1, &mut send_buf2, &mut peer.transport, peer.endpoint.unwrap(), peer.snow_state.as_mut().unwrap(), peer.root_public_bft_key, &sock, &mut net_stats);
+                    if peer.endpoint.is_none() || peer.snow_state.is_none() {
+                        continue;
                     }
-                    if let Some((hash, chunk_i)) = peer.latest_status_request_powlink && !hash.eq(&BlockHash::NIL) {
-                        peer.latest_status_request_powlink = None;
-                        powlink_peer(&bft_state, &ctx_str, &mut net_stats, &mut send_buf1, &mut send_buf2, &sock, &mut peer.transport, peer.endpoint.unwrap(), peer.snow_state.as_mut().unwrap(), hash, chunk_i).await;
-                    }
-                    else if let Ok(current_height_start_i) = bft_state.rounds_data.binary_search_by_key(&(bft_state.height, 0), |el| (el.height, el.round))
+                    if let Some(height) = peer.latest_status_request_height
+                        && height < bft_state.height
                     {
-                        for round_i in (current_height_start_i..bft_state.rounds_data.len()).rev()
-                        {
+                        peer.latest_status_request_height = None;
+                        send_round_data_to_peer(
+                            &bft_state,
+                            false,
+                            &bft_state.recent_commit_round_cache[height as usize],
+                            &ctx_str,
+                            &mut send_buf1,
+                            &mut send_buf2,
+                            &mut peer.transport,
+                            peer.endpoint.unwrap(),
+                            peer.snow_state.as_mut().unwrap(),
+                            peer.root_public_bft_key,
+                            &sock,
+                            &mut net_stats,
+                        );
+                    }
+                    if let Some((hash, chunk_i)) = peer.latest_status_request_powlink
+                        && !hash.eq(&BlockHash::NIL)
+                    {
+                        peer.latest_status_request_powlink = None;
+                        powlink_peer(
+                            &bft_state,
+                            &ctx_str,
+                            &mut net_stats,
+                            &mut send_buf1,
+                            &mut send_buf2,
+                            &sock,
+                            &mut peer.transport,
+                            peer.endpoint.unwrap(),
+                            peer.snow_state.as_mut().unwrap(),
+                            hash,
+                            chunk_i,
+                        )
+                        .await;
+                    } else if let Ok(current_height_start_i) = bft_state
+                        .rounds_data
+                        .binary_search_by_key(&(bft_state.height, 0), |el| (el.height, el.round))
+                    {
+                        for round_i in (current_height_start_i..bft_state.rounds_data.len()).rev() {
                             let round_data = &bft_state.rounds_data[round_i];
-                            send_round_data_to_peer(&bft_state, true, &round_data, &ctx_str, &mut send_buf1, &mut send_buf2, &mut peer.transport, peer.endpoint.unwrap(), peer.snow_state.as_mut().unwrap(), peer.root_public_bft_key, &sock, &mut net_stats);
+                            send_round_data_to_peer(
+                                &bft_state,
+                                true,
+                                &round_data,
+                                &ctx_str,
+                                &mut send_buf1,
+                                &mut send_buf2,
+                                &mut peer.transport,
+                                peer.endpoint.unwrap(),
+                                peer.snow_state.as_mut().unwrap(),
+                                peer.root_public_bft_key,
+                                &sock,
+                                &mut net_stats,
+                            );
                         }
                     } else {
-                        eprintln!("{}: \x1b[91mBFT ERROR\x1b[0m: round_data array was empty", ctx_str);
+                        eprintln!(
+                            "{}: \x1b[91mBFT ERROR\x1b[0m: round_data array was empty",
+                            ctx_str
+                        );
                     }
 
                     if let Some(cmd) = &roster_cmd {
-                        let header = PacketHeader::new::<PACKET_TYPE_ROSTER_CMD>(peer.transport.ack_latest, peer.transport.ack_field);
-                        let mut o = write_header_and_maybe_status(header, false, &bft_state, &roster, &mut send_buf1[..], peer.transport.nonce);
-                        o        += cmd.as_bytes().write_to(&mut send_buf1[o..]);
+                        let header = PacketHeader::new::<PACKET_TYPE_ROSTER_CMD>(
+                            peer.transport.ack_latest,
+                            peer.transport.ack_field,
+                        );
+                        let mut o = write_header_and_maybe_status(
+                            header,
+                            false,
+                            &bft_state,
+                            &roster,
+                            &mut send_buf1[..],
+                            peer.transport.nonce,
+                        );
+                        o += cmd.as_bytes().write_to(&mut send_buf1[o..]);
                         print_packet_tag_send(header);
-                        send_noise_msg(&ctx_str, &mut peer.transport, peer.snow_state.as_mut().unwrap(), &sock, peer.endpoint.unwrap(), &mut send_buf2, &send_buf1[..o], &mut net_stats);
+                        send_noise_msg(
+                            &ctx_str,
+                            &mut peer.transport,
+                            peer.snow_state.as_mut().unwrap(),
+                            &sock,
+                            peer.endpoint.unwrap(),
+                            &mut send_buf2,
+                            &send_buf1[..o],
+                            &mut net_stats,
+                        );
                     }
                 }
 
                 for peer_i in 0..unknown_peers.len() {
                     let peer = &mut unknown_peers[peer_i];
-                    if peer.endpoint.is_none() || peer.snow_state.is_none() { continue; }
-                    if let Some(height) = peer.latest_status_request_height && height < bft_state.height {
-                        peer.latest_status_request_height = None;
-                        send_round_data_to_peer(&bft_state, false, &bft_state.recent_commit_round_cache[height as usize], &ctx_str, &mut send_buf1, &mut send_buf2, &mut peer.transport, peer.endpoint.unwrap(), peer.snow_state.as_mut().unwrap(), [0; 32], &sock, &mut net_stats);
+                    if peer.endpoint.is_none() || peer.snow_state.is_none() {
+                        continue;
                     }
-                    if let Some((hash, chunk_i)) = peer.latest_status_request_powlink && !hash.eq(&BlockHash::NIL) {
+                    if let Some(height) = peer.latest_status_request_height
+                        && height < bft_state.height
+                    {
+                        peer.latest_status_request_height = None;
+                        send_round_data_to_peer(
+                            &bft_state,
+                            false,
+                            &bft_state.recent_commit_round_cache[height as usize],
+                            &ctx_str,
+                            &mut send_buf1,
+                            &mut send_buf2,
+                            &mut peer.transport,
+                            peer.endpoint.unwrap(),
+                            peer.snow_state.as_mut().unwrap(),
+                            [0; 32],
+                            &sock,
+                            &mut net_stats,
+                        );
+                    }
+                    if let Some((hash, chunk_i)) = peer.latest_status_request_powlink
+                        && !hash.eq(&BlockHash::NIL)
+                    {
                         peer.latest_status_request_powlink = None;
-                        powlink_peer(&bft_state, &ctx_str, &mut net_stats, &mut send_buf1, &mut send_buf2, &sock, &mut peer.transport, peer.endpoint.unwrap(), peer.snow_state.as_mut().unwrap(), hash, chunk_i).await;
+                        powlink_peer(
+                            &bft_state,
+                            &ctx_str,
+                            &mut net_stats,
+                            &mut send_buf1,
+                            &mut send_buf2,
+                            &sock,
+                            &mut peer.transport,
+                            peer.endpoint.unwrap(),
+                            peer.snow_state.as_mut().unwrap(),
+                            hash,
+                            chunk_i,
+                        )
+                        .await;
                     }
 
                     if let Some(cmd) = &roster_cmd {
-                        let header = PacketHeader::new::<PACKET_TYPE_ROSTER_CMD>(peer.transport.ack_latest, peer.transport.ack_field);
-                        let mut o = write_header_and_maybe_status(header, false, &bft_state, &roster, &mut send_buf1[..], peer.transport.nonce);
-                        o        += cmd.as_bytes().write_to(&mut send_buf1[o..]);
+                        let header = PacketHeader::new::<PACKET_TYPE_ROSTER_CMD>(
+                            peer.transport.ack_latest,
+                            peer.transport.ack_field,
+                        );
+                        let mut o = write_header_and_maybe_status(
+                            header,
+                            false,
+                            &bft_state,
+                            &roster,
+                            &mut send_buf1[..],
+                            peer.transport.nonce,
+                        );
+                        o += cmd.as_bytes().write_to(&mut send_buf1[o..]);
                         print_packet_tag_send(header);
-                        send_noise_msg(&ctx_str, &mut peer.transport, peer.snow_state.as_mut().unwrap(), &sock, peer.endpoint.unwrap(), &mut send_buf2, &send_buf1[..o], &mut net_stats);
+                        send_noise_msg(
+                            &ctx_str,
+                            &mut peer.transport,
+                            peer.snow_state.as_mut().unwrap(),
+                            &sock,
+                            peer.endpoint.unwrap(),
+                            &mut send_buf2,
+                            &send_buf1[..o],
+                            &mut net_stats,
+                        );
                     }
                 }
 
@@ -2441,28 +3630,41 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                     let elapsed = net_stats_window_start.elapsed();
                     let nonzero_elapsed_sec = elapsed.as_secs_f32().max(1.0);
 
-                    let kbps = (std::cmp::max(1, net_stats.bytes_sent)   as f32) / 1000.0 / (nonzero_elapsed_sec);
-                    let  pps = (std::cmp::max(1, net_stats.packets_sent) as f32)          / (nonzero_elapsed_sec);
-                    let  bpp = (std::cmp::max(1, net_stats.bytes_sent)   as f32)          / (std::cmp::max(1, net_stats.packets_sent) as f32);
+                    let kbps = (std::cmp::max(1, net_stats.bytes_sent) as f32)
+                        / 1000.0
+                        / (nonzero_elapsed_sec);
+                    let pps =
+                        (std::cmp::max(1, net_stats.packets_sent) as f32) / (nonzero_elapsed_sec);
+                    let bpp = (std::cmp::max(1, net_stats.bytes_sent) as f32)
+                        / (std::cmp::max(1, net_stats.packets_sent) as f32);
 
                     let kbps = kbps as u32;
-                    let  pps =  pps as u32;
-                    let  bpp =  bpp as u32;
+                    let pps = pps as u32;
+                    let bpp = bpp as u32;
 
                     if kbps != 0 {
-                        println!("{}: \x1b[92mNET\x1b[0m: {} KB/s | {} packets/s | {} bytes/packet",
-                                 ctx_str, kbps, pps, bpp);
+                        println!(
+                            "{}: \x1b[92mNET\x1b[0m: {} KB/s | {} packets/s | {} bytes/packet",
+                            ctx_str, kbps, pps, bpp
+                        );
                     }
                 }
 
                 // POWLINK UPDATE
                 if let Some((hash, powlink)) = bft_state.current_powlink.as_mut() {
                     let hash = *hash;
-                    if powlink.block.is_none() && powlink.data.len() != 0 && powlink.chunk_i as usize == powlink_chunks_n(powlink.data.len()) {
-                        if PRINT_POWLINK { println!("{}: PowLink: Block {:?} is DONE!", ctx_str, hash); }
+                    if powlink.block.is_none()
+                        && powlink.data.len() != 0
+                        && powlink.chunk_i as usize == powlink_chunks_n(powlink.data.len())
+                    {
+                        if PRINT_POWLINK {
+                            println!("{}: PowLink: Block {:?} is DONE!", ctx_str, hash);
+                        }
 
                         let bytes = &powlink.data;
-                        if let Some(block) = bft_state.parse_pow_closure.0(hash.0, bytes.clone()).await {
+                        if let Some(block) =
+                            bft_state.parse_pow_closure.0(hash.0, bytes.clone()).await
+                        {
                             powlink.block = Some(block.clone());
                         }
                     }
@@ -2476,24 +3678,57 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                             let mut push_buffer = Vec::new();
                             std::mem::swap(&mut push_buffer, &mut bft_state.pow_submit_block_queue);
                             for block in push_buffer.into_iter().rev() {
-                                if PRINT_POWLINK { println!("{}: PowLink: \x1b[92mFLUSHING POW\x1b[0;0m hash: {:?}...", ctx_str, block.hash()); }
+                                if PRINT_POWLINK {
+                                    println!(
+                                        "{}: PowLink: \x1b[92mFLUSHING POW\x1b[0;0m hash: {:?}...",
+                                        ctx_str,
+                                        block.hash()
+                                    );
+                                }
                                 bft_state.push_pow_closure.0(block).await;
                             }
                         } else {
-                            bft_state.current_powlink = Some((BlockHash(prev_hash), Powlink::default()));
+                            bft_state.current_powlink =
+                                Some((BlockHash(prev_hash), Powlink::default()));
                             let len = bft_state.pow_submit_block_queue.len() + 1;
-                            if PRINT_POWLINK { println!("{}: PowLink: \x1b[93mBLOCK NEEDED\x1b[0m hash: {:?}...", ctx_str, prev_hash); }
-                            if PRINT_POWLINK { println!("{}: PowLink: \x1b[93mBLOCK NEEDED\x1b[0m count: {:?}...", ctx_str, len); }
+                            if PRINT_POWLINK {
+                                println!(
+                                    "{}: PowLink: \x1b[93mBLOCK NEEDED\x1b[0m hash: {:?}...",
+                                    ctx_str, prev_hash
+                                );
+                            }
+                            if PRINT_POWLINK {
+                                println!(
+                                    "{}: PowLink: \x1b[93mBLOCK NEEDED\x1b[0m count: {:?}...",
+                                    ctx_str, len
+                                );
+                            }
                         }
                     } else {
                         if bft_state.pow_submit_block_queue.len() > 0 {
-                            if bft_state.is_pow_in_chain_closure.0(bft_state.pow_submit_block_queue[bft_state.pow_submit_block_queue.len()-1].hash().0).await {
+                            if bft_state.is_pow_in_chain_closure.0(
+                                bft_state.pow_submit_block_queue
+                                    [bft_state.pow_submit_block_queue.len() - 1]
+                                    .hash()
+                                    .0,
+                            )
+                            .await
+                            {
                                 bft_state.current_powlink = None;
                                 let mut push_buffer = Vec::new();
-                                std::mem::swap(&mut push_buffer, &mut bft_state.pow_submit_block_queue);
+                                std::mem::swap(
+                                    &mut push_buffer,
+                                    &mut bft_state.pow_submit_block_queue,
+                                );
                                 push_buffer.truncate(push_buffer.len() - 1);
                                 for block in push_buffer.into_iter().rev() {
-                                    if PRINT_POWLINK { println!("{}: PowLink: \x1b[92mFLUSHING POW\x1b[0;0m hash: {:?}...", ctx_str, block.hash()); }
+                                    if PRINT_POWLINK {
+                                        println!(
+                                            "{}: PowLink: \x1b[92mFLUSHING POW\x1b[0;0m hash: {:?}...",
+                                            ctx_str,
+                                            block.hash()
+                                        );
+                                    }
                                     bft_state.push_pow_closure.0(block).await;
                                 }
                             }
@@ -2512,12 +3747,12 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
         }
 
         fn timeout_drop(transport: &mut PeerTransport) {
-            let mut rtt_sum   = 0.0;
+            let mut rtt_sum = 0.0;
             let mut rtt_sum_n = 0.0;
             for slot_i in 0..transport.acknowledged_sent_packets.slots.len() {
                 let packet = transport.acknowledged_sent_packets.slots[slot_i].value;
                 if packet.rtt > 0.0 {
-                    rtt_sum   += packet.rtt;
+                    rtt_sum += packet.rtt;
                     rtt_sum_n += 1.0;
                 }
             }
@@ -2531,8 +3766,10 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                 for slot_i in 0..transport.sent_packets.slots.len() {
                     let sent_packet = &mut transport.sent_packets.slots[slot_i].value;
                     if sent_packet.bytes > 0 {
-                        let time_since_sent = now.duration_since(sent_packet.time_sent).as_secs_f64();
-                        if time_since_sent > mean_rtt * 1.5 { // timeout-drop
+                        let time_since_sent =
+                            now.duration_since(sent_packet.time_sent).as_secs_f64();
+                        if time_since_sent > mean_rtt * 1.5 {
+                            // timeout-drop
                             *sent_packet = SentPacket::default();
                         }
                     }
@@ -2547,12 +3784,18 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
         }
 
         let remaining = next_tick_time.saturating_duration_since(was_now);
-        let (length, addr) = match tokio::time::timeout(remaining, sock.recv_from(&mut recv_buf1)).await {
-            Err(_elapsed) => continue, // timeout
-            Ok(Err(error)) => { println!("Socket error: {:?}", error); continue; },
-            Ok(Ok(ret)) => ret,
-        };
-        if length < 8 + PACKET_HEADER_SIZE { continue; } // early out to simplify nonce code
+        let (length, addr) =
+            match tokio::time::timeout(remaining, sock.recv_from(&mut recv_buf1)).await {
+                Err(_elapsed) => continue, // timeout
+                Ok(Err(error)) => {
+                    println!("Socket error: {:?}", error);
+                    continue;
+                }
+                Ok(Ok(ret)) => ret,
+            };
+        if length < 8 + PACKET_HEADER_SIZE {
+            continue;
+        } // early out to simplify nonce code
         let raw_msg = &recv_buf1[..length];
 
         let from_ip = match addr {
@@ -2569,15 +3812,21 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
 
         //  NOTE(Security): Actually we would need to loop because a peer could sign a message claiming to own an IP and PORT that it actually does not own. That also means falling back on
         //      the unknown connections array since that also shouldn't be able to be blocked.
-        if let Some(i) = peers.iter().map(|p| p.endpoint.unwrap_or_default()).position(|endpoint| endpoint.ip_address == from_ip && endpoint.port == from_port) {
+        if let Some(i) = peers
+            .iter()
+            .map(|p| p.endpoint.unwrap_or_default())
+            .position(|endpoint| endpoint.ip_address == from_ip && endpoint.port == from_port)
+        {
             let peer_endpoint = peers[i].endpoint.unwrap();
             loop {
                 let peer = &mut peers[i];
                 if let Some(snow_state) = &mut peer.snow_state {
                     nonce = u64::from_le_bytes(raw_msg[0..8].try_into().unwrap());
-                    if let Ok(length) = snow_state.read_message(nonce, &raw_msg[8..], &mut recv_buf2) {
+                    if let Ok(length) =
+                        snow_state.read_message(nonce, &raw_msg[8..], &mut recv_buf2)
+                    {
                         if nonce_is_ok(nonce, peer.transport.ack_latest, peer.transport.ack_field) {
-                            msg        = Some(&recv_buf2[0..length]);
+                            msg = Some(&recv_buf2[0..length]);
                             peer_index = i;
                         }
                         break;
@@ -2586,8 +3835,24 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
 
                 if let Some(outgoing) = &mut peer.outgoing_handshake_state {
                     if let Ok(length) = outgoing.read_message(raw_msg, &mut recv_buf2) {
-                        fn finish_outgoing_handshake(ctx_str: &str, send_buf1: &mut [u8], send_buf2: &mut [u8], sock: &tokio::net::UdpSocket, peer_endpoint: SecureUdpEndpoint, peer: &mut Peer, mut snow_state: snow::StatelessTransportState, nonce: u64, connection_knowledge: ConnectionKnowledge, stats: &mut NetworkStats) {
-                            let packet_type = if connection_knowledge == ConnectionKnowledge::Unknown { PACKET_TYPE_CLIENT_UNKNOWN_ACK } else { PACKET_TYPE_CLIENT_ACK };
+                        fn finish_outgoing_handshake(
+                            ctx_str: &str,
+                            send_buf1: &mut [u8],
+                            send_buf2: &mut [u8],
+                            sock: &tokio::net::UdpSocket,
+                            peer_endpoint: SecureUdpEndpoint,
+                            peer: &mut Peer,
+                            mut snow_state: snow::StatelessTransportState,
+                            nonce: u64,
+                            connection_knowledge: ConnectionKnowledge,
+                            stats: &mut NetworkStats,
+                        ) {
+                            let packet_type =
+                                if connection_knowledge == ConnectionKnowledge::Unknown {
+                                    PACKET_TYPE_CLIENT_UNKNOWN_ACK
+                                } else {
+                                    PACKET_TYPE_CLIENT_ACK
+                                };
 
                             // TODO: we should rate-limit new connections so adversaries can't exhaust your entropy pool by rapidly asking for new nonces
                             peer.transport.nonce = rand::random::<u64>() >> (PACKET_TAG_BITS + 1);
@@ -2597,14 +3862,23 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                             o += header.write_to(&mut send_buf1[o..]);
 
                             print_packet_tag_send(header);
-                            send_noise_msg(ctx_str, &mut peer.transport, &mut snow_state, sock, peer_endpoint, send_buf2, &send_buf1[..o], stats);
+                            send_noise_msg(
+                                ctx_str,
+                                &mut peer.transport,
+                                &mut snow_state,
+                                sock,
+                                peer_endpoint,
+                                send_buf2,
+                                &send_buf1[..o],
+                                stats,
+                            );
 
-                            peer.snow_state                    = Some(snow_state);
-                            peer.outgoing_handshake_state      = None;
+                            peer.snow_state = Some(snow_state);
+                            peer.outgoing_handshake_state = None;
                             peer.pending_client_ack_snow_state = None;
-                            peer.transport.ack_latest          = nonce;
-                            peer.transport.ack_field           = !0;
-                            peer.connection_knowledge         = connection_knowledge;
+                            peer.transport.ack_latest = nonce;
+                            peer.transport.ack_field = !0;
+                            peer.connection_knowledge = connection_knowledge;
                         }
 
                         if length < 8 + PACKET_HEADER_SIZE {
@@ -2614,7 +3888,9 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                         nonce = u64::from_le_bytes(recv_buf2[..8].try_into().unwrap());
 
                         let header_and_local_msg = &recv_buf2[8..length]; // @Duplicate
-                        let Ok(header) = PacketHeader::read_from(&header_and_local_msg[..]) else { break; }; // @TodoHeaderAndStatus
+                        let Ok(header) = PacketHeader::read_from(&header_and_local_msg[..]) else {
+                            break;
+                        }; // @TodoHeaderAndStatus
                         let packet_type = header.type_();
                         let local_msg = &header_and_local_msg[PACKET_HEADER_SIZE..];
 
@@ -2625,35 +3901,99 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                         if packet_type == PACKET_TYPE_SERVER_HELLO {
                             {
                                 let them: &[u8; 32] = &peer.root_public_bft_key;
-                                let me:   &[u8; 32] = &my_root_public_bft_key.into();
+                                let me: &[u8; 32] = &my_root_public_bft_key.into();
 
                                 if them == me {
-                                    eprintln!("\x1b[91mKEY MATCH\x1b[0m: Received a SERVER_HELLO from a peer reporting the same key as me.");
+                                    eprintln!(
+                                        "\x1b[91mKEY MATCH\x1b[0m: Received a SERVER_HELLO from a peer reporting the same key as me."
+                                    );
                                     break;
                                 }
                             }
-                            if peer.pending_client_ack_snow_state.is_none() || !contended_noise_is_initiator(&bft_state.hash_keys, &my_root_public_bft_key.into(), &peer.root_public_bft_key) {
-                                if let Ok(snow_state) = peer.outgoing_handshake_state.take().unwrap().into_stateless_transport_mode() {
-                                    if PRINT_PROTOCOL { println!("{:05}: Finished outgoing handshake and got nonce {} with {}", my_port, nonce, addr); }
-                                    finish_outgoing_handshake(&ctx_str, &mut send_buf1, &mut send_buf2, &sock, peer_endpoint, peer, snow_state, nonce, ConnectionKnowledge::Known, &mut net_stats);
+                            if peer.pending_client_ack_snow_state.is_none()
+                                || !contended_noise_is_initiator(
+                                    &bft_state.hash_keys,
+                                    &my_root_public_bft_key.into(),
+                                    &peer.root_public_bft_key,
+                                )
+                            {
+                                if let Ok(snow_state) = peer
+                                    .outgoing_handshake_state
+                                    .take()
+                                    .unwrap()
+                                    .into_stateless_transport_mode()
+                                {
+                                    if PRINT_PROTOCOL {
+                                        println!(
+                                            "{:05}: Finished outgoing handshake and got nonce {} with {}",
+                                            my_port, nonce, addr
+                                        );
+                                    }
+                                    finish_outgoing_handshake(
+                                        &ctx_str,
+                                        &mut send_buf1,
+                                        &mut send_buf2,
+                                        &sock,
+                                        peer_endpoint,
+                                        peer,
+                                        snow_state,
+                                        nonce,
+                                        ConnectionKnowledge::Known,
+                                        &mut net_stats,
+                                    );
                                 }
                                 break;
                             }
-                        } else if packet_type == PACKET_TYPE_SERVER_UNKNOWN_HELLO && local_msg.len() == 18 {
-                            let my_apparent_ip       = &local_msg[  ..16];
-                            let my_apparent_port     = &local_msg[16..18];
-                            let my_apparent_endpoint = SecureUdpEndpoint { ip_address: my_apparent_ip.try_into().unwrap(), port: u16::from_le_bytes(my_apparent_port.try_into().unwrap()), public_key: my_static_keypair.public };
+                        } else if packet_type == PACKET_TYPE_SERVER_UNKNOWN_HELLO
+                            && local_msg.len() == 18
+                        {
+                            let my_apparent_ip = &local_msg[..16];
+                            let my_apparent_port = &local_msg[16..18];
+                            let my_apparent_endpoint = SecureUdpEndpoint {
+                                ip_address: my_apparent_ip.try_into().unwrap(),
+                                port: u16::from_le_bytes(my_apparent_port.try_into().unwrap()),
+                                public_key: my_static_keypair.public,
+                            };
                             // TODO hash
-                            if let Ok(snow_state) = peer.outgoing_handshake_state.take().unwrap().into_stateless_transport_mode() {
-                                if PRINT_PROTOCOL { println!("{:05}: Finished outgoing unknown handshake and got nonce {} with {}, I am percieved as {:?}", my_port, nonce, addr, my_apparent_endpoint); }
+                            if let Ok(snow_state) = peer
+                                .outgoing_handshake_state
+                                .take()
+                                .unwrap()
+                                .into_stateless_transport_mode()
+                            {
+                                if PRINT_PROTOCOL {
+                                    println!(
+                                        "{:05}: Finished outgoing unknown handshake and got nonce {} with {}, I am percieved as {:?}",
+                                        my_port, nonce, addr, my_apparent_endpoint
+                                    );
+                                }
 
                                 if my_endpoint_evidence.is_none() {
-                                    let evidence = EndpointEvidence { endpoint: my_apparent_endpoint, root_public_bft_key: my_root_public_bft_key.into() };
-                                    if PRINT_PROTOCOL { println!("{:05}: I am locking in the endpoint evidence {:?}", my_port, evidence); }
+                                    let evidence = EndpointEvidence {
+                                        endpoint: my_apparent_endpoint,
+                                        root_public_bft_key: my_root_public_bft_key.into(),
+                                    };
+                                    if PRINT_PROTOCOL {
+                                        println!(
+                                            "{:05}: I am locking in the endpoint evidence {:?}",
+                                            my_port, evidence
+                                        );
+                                    }
                                     my_endpoint_evidence = Some(evidence);
                                 }
 
-                                finish_outgoing_handshake(&ctx_str, &mut send_buf1, &mut send_buf2, &sock, peer_endpoint, peer, snow_state, nonce, ConnectionKnowledge::Unknown, &mut net_stats);
+                                finish_outgoing_handshake(
+                                    &ctx_str,
+                                    &mut send_buf1,
+                                    &mut send_buf2,
+                                    &sock,
+                                    peer_endpoint,
+                                    peer,
+                                    snow_state,
+                                    nonce,
+                                    ConnectionKnowledge::Unknown,
+                                    &mut net_stats,
+                                );
                             }
                             break;
                         }
@@ -2661,9 +4001,12 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                 }
                 if let Some(incoming) = &mut peer.pending_client_ack_snow_state {
                     nonce = u64::from_le_bytes(raw_msg[..8].try_into().unwrap());
-                    if let Ok(length) = incoming.read_message(nonce, &raw_msg[8..], &mut recv_buf2) {
+                    if let Ok(length) = incoming.read_message(nonce, &raw_msg[8..], &mut recv_buf2)
+                    {
                         let header_and_local_msg = &recv_buf2[..length]; // @Duplicate
-                        let Ok(header) = PacketHeader::read_from(&header_and_local_msg[..]) else { break; }; // @TodoHeaderAndStatus
+                        let Ok(header) = PacketHeader::read_from(&header_and_local_msg[..]) else {
+                            break;
+                        }; // @TodoHeaderAndStatus
                         let packet_type = header.type_();
 
                         print_packet_tag_recv(header);
@@ -2671,22 +4014,32 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                         process_acks(&mut peer.transport, header);
 
                         if packet_type == PACKET_TYPE_CLIENT_ACK {
-                            if PRINT_PROTOCOL { println!("{:05}: Finished incoming handshake and got nonce {} with {}", my_port, nonce, addr); }
-                            peer.snow_state          = peer.pending_client_ack_snow_state.take();
+                            if PRINT_PROTOCOL {
+                                println!(
+                                    "{:05}: Finished incoming handshake and got nonce {} with {}",
+                                    my_port, nonce, addr
+                                );
+                            }
+                            peer.snow_state = peer.pending_client_ack_snow_state.take();
                             peer.outgoing_handshake_state = None;
-                            peer.transport.ack_latest     = nonce;
-                            peer.transport.ack_field      = !0;
-                            peer.connection_knowledge    = ConnectionKnowledge::Known;
+                            peer.transport.ack_latest = nonce;
+                            peer.transport.ack_field = !0;
+                            peer.connection_knowledge = ConnectionKnowledge::Known;
                             break;
                         }
                     }
                 }
-                let mut incoming_state: snow::HandshakeState = snow::Builder::new(noise_params.clone())
-                    .local_private_key(&my_static_keypair.private).unwrap()
-                    .build_responder().unwrap();
+                let mut incoming_state: snow::HandshakeState =
+                    snow::Builder::new(noise_params.clone())
+                        .local_private_key(&my_static_keypair.private)
+                        .unwrap()
+                        .build_responder()
+                        .unwrap();
                 if let Ok(length) = incoming_state.read_message(raw_msg, &mut recv_buf2) {
                     let header_and_local_msg = &recv_buf2[..length]; // @Duplicate
-                    let Ok(header) = PacketHeader::read_from(&header_and_local_msg[..]) else { break; }; // @TodoHeaderAndStatus
+                    let Ok(header) = PacketHeader::read_from(&header_and_local_msg[..]) else {
+                        break;
+                    }; // @TodoHeaderAndStatus
                     let packet_type = header.type_();
 
                     print_packet_tag_recv(header);
@@ -2694,19 +4047,39 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                     process_acks(&mut peer.transport, header);
 
                     if packet_type == PACKET_TYPE_CLIENT_HELLO {
-                        let client_endpoint = SecureUdpEndpoint { public_key: incoming_state.get_remote_static().unwrap().try_into().unwrap(), ip_address: from_ip, port: from_port };
-                        if PRINT_PROTOCOL { println!("{:05}: Server received client hello from static key = {:?}", my_port, client_endpoint); }
+                        let client_endpoint = SecureUdpEndpoint {
+                            public_key: incoming_state
+                                .get_remote_static()
+                                .unwrap()
+                                .try_into()
+                                .unwrap(),
+                            ip_address: from_ip,
+                            port: from_port,
+                        };
+                        if PRINT_PROTOCOL {
+                            println!(
+                                "{:05}: Server received client hello from static key = {:?}",
+                                my_port, client_endpoint
+                            );
+                        }
                         {
                             let them: &[u8; 32] = &peer.root_public_bft_key;
-                            let me:   &[u8; 32] = &my_root_public_bft_key.into();
+                            let me: &[u8; 32] = &my_root_public_bft_key.into();
 
                             if them == me {
-                                eprintln!("\x1b[91mKEY MATCH\x1b[0m: Received a CLIENT_HELLO from a peer reporting the same key as me.");
+                                eprintln!(
+                                    "\x1b[91mKEY MATCH\x1b[0m: Received a CLIENT_HELLO from a peer reporting the same key as me."
+                                );
                                 break;
                             }
                         }
-                        if peer.outgoing_handshake_state.is_none() || contended_noise_is_initiator(&bft_state.hash_keys, &my_root_public_bft_key.into(), &peer.root_public_bft_key) {
-
+                        if peer.outgoing_handshake_state.is_none()
+                            || contended_noise_is_initiator(
+                                &bft_state.hash_keys,
+                                &my_root_public_bft_key.into(),
+                                &peer.root_public_bft_key,
+                            )
+                        {
                             // TODO: we should rate-limit new connections so adversaries can't exhaust your entropy pool by rapidly asking for new nonces
                             let start_nonce = rand::random::<u64>() >> (PACKET_TAG_BITS + 1);
 
@@ -2714,15 +4087,24 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
 
                             let mut o = 0;
                             o += start_nonce.write_to(&mut send_buf1[o..]);
-                            o += header     .write_to(&mut send_buf1[o..]);
+                            o += header.write_to(&mut send_buf1[o..]);
 
-                            let n = incoming_state.write_message(&send_buf1[..o], &mut send_buf2).unwrap();
+                            let n = incoming_state
+                                .write_message(&send_buf1[..o], &mut send_buf2)
+                                .unwrap();
 
                             // NOTE(Phillip): Let me know if there is an important reason to send the sock message when unsuccessfully entering stateless transport mode
                             if let Ok(snow_state) = incoming_state.into_stateless_transport_mode() {
                                 peer.transport.nonce = start_nonce; // @Cleanup @Lazy.
                                 print_packet_tag_send(header);
-                                send_sock_msg(&ctx_str, &mut peer.transport, &sock, peer_endpoint, &send_buf2[..n], &mut net_stats);
+                                send_sock_msg(
+                                    &ctx_str,
+                                    &mut peer.transport,
+                                    &sock,
+                                    peer_endpoint,
+                                    &send_buf2[..n],
+                                    &mut net_stats,
+                                );
                                 peer.transport.nonce += 1;
                                 peer.pending_client_ack_snow_state = Some(snow_state);
                             }
@@ -2734,12 +4116,22 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
             }
         } else {
             loop {
-                if let Some(i) = unknown_peers.iter().position(|p| p.endpoint.is_some() && p.endpoint.unwrap().ip_address == from_ip && p.endpoint.unwrap().port == from_port) {
+                if let Some(i) = unknown_peers.iter().position(|p| {
+                    p.endpoint.is_some()
+                        && p.endpoint.unwrap().ip_address == from_ip
+                        && p.endpoint.unwrap().port == from_port
+                }) {
                     let peer = &mut unknown_peers[i];
                     nonce = u64::from_le_bytes(raw_msg[..8].try_into().unwrap());
-                    if let Ok(length) = peer.snow_state.as_ref().unwrap().read_message(nonce, &raw_msg[8..], &mut recv_buf2) {
+                    if let Ok(length) = peer.snow_state.as_ref().unwrap().read_message(
+                        nonce,
+                        &raw_msg[8..],
+                        &mut recv_buf2,
+                    ) {
                         let header_and_local_msg = &recv_buf2[..length]; // @Duplicate
-                        let Ok(header) = PacketHeader::read_from(&header_and_local_msg[..]) else { break; }; // @TodoHeaderAndStatus
+                        let Ok(header) = PacketHeader::read_from(&header_and_local_msg[..]) else {
+                            break;
+                        }; // @TodoHeaderAndStatus
                         let packet_type = header.type_();
 
                         print_packet_tag_recv(header);
@@ -2748,36 +4140,59 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
 
                         if peer.pending_client_ack {
                             if packet_type == PACKET_TYPE_CLIENT_UNKNOWN_ACK {
-                                if PRINT_PROTOCOL { println!("{:05}: Finished incoming unknown handshake and got nonce {} with {}", my_port, nonce, addr); }
+                                if PRINT_PROTOCOL {
+                                    println!(
+                                        "{:05}: Finished incoming unknown handshake and got nonce {} with {}",
+                                        my_port, nonce, addr
+                                    );
+                                }
                                 peer.pending_client_ack = false;
-                                peer.transport.ack_latest   = nonce;
-                                peer.transport.ack_field    = !0;
+                                peer.transport.ack_latest = nonce;
+                                peer.transport.ack_field = !0;
                                 break;
                             }
                             break;
                         }
 
                         if nonce_is_ok(nonce, peer.transport.ack_latest, peer.transport.ack_field) {
-                            msg             = Some(&header_and_local_msg);
-                            peer_index      = i;
-                            peer_knowledge  = ConnectionKnowledge::Unknown;
+                            msg = Some(&header_and_local_msg);
+                            peer_index = i;
+                            peer_knowledge = ConnectionKnowledge::Unknown;
                         }
                         break;
                     }
                 }
-                let mut incoming_state: snow::HandshakeState = snow::Builder::new(noise_params.clone())
-                    .local_private_key(&my_static_keypair.private).unwrap()
-                    .build_responder().unwrap();
+                let mut incoming_state: snow::HandshakeState =
+                    snow::Builder::new(noise_params.clone())
+                        .local_private_key(&my_static_keypair.private)
+                        .unwrap()
+                        .build_responder()
+                        .unwrap();
                 if let Ok(length) = incoming_state.read_message(raw_msg, &mut recv_buf2) {
                     let header_and_local_msg = &recv_buf2[..length]; // @Duplicate
-                    let Ok(header) = PacketHeader::read_from(&header_and_local_msg[..]) else { break; }; // @TodoHeaderAndStatus
+                    let Ok(header) = PacketHeader::read_from(&header_and_local_msg[..]) else {
+                        break;
+                    }; // @TodoHeaderAndStatus
                     let packet_type = header.type_();
 
                     print_packet_tag_recv(header);
 
                     if packet_type == PACKET_TYPE_CLIENT_HELLO {
-                        let client_endpoint = SecureUdpEndpoint { public_key: incoming_state.get_remote_static().unwrap().try_into().unwrap(), ip_address: from_ip, port: from_port };
-                        if PRINT_PROTOCOL { println!("{:05}: Server received client hello from unknown peer with static key = {:?}", my_port, client_endpoint); }
+                        let client_endpoint = SecureUdpEndpoint {
+                            public_key: incoming_state
+                                .get_remote_static()
+                                .unwrap()
+                                .try_into()
+                                .unwrap(),
+                            ip_address: from_ip,
+                            port: from_port,
+                        };
+                        if PRINT_PROTOCOL {
+                            println!(
+                                "{:05}: Server received client hello from unknown peer with static key = {:?}",
+                                my_port, client_endpoint
+                            );
+                        }
 
                         // TODO: we should rate-limit new connections so adversaries can't exhaust your entropy pool by rapidly asking for new nonces
                         let start_nonce = rand::random::<u64>() >> (PACKET_TAG_BITS + 1);
@@ -2786,18 +4201,29 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
 
                         let mut o = 0;
                         o += start_nonce.write_to(&mut send_buf1[o..]);
-                        o += header     .write_to(&mut send_buf1[o..]);
-                        o += from_ip    .write_to(&mut send_buf1[o..]);
-                        o += from_port  .write_to(&mut send_buf1[o..]);
+                        o += header.write_to(&mut send_buf1[o..]);
+                        o += from_ip.write_to(&mut send_buf1[o..]);
+                        o += from_port.write_to(&mut send_buf1[o..]);
 
-                        let n = incoming_state.write_message(&send_buf1[..o], &mut send_buf2).unwrap();
+                        let n = incoming_state
+                            .write_message(&send_buf1[..o], &mut send_buf2)
+                            .unwrap();
 
                         // NOTE(Phillip): Let me know if there is an important reason to send the sock message when unsuccessfully entering stateless transport mode
-                        if let Ok(stateless_snow_state) = incoming_state.into_stateless_transport_mode() {
+                        if let Ok(stateless_snow_state) =
+                            incoming_state.into_stateless_transport_mode()
+                        {
                             let mut transport = PeerTransport::default();
                             transport.nonce = start_nonce;
                             print_packet_tag_send(header);
-                            send_sock_msg(&ctx_str, &mut transport, &sock, client_endpoint, &send_buf2[..n], &mut net_stats);
+                            send_sock_msg(
+                                &ctx_str,
+                                &mut transport,
+                                &sock,
+                                client_endpoint,
+                                &send_buf2[..n],
+                                &mut net_stats,
+                            );
                             transport.nonce += 1;
                             unknown_peers.push(Peer {
                                 root_public_bft_key: [0; 32],
@@ -2821,9 +4247,13 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                 break;
             }
         }
-        if msg.is_none() { continue; }
+        if msg.is_none() {
+            continue;
+        }
         let msg: &[u8] = msg.unwrap();
-        if msg.len() == 0 { continue; }
+        if msg.len() == 0 {
+            continue;
+        }
         let Ok((header, status, read_o)) = read_header_and_maybe_status(&msg[..]) else {
             continue;
         };
@@ -2839,42 +4269,76 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
                     continue;
                 }
             };
-            let hash        = hdr.hash;
-            let block_size  = hdr.block_size as usize;
-            let chunk_i     = hdr.chunk_i    as usize;
-            let chunk_size  = usize::min(POWLINK_CHUNK_DATA_SIZE, block_size - chunk_i * POWLINK_CHUNK_DATA_SIZE);
-            let packet_size = PACKET_HEADER_SIZE + PacketPowlinkChunkHeader::SERIALIZED_SIZE + chunk_size;
-            let chunks_n    = powlink_chunks_n(block_size);
+            let hash = hdr.hash;
+            let block_size = hdr.block_size as usize;
+            let chunk_i = hdr.chunk_i as usize;
+            let chunk_size = usize::min(
+                POWLINK_CHUNK_DATA_SIZE,
+                block_size - chunk_i * POWLINK_CHUNK_DATA_SIZE,
+            );
+            let packet_size =
+                PACKET_HEADER_SIZE + PacketPowlinkChunkHeader::SERIALIZED_SIZE + chunk_size;
+            let chunks_n = powlink_chunks_n(block_size);
 
             if hdr.block_size as usize > POWLINK_MAX_DATA_SIZE {
-                eprintln!("{}: PowLink: Block was too big: {} bytes (max 2,000,000)", ctx_str, hdr.block_size);
+                eprintln!(
+                    "{}: PowLink: Block was too big: {} bytes (max 2,000,000)",
+                    ctx_str, hdr.block_size
+                );
                 continue;
             }
             if chunk_i >= chunks_n {
-                eprintln!("{}: PowLink: Chunk index #{} out of bounds (maximum {} -- the block size is {})", ctx_str, chunk_i, chunks_n, block_size);
+                eprintln!(
+                    "{}: PowLink: Chunk index #{} out of bounds (maximum {} -- the block size is {})",
+                    ctx_str, chunk_i, chunks_n, block_size
+                );
                 continue;
             }
 
             if msg.len() != packet_size {
-                eprintln!("{}: PowLink: Couldn't read chunk #{}: incorrect size {} (wanted {})", ctx_str, chunk_i, msg.len(), packet_size);
+                eprintln!(
+                    "{}: PowLink: Couldn't read chunk #{}: incorrect size {} (wanted {})",
+                    ctx_str,
+                    chunk_i,
+                    msg.len(),
+                    packet_size
+                );
                 continue;
             }
 
-            if bft_state.current_powlink.is_some() && bft_state.current_powlink.as_ref().unwrap().0 == hash {
+            if bft_state.current_powlink.is_some()
+                && bft_state.current_powlink.as_ref().unwrap().0 == hash
+            {
                 let powlink = &mut bft_state.current_powlink.as_mut().unwrap().1;
                 if (powlink.chunk_i as usize) < chunk_i {
-                    eprintln!("{}: PowLink: Unfortunately dropping chunk {} for block {:?} because it is {} chunks ahead of our current edge {}", ctx_str, chunk_i, hash, (chunk_i - powlink.chunk_i as usize), powlink.chunk_i);
+                    eprintln!(
+                        "{}: PowLink: Unfortunately dropping chunk {} for block {:?} because it is {} chunks ahead of our current edge {}",
+                        ctx_str,
+                        chunk_i,
+                        hash,
+                        (chunk_i - powlink.chunk_i as usize),
+                        powlink.chunk_i
+                    );
                     continue;
                 }
                 if (powlink.chunk_i as usize) > chunk_i {
-                    eprintln!("{}: PowLink: Discarding redundant chunk {} for block {:?} because it is {} chunks behind our current edge {}", ctx_str, chunk_i, hash, (powlink.chunk_i as usize - chunk_i), powlink.chunk_i);
+                    eprintln!(
+                        "{}: PowLink: Discarding redundant chunk {} for block {:?} because it is {} chunks behind our current edge {}",
+                        ctx_str,
+                        chunk_i,
+                        hash,
+                        (powlink.chunk_i as usize - chunk_i),
+                        powlink.chunk_i
+                    );
                     continue;
                 }
 
                 // Just expand or shrink to "new" block size. PowLink is not trustless anyway, so nothing important is worth doing here to ward off adversaries.
-                if powlink.data.len() != 0 &&
-                   powlink.data.len() != block_size {
-                    eprintln!("{}: PowLink: Warning: Block size changed for hash {:?}. Shenanigans afoot.", ctx_str, hash);
+                if powlink.data.len() != 0 && powlink.data.len() != block_size {
+                    eprintln!(
+                        "{}: PowLink: Warning: Block size changed for hash {:?}. Shenanigans afoot.",
+                        ctx_str, hash
+                    );
                 }
 
                 powlink.data.resize(block_size, 0);
@@ -2884,11 +4348,14 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
 
                 debug_assert!(chunk_dst_size == chunk_src_size);
                 if chunk_dst_size != chunk_src_size {
-                    eprintln!("{}: PowLink Error: Destination size and source size differ - {} vs {}. Hash is {:?}", ctx_str, chunk_dst_size, chunk_src_size, hash);
+                    eprintln!(
+                        "{}: PowLink Error: Destination size and source size differ - {} vs {}. Hash is {:?}",
+                        ctx_str, chunk_dst_size, chunk_src_size, hash
+                    );
                     continue;
                 }
 
-                let chunk_src_data = &             msg[chunk_src_o..chunk_src_o + chunk_src_size];
+                let chunk_src_data = &msg[chunk_src_o..chunk_src_o + chunk_src_size];
                 let chunk_dst_data = &mut powlink.data[chunk_dst_o..chunk_dst_o + chunk_dst_size];
 
                 // if PRINT_POWLINK { println!("{}: PowLink: Received chunk #{} ({} bytes) of block! Hash: {:?}", ctx_str, chunk_i, chunk_dst_size, hash); }
@@ -2905,117 +4372,217 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
         if peer_knowledge == ConnectionKnowledge::Unknown {
             let peer = &mut unknown_peers[peer_index];
             peer.watch_dog = Instant::now();
-            nonce_update(nonce, &mut peer.transport.ack_latest, &mut peer.transport.ack_field);
+            nonce_update(
+                nonce,
+                &mut peer.transport.ack_latest,
+                &mut peer.transport.ack_field,
+            );
 
             process_acks(&mut peer.transport, header);
 
             if let Some(status) = status {
                 peer.latest_status_request_height = Some(status.height);
-                peer.latest_status_request_powlink = Some((status.powlink_hash, status.powlink_chunk_i));
+                peer.latest_status_request_powlink =
+                    Some((status.powlink_hash, status.powlink_chunk_i));
             }
 
             match packet_type {
-                PACKET_TYPE_ENDPOINT_EVIDENCE => match EndpointEvidence::read_from(&msg[read_o..]) {
-                    Ok(evidence) => if let Some(i) = peers.iter().position(|p| p.root_public_bft_key == evidence.root_public_bft_key) {
-                        peers[i].endpoint = Some(evidence.endpoint);
-                        if peer.endpoint == Some(evidence.endpoint) {
-                            if PRINT_PROTOCOL { println!("{:05}: Promoting unknown peer connection {:?}", my_port, peer.endpoint); }
-                            let peer = unknown_peers.remove(peer_index);
-                            peers[i].outgoing_handshake_state      = None;
-                            peers[i].pending_client_ack_snow_state = None;
-                            peers[i].snow_state                    = peer.snow_state;
-                            peers[i].watch_dog                     = Instant::now();
-                            peers[i].transport                     = peer.transport;
-                            peers[i].connection_knowledge          = ConnectionKnowledge::Known;
+                PACKET_TYPE_ENDPOINT_EVIDENCE => {
+                    match EndpointEvidence::read_from(&msg[read_o..]) {
+                        Ok(evidence) => {
+                            if let Some(i) = peers
+                                .iter()
+                                .position(|p| p.root_public_bft_key == evidence.root_public_bft_key)
+                            {
+                                peers[i].endpoint = Some(evidence.endpoint);
+                                if peer.endpoint == Some(evidence.endpoint) {
+                                    if PRINT_PROTOCOL {
+                                        println!(
+                                            "{:05}: Promoting unknown peer connection {:?}",
+                                            my_port, peer.endpoint
+                                        );
+                                    }
+                                    let peer = unknown_peers.remove(peer_index);
+                                    peers[i].outgoing_handshake_state = None;
+                                    peers[i].pending_client_ack_snow_state = None;
+                                    peers[i].snow_state = peer.snow_state;
+                                    peers[i].watch_dog = Instant::now();
+                                    peers[i].transport = peer.transport;
+                                    peers[i].connection_knowledge = ConnectionKnowledge::Known;
+                                }
+                                roster_endpoint_evidence.retain(|e| {
+                                    e.root_public_bft_key != evidence.root_public_bft_key
+                                });
+                                roster_endpoint_evidence.push(evidence);
+                            }
                         }
-                        roster_endpoint_evidence.retain(|e| e.root_public_bft_key != evidence.root_public_bft_key);
-                        roster_endpoint_evidence.push(evidence);
+                        Err(err) => {
+                            eprintln!("{:05}: couldn't read endpoint evidence: {}", my_port, err)
+                        }
                     }
-                    Err(err) => eprintln!("{:05}: couldn't read endpoint evidence: {}", my_port, err),
-                },
-                PACKET_TYPE_ROSTER_CMD => if msg[read_o..].len() > 0 {
-                    if let Ok(cmd) = String::from_utf8(msg[read_o..].to_vec()) { bft_state.roster_cmd = Some(cmd); }
-                },
+                }
+                PACKET_TYPE_ROSTER_CMD => {
+                    if msg[read_o..].len() > 0 {
+                        if let Ok(cmd) = String::from_utf8(msg[read_o..].to_vec()) {
+                            bft_state.roster_cmd = Some(cmd);
+                        }
+                    }
+                }
                 PACKET_TYPE_EMPTY => (),
                 _ => (), //println!("{:05}:  From unknown peer!   field={:016X} packet_type=0x{:X} Got '{:?}' from {}", my_port, peer.transport.ack_field, packet_type, msg, addr),
             }
             continue;
-        }
-
-        else {
+        } else {
             let peer = &mut peers[peer_index];
             peer.watch_dog = Instant::now();
-            nonce_update(nonce, &mut peer.transport.ack_latest, &mut peer.transport.ack_field);
+            nonce_update(
+                nonce,
+                &mut peer.transport.ack_latest,
+                &mut peer.transport.ack_field,
+            );
 
             process_acks(&mut peer.transport, header);
 
             // TODO: other TAGs should also cause this transition
             if let Some(status) = status {
                 if peer.connection_knowledge == ConnectionKnowledge::Unknown {
-                    if PRINT_PROTOCOL { println!("{:05}: Got a status, this means that the other side does not consider me unknown anymore!", my_port); }
+                    if PRINT_PROTOCOL {
+                        println!(
+                            "{:05}: Got a status, this means that the other side does not consider me unknown anymore!",
+                            my_port
+                        );
+                    }
                     peer.connection_knowledge = ConnectionKnowledge::Known;
                 }
 
                 peer.latest_status_request_height = Some(status.height);
-                peer.latest_status_request_powlink = Some((status.powlink_hash, status.powlink_chunk_i));
+                peer.latest_status_request_powlink =
+                    Some((status.powlink_hash, status.powlink_chunk_i));
                 peer.latest_status = Some(status);
             }
 
             const_assert!(PACKET_TYPE_PREVOTE_SIGNATURES + 1 == PACKET_TYPE_PRECOMMIT_SIGNATURES);
             match packet_type {
-                PACKET_TYPE_ENDPOINT_EVIDENCE => match EndpointEvidence::read_from(&msg[read_o..]) {
-                    Ok(evidence) => if let Some(i) = peers.iter().position(|p| p.root_public_bft_key == evidence.root_public_bft_key) {
-                        peers[i].endpoint = Some(evidence.endpoint);
-                        roster_endpoint_evidence.retain(|e| e.root_public_bft_key != evidence.root_public_bft_key);
-                        roster_endpoint_evidence.push(evidence);
+                PACKET_TYPE_ENDPOINT_EVIDENCE => {
+                    match EndpointEvidence::read_from(&msg[read_o..]) {
+                        Ok(evidence) => {
+                            if let Some(i) = peers
+                                .iter()
+                                .position(|p| p.root_public_bft_key == evidence.root_public_bft_key)
+                            {
+                                peers[i].endpoint = Some(evidence.endpoint);
+                                roster_endpoint_evidence.retain(|e| {
+                                    e.root_public_bft_key != evidence.root_public_bft_key
+                                });
+                                roster_endpoint_evidence.push(evidence);
+                            }
+                        }
+                        Err(err) => {
+                            eprintln!("{:05}: couldn't read endpoint evidence: {}", my_port, err)
+                        }
                     }
-                    Err(err) => eprintln!("{:05}: couldn't read endpoint evidence: {}", my_port, err),
                 }
 
                 PACKET_TYPE_PROPOSAL_CHUNK => {
-                    let hdr = match PacketProposalChunkHeader::read_from(&msg[read_o..]) { Ok(v)=>v, Err(err)=>{
-                        eprintln!("{:05}: couldn't read proposal header: {}", my_port, err);
-                        continue;
-                    }};
+                    let hdr = match PacketProposalChunkHeader::read_from(&msg[read_o..]) {
+                        Ok(v) => v,
+                        Err(err) => {
+                            eprintln!("{:05}: couldn't read proposal header: {}", my_port, err);
+                            continue;
+                        }
+                    };
                     let proposal_size = hdr.proposal_size as usize;
-                    let chunk_i       = hdr.chunk_i       as usize;
-                    let chunk_size = usize::min(PROPOSAL_CHUNK_DATA_SIZE, proposal_size - chunk_i * PROPOSAL_CHUNK_DATA_SIZE);
+                    let chunk_i = hdr.chunk_i as usize;
+                    let chunk_size = usize::min(
+                        PROPOSAL_CHUNK_DATA_SIZE,
+                        proposal_size - chunk_i * PROPOSAL_CHUNK_DATA_SIZE,
+                    );
                     let packet_size = chunk_size + PROPOSAL_PACKET_EXTRA;
 
                     // NOTE: assume for the moment that this is the valid height, we'll check in the subsequent call
                     // ALT:  cache proposer for *current* round
                     if msg.len() == packet_size {
-                        if let (Some(roster_i), _) = TMState::proposer_from_height_round(&bft_state.hash_keys, &roster, hdr.height, hdr.round) {
-                            let sig_o = PACKET_HEADER_SIZE + PacketProposalChunkHeader::SERIALIZED_SIZE + chunk_size;
-                            bft_state.check_and_incorporate_msg(hdr.height, hdr.round, hdr.chunk_i as usize, hdr.proposal_id, hdr.valid_round,
-                                &roster, roster_i, packet_type, &msg[read_o..sig_o], TMSig(msg[sig_o..sig_o+64].try_into().unwrap()));
+                        if let (Some(roster_i), _) = TMState::proposer_from_height_round(
+                            &bft_state.hash_keys,
+                            &roster,
+                            hdr.height,
+                            hdr.round,
+                        ) {
+                            let sig_o = PACKET_HEADER_SIZE
+                                + PacketProposalChunkHeader::SERIALIZED_SIZE
+                                + chunk_size;
+                            bft_state.check_and_incorporate_msg(
+                                hdr.height,
+                                hdr.round,
+                                hdr.chunk_i as usize,
+                                hdr.proposal_id,
+                                hdr.valid_round,
+                                &roster,
+                                roster_i,
+                                packet_type,
+                                &msg[read_o..sig_o],
+                                TMSig(msg[sig_o..sig_o + 64].try_into().unwrap()),
+                            );
                         }
                     } else {
-                        eprintln!("{:05}: couldn't read proposal chunk: incorrect size {}", my_port, msg.len());
+                        eprintln!(
+                            "{:05}: couldn't read proposal chunk: incorrect size {}",
+                            my_port,
+                            msg.len()
+                        );
                     }
                 }
 
-                PACKET_TYPE_PREVOTE_SIGNATURES | PACKET_TYPE_PRECOMMIT_SIGNATURES => match PacketVotes::read_from(&msg[read_o..]) {
-                    Ok(packet) => {
-                        let is_precommit = packet_type - PACKET_TYPE_PREVOTE_SIGNATURES;
-                        let value_ids    = [ ValueId::NIL, packet.value_id ];
+                PACKET_TYPE_PREVOTE_SIGNATURES | PACKET_TYPE_PRECOMMIT_SIGNATURES => {
+                    match PacketVotes::read_from(&msg[read_o..]) {
+                        Ok(packet) => {
+                            let is_precommit = packet_type - PACKET_TYPE_PREVOTE_SIGNATURES;
+                            let value_ids = [ValueId::NIL, packet.value_id];
 
-                        for vote_i in 0..(packet.no_votes_n + packet.yes_votes_n) as usize {
-                            // Note(Sam): We can change the format of votes to be cool and branchless after the workshop.
-                            if let Some(roster_member) = roster.get(packet.votes[vote_i].roster_i as usize) {
-                                let sign_datas   = make_vote_sign_datas(roster_member.pub_key.0, is_precommit != 0, packet.height, packet.round, packet.value_id);
-                                let no_yes_i = (vote_i >= packet.no_votes_n as usize) as usize;
-                                bft_state.check_and_incorporate_msg(packet.height, packet.round, 0, value_ids[no_yes_i], -2,
-                                    &roster, packet.votes[vote_i].roster_i as usize, packet_type, &sign_datas[no_yes_i], TMSig(packet.votes[vote_i].sig.0));
+                            for vote_i in 0..(packet.no_votes_n + packet.yes_votes_n) as usize {
+                                // Note(Sam): We can change the format of votes to be cool and branchless after the workshop.
+                                if let Some(roster_member) =
+                                    roster.get(packet.votes[vote_i].roster_i as usize)
+                                {
+                                    let sign_datas = make_vote_sign_datas(
+                                        roster_member.pub_key.0,
+                                        is_precommit != 0,
+                                        packet.height,
+                                        packet.round,
+                                        packet.value_id,
+                                    );
+                                    let no_yes_i = (vote_i >= packet.no_votes_n as usize) as usize;
+                                    bft_state.check_and_incorporate_msg(
+                                        packet.height,
+                                        packet.round,
+                                        0,
+                                        value_ids[no_yes_i],
+                                        -2,
+                                        &roster,
+                                        packet.votes[vote_i].roster_i as usize,
+                                        packet_type,
+                                        &sign_datas[no_yes_i],
+                                        TMSig(packet.votes[vote_i].sig.0),
+                                    );
+                                }
                             }
                         }
+                        Err(err) => eprintln!(
+                            "{:05}: couldn't read {}: {}",
+                            my_port,
+                            packet_name_from_tag(packet_type),
+                            err
+                        ),
                     }
-                    Err(err) => eprintln!("{:05}: couldn't read {}: {}", my_port, packet_name_from_tag(packet_type), err),
                 }
 
-                PACKET_TYPE_ROSTER_CMD => if msg[read_o..].len() > 0 {
-                    if let Ok(cmd) = String::from_utf8(msg[read_o..].to_vec()) { bft_state.roster_cmd = Some(cmd); }
-                },
+                PACKET_TYPE_ROSTER_CMD => {
+                    if msg[read_o..].len() > 0 {
+                        if let Ok(cmd) = String::from_utf8(msg[read_o..].to_vec()) {
+                            bft_state.roster_cmd = Some(cmd);
+                        }
+                    }
+                }
                 PACKET_TYPE_EMPTY => {}
                 _ => {} // println!("{}:  From known peer!   field={:016X} Got '{:?}' from {}", my_port, peer.transport.ack_field, msg, addr);
             }
@@ -3025,60 +4592,77 @@ fn goofy_addr_string_to_stuff(addr: &str) -> (StaticDHKeyPair, SecureUdpEndpoint
 }
 
 // network
-const PACKET_TYPE_EMPTY:                u8 =  0;
-const PACKET_TYPE_CLIENT_HELLO:         u8 =  1;
-const PACKET_TYPE_CLIENT_UNKNOWN_ACK:   u8 =  2;
-const PACKET_TYPE_CLIENT_ACK:           u8 =  3;
-const PACKET_TYPE_SERVER_UNKNOWN_HELLO: u8 =  4;
-const PACKET_TYPE_SERVER_HELLO:         u8 =  5;
-const PACKET_TYPE_ENDPOINT_EVIDENCE:    u8 =  6;
+const PACKET_TYPE_EMPTY: u8 = 0;
+const PACKET_TYPE_CLIENT_HELLO: u8 = 1;
+const PACKET_TYPE_CLIENT_UNKNOWN_ACK: u8 = 2;
+const PACKET_TYPE_CLIENT_ACK: u8 = 3;
+const PACKET_TYPE_SERVER_UNKNOWN_HELLO: u8 = 4;
+const PACKET_TYPE_SERVER_HELLO: u8 = 5;
+const PACKET_TYPE_ENDPOINT_EVIDENCE: u8 = 6;
 // consensus
-const PACKET_TYPE_PROPOSAL_CHUNK:       u8 =  7;
-const PACKET_TYPE_PREVOTE_SIGNATURES:   u8 =  8;
-const PACKET_TYPE_PRECOMMIT_SIGNATURES: u8 =  9;
+const PACKET_TYPE_PROPOSAL_CHUNK: u8 = 7;
+const PACKET_TYPE_PREVOTE_SIGNATURES: u8 = 8;
+const PACKET_TYPE_PRECOMMIT_SIGNATURES: u8 = 9;
 // misc
-const PACKET_TYPE_ROSTER_CMD:           u8 = 10;
-const PACKET_TYPE_POWLINK_CHUNK:        u8 = 11;
-const PACKET_TYPE_COUNT:                u8 = 12;
+const PACKET_TYPE_ROSTER_CMD: u8 = 10;
+const PACKET_TYPE_POWLINK_CHUNK: u8 = 11;
+const PACKET_TYPE_COUNT: u8 = 12;
 
+const PACKET_TYPE_BITS: u8 = 7;
+const PACKET_TYPE_MASK: u8 = (1 << PACKET_TYPE_BITS) - 1;
 
-const PACKET_TYPE_BITS:                 u8 =  7;
-const PACKET_TYPE_MASK:                 u8 = (1 << PACKET_TYPE_BITS) - 1;
+const PACKET_TAG_STATUS_SHIFT: u8 = PACKET_TYPE_BITS;
+const PACKET_TAG_STATUS_FLAG: u8 = 1 << PACKET_TAG_STATUS_SHIFT;
 
-const PACKET_TAG_STATUS_SHIFT:          u8 = PACKET_TYPE_BITS;
-const PACKET_TAG_STATUS_FLAG:           u8 = 1 << PACKET_TAG_STATUS_SHIFT;
-
-const PACKET_TAG_BITS:                  u8 = 8;
-const PACKET_TAG_MASK:                  u8 = ((1 << PACKET_TAG_BITS as u64) - 1) as u8;
-
+const PACKET_TAG_BITS: u8 = 8;
+const PACKET_TAG_MASK: u8 = ((1 << PACKET_TAG_BITS as u64) - 1) as u8;
 
 const PACKET_TYPE_NAMES: [[&str; 2]; PACKET_TYPE_COUNT as usize] = {
     let mut names = [["<MISSING>"; 2]; PACKET_TYPE_COUNT as usize];
-    names[PACKET_TYPE_EMPTY                as usize] = ["<EMPTY>",                  "STATUS"];
-    names[PACKET_TYPE_CLIENT_HELLO         as usize] = ["CLIENT_HELLO",             "STATUS+CLIENT_HELLO"];
-    names[PACKET_TYPE_CLIENT_UNKNOWN_ACK   as usize] = ["CLIENT_UNKNOWN_ACK",       "STATUS+CLIENT_UNKNOWN_ACK"];
-    names[PACKET_TYPE_CLIENT_ACK           as usize] = ["CLIENT_ACK",               "STATUS+CLIENT_ACK"];
-    names[PACKET_TYPE_SERVER_UNKNOWN_HELLO as usize] = ["SERVER_UNKNOWN_HELLO",     "STATUS+SERVER_UNKNOWN_HELLO"];
-    names[PACKET_TYPE_SERVER_HELLO         as usize] = ["SERVER_HELLO",             "STATUS+SERVER_HELLO"];
-    names[PACKET_TYPE_ENDPOINT_EVIDENCE    as usize] = ["ENDPOINT_EVIDENCE",        "STATUS+ENDPOINT_EVIDENCE"];
-    names[PACKET_TYPE_PROPOSAL_CHUNK       as usize] = ["PROPOSAL_CHUNK",           "STATUS+PROPOSAL_CHUNK"];
-    names[PACKET_TYPE_PREVOTE_SIGNATURES   as usize] = ["PREVOTE_SIGNATURES",       "STATUS+PREVOTE_SIGNATURES"];
-    names[PACKET_TYPE_PRECOMMIT_SIGNATURES as usize] = ["PRECOMMIT_SIGNATURES",     "STATUS+PRECOMMIT_SIGNATURES"];
-    names[PACKET_TYPE_ROSTER_CMD           as usize] = ["PREVOTE_SIGNATURES",       "STATUS+PREVOTE_SIGNATURES"];
-    names[PACKET_TYPE_POWLINK_CHUNK        as usize] = ["PACKET_TYPE_POWLINK_CHUNK","STATUS+PACKET_TYPE_POWLINK_CHUNK"];
+    names[PACKET_TYPE_EMPTY as usize] = ["<EMPTY>", "STATUS"];
+    names[PACKET_TYPE_CLIENT_HELLO as usize] = ["CLIENT_HELLO", "STATUS+CLIENT_HELLO"];
+    names[PACKET_TYPE_CLIENT_UNKNOWN_ACK as usize] =
+        ["CLIENT_UNKNOWN_ACK", "STATUS+CLIENT_UNKNOWN_ACK"];
+    names[PACKET_TYPE_CLIENT_ACK as usize] = ["CLIENT_ACK", "STATUS+CLIENT_ACK"];
+    names[PACKET_TYPE_SERVER_UNKNOWN_HELLO as usize] =
+        ["SERVER_UNKNOWN_HELLO", "STATUS+SERVER_UNKNOWN_HELLO"];
+    names[PACKET_TYPE_SERVER_HELLO as usize] = ["SERVER_HELLO", "STATUS+SERVER_HELLO"];
+    names[PACKET_TYPE_ENDPOINT_EVIDENCE as usize] =
+        ["ENDPOINT_EVIDENCE", "STATUS+ENDPOINT_EVIDENCE"];
+    names[PACKET_TYPE_PROPOSAL_CHUNK as usize] = ["PROPOSAL_CHUNK", "STATUS+PROPOSAL_CHUNK"];
+    names[PACKET_TYPE_PREVOTE_SIGNATURES as usize] =
+        ["PREVOTE_SIGNATURES", "STATUS+PREVOTE_SIGNATURES"];
+    names[PACKET_TYPE_PRECOMMIT_SIGNATURES as usize] =
+        ["PRECOMMIT_SIGNATURES", "STATUS+PRECOMMIT_SIGNATURES"];
+    names[PACKET_TYPE_ROSTER_CMD as usize] = ["PREVOTE_SIGNATURES", "STATUS+PREVOTE_SIGNATURES"];
+    names[PACKET_TYPE_POWLINK_CHUNK as usize] = [
+        "PACKET_TYPE_POWLINK_CHUNK",
+        "STATUS+PACKET_TYPE_POWLINK_CHUNK",
+    ];
     const_assert!(PACKET_TYPE_COUNT == 12); // keep names array updated when adding other tags
     names
 };
 fn packet_name_from_tag(packet_tag: u8) -> &'static str {
-    PACKET_TYPE_NAMES.get(packet_tag as usize).unwrap_or(&["<UNKNOWN>", "STATUS+<UNKNOWN>"])[(packet_tag >> PACKET_TAG_STATUS_SHIFT & 1) as usize]
+    PACKET_TYPE_NAMES
+        .get(packet_tag as usize)
+        .unwrap_or(&["<UNKNOWN>", "STATUS+<UNKNOWN>"])
+        [(packet_tag >> PACKET_TAG_STATUS_SHIFT & 1) as usize]
 }
 fn print_packet_tag_send(header: PacketHeader) {
-    if header.type_() >= PACKET_TYPE_PROPOSAL_CHUNK { return; } // @Debug
-    if PRINT_PROTOCOL_TAG { println!("PACKET_{} ->", packet_name_from_tag(header.tag())); }
+    if header.type_() >= PACKET_TYPE_PROPOSAL_CHUNK {
+        return;
+    } // @Debug
+    if PRINT_PROTOCOL_TAG {
+        println!("PACKET_{} ->", packet_name_from_tag(header.tag()));
+    }
 }
 fn print_packet_tag_recv(header: PacketHeader) {
-    if header.type_() >= PACKET_TYPE_PROPOSAL_CHUNK { return; } // @Debug
-    if PRINT_PROTOCOL_TAG { println!("<- PACKET_{}", packet_name_from_tag(header.tag())); }
+    if header.type_() >= PACKET_TYPE_PROPOSAL_CHUNK {
+        return;
+    } // @Debug
+    if PRINT_PROTOCOL_TAG {
+        println!("<- PACKET_{}", packet_name_from_tag(header.tag()));
+    }
 }
 
 // NOTE(azmr): could add packet sizes so we can check all sizes in 1 location
@@ -3086,26 +4670,28 @@ fn print_packet_tag_recv(header: PacketHeader) {
 // ALT: if we limit to u16 chunk indexes & have ~1KB chunk data per packet, we could have block sizes up to ~65MB
 // N.B. with ranges like this, we either want to be half-exclusive & not allow type::MAX values, or use a special value for empty (e.g. hi < lo)
 type ProposalRng = [u32; 2]; // [lo, hi)
-type VoteRng     = [u16; 2];
+type VoteRng = [u16; 2];
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BlockHash(pub [u8; 32]);
-impl BlockHash { const NIL: Self = Self([0; 32]); }
+impl BlockHash {
+    const NIL: Self = Self([0; 32]);
+}
 const STATUS_PROPOSAL_RNGS_N: usize = 1;
 const STATUS_VOTE_RNGS_N: usize = 1; // ALT: split prevote/precommit numbers
 #[derive(Clone, Debug)]
 struct PacketStatus {
     height: u64,
-    round:  u32, // as context for following request ranges
+    round: u32, // as context for following request ranges
     need_proposal_chunk_rngs: [ProposalRng; STATUS_PROPOSAL_RNGS_N],
     need_vote_rngs: [[VoteRng; STATUS_VOTE_RNGS_N]; 2], // 1 for prevote, 1 for precommit
-    powlink_hash: BlockHash, // block needed
+    powlink_hash: BlockHash,                            // block needed
     powlink_chunk_i: u16, // my next needed index into the stream of chunks of the block
 }
 impl PacketStatus {
-    pub fn write_to(&self, buf: &mut[u8]) -> usize {
+    pub fn write_to(&self, buf: &mut [u8]) -> usize {
         let mut o = 0;
         o += self.height.write_to(&mut buf[o..]);
-        o += self.round .write_to(&mut buf[o..]);
+        o += self.round.write_to(&mut buf[o..]);
         for chunk_rng in &self.need_proposal_chunk_rngs {
             o += chunk_rng[0].write_to(&mut buf[o..]);
             o += chunk_rng[1].write_to(&mut buf[o..]);
@@ -3123,9 +4709,10 @@ impl PacketStatus {
 
     pub fn read_from<R: Read>(mut r: R) -> std::io::Result<Self> {
         let mut packet = Self {
-            height: 0, round: 0,
-            need_proposal_chunk_rngs: [[0;2]; STATUS_PROPOSAL_RNGS_N],
-            need_vote_rngs: [[[0;2]; STATUS_VOTE_RNGS_N]; 2],
+            height: 0,
+            round: 0,
+            need_proposal_chunk_rngs: [[0; 2]; STATUS_PROPOSAL_RNGS_N],
+            need_vote_rngs: [[[0; 2]; STATUS_VOTE_RNGS_N]; 2],
             powlink_hash: BlockHash::NIL,
             powlink_chunk_i: 0,
         };
@@ -3155,7 +4742,7 @@ struct PacketHeader {
 }
 impl PacketHeader {
     const fn assert_valid_tag<const TAG: u8>() {
-        assert!((TAG & ! PACKET_TYPE_MASK) == 0);
+        assert!((TAG & !PACKET_TYPE_MASK) == 0);
     }
 
     pub fn new<const TAG: u8>(ack_latest: u64, ack_field: u64) -> PacketHeader {
@@ -3169,21 +4756,29 @@ impl PacketHeader {
         }
     }
 
-    pub fn has_status(&self) -> bool { self.tag_and_ack as u8  & PACKET_TAG_STATUS_FLAG != 0 }
-    pub fn type_     (&self) -> u8   { self.tag_and_ack as u8  & PACKET_TYPE_MASK            }
-    pub fn tag       (&self) -> u8   { self.tag_and_ack as u8  & PACKET_TAG_MASK             }
-    pub fn ack       (&self) -> u64  { self.tag_and_ack       >> PACKET_TAG_BITS }
+    pub fn has_status(&self) -> bool {
+        self.tag_and_ack as u8 & PACKET_TAG_STATUS_FLAG != 0
+    }
+    pub fn type_(&self) -> u8 {
+        self.tag_and_ack as u8 & PACKET_TYPE_MASK
+    }
+    pub fn tag(&self) -> u8 {
+        self.tag_and_ack as u8 & PACKET_TAG_MASK
+    }
+    pub fn ack(&self) -> u64 {
+        self.tag_and_ack >> PACKET_TAG_BITS
+    }
 
     pub fn write_to(&self, buf: &mut [u8]) -> usize {
         let mut o = 0;
         o += self.tag_and_ack.write_to(&mut buf[o..]);
-        o += self.ack_field  .write_to(&mut buf[o..]);
+        o += self.ack_field.write_to(&mut buf[o..]);
         o
     }
 
     pub fn read_from<R: Read>(mut r: R) -> std::io::Result<Self> {
         let tag_and_ack = r.read_u64::<LittleEndian>()?;
-        let ack_field   = r.read_u64::<LittleEndian>()?;
+        let ack_field = r.read_u64::<LittleEndian>()?;
         Ok(Self {
             tag_and_ack,
             ack_field,
@@ -3192,8 +4787,16 @@ impl PacketHeader {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-struct PubKeySig { roster_i: u16, sig: TMSig, }
-impl PubKeySig { const NIL: Self = Self{ roster_i: u16::MAX, sig: TMSig::NIL }; }
+struct PubKeySig {
+    roster_i: u16,
+    sig: TMSig,
+}
+impl PubKeySig {
+    const NIL: Self = Self {
+        roster_i: u16::MAX,
+        sig: TMSig::NIL,
+    };
+}
 
 // ALT: common consensus packet header: { packet header, height, round, value_id }
 
@@ -3203,45 +4806,48 @@ impl PubKeySig { const NIL: Self = Self{ roster_i: u16::MAX, sig: TMSig::NIL }; 
 #[derive(Debug)]
 struct PacketVotes {
     // header
-    no_votes_n:  u8,
+    no_votes_n: u8,
     yes_votes_n: u8,
     // pad_:     u16, // TODO: useful?
-    round:      u32,
-    height:     u64,
-    value_id:   ValueId,
+    round: u32,
+    height: u64,
+    value_id: ValueId,
     // TODO: use u16 roster_idxs instead of pub_keys
-    votes:    [PubKeySig; 18],
+    votes: [PubKeySig; 18],
 }
 const_assert!(size_of::<PacketVotes>() == 1240); // TODO(azmr): exactly how much space is left
-                                                 // after noise/nonce/ECC/...?
-                                                 // TODO(phil): figure out the padding here
+// after noise/nonce/ECC/...?
+// TODO(phil): figure out the padding here
 
 impl PacketVotes {
     fn write_to(&self, buf: &mut [u8]) -> usize {
         let mut o = 0;
-        o += self.no_votes_n .write_to(&mut buf[o..]);
+        o += self.no_votes_n.write_to(&mut buf[o..]);
         o += self.yes_votes_n.write_to(&mut buf[o..]);
-        o += self.round      .write_to(&mut buf[o..]);
-        o += self.height     .write_to(&mut buf[o..]);
-        o += self.value_id.0 .write_to(&mut buf[o..]);
+        o += self.round.write_to(&mut buf[o..]);
+        o += self.height.write_to(&mut buf[o..]);
+        o += self.value_id.0.write_to(&mut buf[o..]);
         // NOTE(azmr): slight saving of bytes-on-wire if unused? i.e. initial few times each
         for i in 0..(self.no_votes_n + self.yes_votes_n) as usize {
             o += &self.votes[i].roster_i.write_to(&mut buf[o..]);
-            o += &self.votes[i].sig   .0.write_to(&mut buf[o..]);
+            o += &self.votes[i].sig.0.write_to(&mut buf[o..]);
         }
         o
     }
 
     pub fn read_from<R: Read>(mut r: R) -> std::io::Result<Self> {
         let mut packet = PacketVotes {
-            no_votes_n: 0, yes_votes_n: 0, round: 0, height: 0,
+            no_votes_n: 0,
+            yes_votes_n: 0,
+            round: 0,
+            height: 0,
             value_id: ValueId::NIL,
             votes: [PubKeySig::NIL; 18],
         };
-        packet.no_votes_n  = r.read_u8()?;
+        packet.no_votes_n = r.read_u8()?;
         packet.yes_votes_n = r.read_u8()?;
-        packet.round       = r.read_u32::<LittleEndian>()?;
-        packet.height      = r.read_u64::<LittleEndian>()?;
+        packet.round = r.read_u32::<LittleEndian>()?;
+        packet.height = r.read_u64::<LittleEndian>()?;
         r.read_exact(&mut packet.value_id.0)?;
         for i in 0..(packet.no_votes_n + packet.yes_votes_n) as usize {
             packet.votes[i].roster_i = r.read_u16::<LittleEndian>()?;
@@ -3251,7 +4857,7 @@ impl PacketVotes {
     }
 }
 
-const PROPOSAL_PACKET_EXTRA:    usize = (PACKET_HEADER_SIZE + 56 + 64);
+const PROPOSAL_PACKET_EXTRA: usize = (PACKET_HEADER_SIZE + 56 + 64);
 const PROPOSAL_CHUNK_DATA_SIZE: usize = PATH_MTU - PROPOSAL_PACKET_EXTRA;
 
 // NOTE(azmr): this is:
@@ -3260,28 +4866,32 @@ const PROPOSAL_CHUNK_DATA_SIZE: usize = PATH_MTU - PROPOSAL_PACKET_EXTRA;
 #[derive(Debug)]
 struct PacketProposalChunkHeader {
     // header
-    chunk_i:       u32,
+    chunk_i: u32,
     proposal_size: u32,
-    round:         u32,
-    valid_round:   i64, // serialized as u32 with 0xff.ff for -1
-    height:        u64,
-    proposal_id:   ValueId, // for the total proposal, not just this chunk
-    // data:        [u8; 1087], // 1200-113
-    // proposer_signature: TMSig,
+    round: u32,
+    valid_round: i64, // serialized as u32 with 0xff.ff for -1
+    height: u64,
+    proposal_id: ValueId, // for the total proposal, not just this chunk
+                          // data:        [u8; 1087], // 1200-113
+                          // proposer_signature: TMSig,
 }
 impl PacketProposalChunkHeader {
     const SERIALIZED_SIZE: usize = 4 * 4 + 8 + 32; // 56
 
     fn write_to(&self, buf: &mut [u8]) -> usize {
-        let valid_round: u32 = if self.valid_round >= 0 { self.valid_round.try_into().unwrap() } else { u32::MAX };
+        let valid_round: u32 = if self.valid_round >= 0 {
+            self.valid_round.try_into().unwrap()
+        } else {
+            u32::MAX
+        };
 
         let mut o = 0;
-        o        += self.chunk_i      .write_to(&mut buf[o..]);
-        o        += self.proposal_size.write_to(&mut buf[o..]);
-        o        += self.round        .write_to(&mut buf[o..]);
-        o        += valid_round       .write_to(&mut buf[o..]);
-        o        += self.height       .write_to(&mut buf[o..]);
-        o        += self.proposal_id.0.write_to(&mut buf[o..]);
+        o += self.chunk_i.write_to(&mut buf[o..]);
+        o += self.proposal_size.write_to(&mut buf[o..]);
+        o += self.round.write_to(&mut buf[o..]);
+        o += valid_round.write_to(&mut buf[o..]);
+        o += self.height.write_to(&mut buf[o..]);
+        o += self.proposal_id.0.write_to(&mut buf[o..]);
         // self.data                .write_to(&mut buf[48..]);
         // self.proposer_signature.0.write_to(&mut buf[1135..]);
         o
@@ -3289,24 +4899,33 @@ impl PacketProposalChunkHeader {
 
     pub fn read_from<R: Read>(mut r: R) -> std::io::Result<Self> {
         let mut packet = PacketProposalChunkHeader {
-            chunk_i: 0, proposal_size: 0, round: 0, height: 0, valid_round: 0, proposal_id: ValueId::NIL
+            chunk_i: 0,
+            proposal_size: 0,
+            round: 0,
+            height: 0,
+            valid_round: 0,
+            proposal_id: ValueId::NIL,
         };
-        packet.chunk_i       = r.read_u32::<LittleEndian>()?;
+        packet.chunk_i = r.read_u32::<LittleEndian>()?;
         packet.proposal_size = r.read_u32::<LittleEndian>()?;
-        packet.round         = r.read_u32::<LittleEndian>()?;
-        let valid_round      = r.read_u32::<LittleEndian>()?;
-        packet.height        = r.read_u64::<LittleEndian>()?;
+        packet.round = r.read_u32::<LittleEndian>()?;
+        let valid_round = r.read_u32::<LittleEndian>()?;
+        packet.height = r.read_u64::<LittleEndian>()?;
         r.read_exact(&mut packet.proposal_id.0)?;
 
-        packet.valid_round = if valid_round != u32::MAX { valid_round.into() } else { -1 };
+        packet.valid_round = if valid_round != u32::MAX {
+            valid_round.into()
+        } else {
+            -1
+        };
         Ok(packet)
     }
 }
 
 use std::collections::HashMap;
 
-const POWLINK_MAX_DATA_SIZE:   usize = 2_000_000;
-const POWLINK_CHUNK_DATA_SIZE: usize =     1_000;
+const POWLINK_MAX_DATA_SIZE: usize = 2_000_000;
+const POWLINK_CHUNK_DATA_SIZE: usize = 1_000;
 
 // @Todo: This is not secure to adversarial sync-servers who give you false PoW block data. We don't isolate streams to individual peers yet.
 //        However, as this is meant as just an optimization, we can safely fallback to Zebra sync.
@@ -3327,16 +4946,16 @@ fn powlink_chunk_o_size(len: usize, chunk_i: usize) -> (usize, usize) {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PacketPowlinkChunkHeader {
-    pub hash:       BlockHash,
+    pub hash: BlockHash,
     pub block_size: u32,
-    pub chunk_i:    u16,
+    pub chunk_i: u16,
 }
 impl Default for PacketPowlinkChunkHeader {
     fn default() -> Self {
         Self {
-            hash:       BlockHash::NIL,
+            hash: BlockHash::NIL,
             block_size: 0,
-            chunk_i:    0,
+            chunk_i: 0,
         }
     }
 }
@@ -3345,9 +4964,9 @@ impl PacketPowlinkChunkHeader {
 
     fn write_to(&self, buf: &mut [u8]) -> usize {
         let mut o = 0;
-        o += self.hash    .0.write_to(&mut buf[o..]);
+        o += self.hash.0.write_to(&mut buf[o..]);
         o += self.block_size.write_to(&mut buf[o..]);
-        o += self.chunk_i   .write_to(&mut buf[o..]);
+        o += self.chunk_i.write_to(&mut buf[o..]);
         o
     }
 
@@ -3355,7 +4974,7 @@ impl PacketPowlinkChunkHeader {
         let mut packet = PacketPowlinkChunkHeader::default();
         r.read_exact(&mut packet.hash.0)?;
         packet.block_size = r.read_u32::<LittleEndian>()?;
-        packet.chunk_i    = r.read_u16::<LittleEndian>()?;
+        packet.chunk_i = r.read_u16::<LittleEndian>()?;
 
         Ok(packet)
     }
@@ -3449,7 +5068,9 @@ pub struct SnowRngResolver {
 
 impl SnowRngResolver {
     pub fn seed_from_u64(seed: u64) -> SnowRngResolver {
-        SnowRngResolver { rng: RustIsBadRngWrapper(ChaCha20Rng::seed_from_u64(seed)) }
+        SnowRngResolver {
+            rng: RustIsBadRngWrapper(ChaCha20Rng::seed_from_u64(seed)),
+        }
     }
 }
 
@@ -3460,10 +5081,16 @@ impl CryptoResolver for SnowRngResolver {
     fn resolve_dh(&self, choice: &snow::params::DHChoice) -> Option<Box<dyn snow::types::Dh>> {
         snow::resolvers::DefaultResolver::resolve_dh(&snow::resolvers::DefaultResolver, choice)
     }
-    fn resolve_hash(&self, choice: &snow::params::HashChoice) -> Option<Box<dyn snow::types::Hash>> {
+    fn resolve_hash(
+        &self,
+        choice: &snow::params::HashChoice,
+    ) -> Option<Box<dyn snow::types::Hash>> {
         snow::resolvers::DefaultResolver::resolve_hash(&snow::resolvers::DefaultResolver, choice)
     }
-    fn resolve_cipher(&self, choice: &snow::params::CipherChoice) -> Option<Box<dyn snow::types::Cipher>> {
+    fn resolve_cipher(
+        &self,
+        choice: &snow::params::CipherChoice,
+    ) -> Option<Box<dyn snow::types::Cipher>> {
         snow::resolvers::DefaultResolver::resolve_cipher(&snow::resolvers::DefaultResolver, choice)
     }
 }
@@ -3479,67 +5106,146 @@ pub fn run_instances(i: usize) {
     const N: usize = 4;
 
     let mut crypto_rng = ChaCha20Rng::seed_from_u64(seed);
-    let static_private_keys : Vec<_> = (0..N).map(|_| {
-        // NOTE: doing this manually to avoid CryptoRng incompatibilities between different rand_core versions
-        let mut secret_key = [0u8; 32];
-        crypto_rng.fill_bytes(&mut secret_key);
-        SigningKey::from(secret_key)
-    }).collect();
+    let static_private_keys: Vec<_> = (0..N)
+        .map(|_| {
+            // NOTE: doing this manually to avoid CryptoRng incompatibilities between different rand_core versions
+            let mut secret_key = [0u8; 32];
+            crypto_rng.fill_bytes(&mut secret_key);
+            SigningKey::from(secret_key)
+        })
+        .collect();
     let mut cumulative_stake = 0;
-    let roster : Vec<SortedRosterMember> = static_private_keys.iter().enumerate().map(|(i, sk)| {
-        let stake = 2000 * (N - 1 - i) as u64;
-        cumulative_stake += stake;
-        SortedRosterMember { pub_key: PubKeyID(sk.verification_key().into()), stake, cumulative_stake }
-    }).collect();
-    assert!(roster.is_sorted_by(|a,b| a.stake >= b.stake)); // descending
+    let roster: Vec<SortedRosterMember> = static_private_keys
+        .iter()
+        .enumerate()
+        .map(|(i, sk)| {
+            let stake = 2000 * (N - 1 - i) as u64;
+            cumulative_stake += stake;
+            SortedRosterMember {
+                pub_key: PubKeyID(sk.verification_key().into()),
+                stake,
+                cumulative_stake,
+            }
+        })
+        .collect();
+    assert!(roster.is_sorted_by(|a, b| a.stake >= b.stake)); // descending
 
-    if PRINT_ROSTER { println!("Roster: {:?}", roster); }
+    if PRINT_ROSTER {
+        println!("Roster: {:?}", roster);
+    }
 
     let static_keypair_zero = {
-        let kp = snow::Builder::with_resolver("Noise_IK_25519_ChaChaPoly_BLAKE2s".parse().unwrap(), Box::new(SnowRngResolver { rng: RustIsBadRngWrapper(crypto_rng.clone()) })).generate_keypair().unwrap();
-        StaticDHKeyPair { private: kp.private.try_into().unwrap(), public: kp.public.try_into().unwrap(), }
+        let kp = snow::Builder::with_resolver(
+            "Noise_IK_25519_ChaChaPoly_BLAKE2s".parse().unwrap(),
+            Box::new(SnowRngResolver {
+                rng: RustIsBadRngWrapper(crypto_rng.clone()),
+            }),
+        )
+        .generate_keypair()
+        .unwrap();
+        StaticDHKeyPair {
+            private: kp.private.try_into().unwrap(),
+            public: kp.public.try_into().unwrap(),
+        }
     };
 
-    let endpoint_zero : SecureUdpEndpoint = {
-        let port : u16 = 3030;
+    let endpoint_zero: SecureUdpEndpoint = {
+        let port: u16 = 3030;
         // let ip = "::1".parse::<std::net::Ipv6Addr>().unwrap();
-        let ip = "127.0.0.1".parse::<std::net::Ipv4Addr>().unwrap().to_ipv6_mapped();
-        SecureUdpEndpoint { ip_address: ip.octets(), port, public_key: static_keypair_zero.public }
+        let ip = "127.0.0.1"
+            .parse::<std::net::Ipv4Addr>()
+            .unwrap()
+            .to_ipv6_mapped();
+        SecureUdpEndpoint {
+            ip_address: ip.octets(),
+            port,
+            public_key: static_keypair_zero.public,
+        }
     };
 
     let evidence_zero = {
-        EndpointEvidence { endpoint: endpoint_zero, root_public_bft_key: static_private_keys[0].verification_key().into() }
+        EndpointEvidence {
+            endpoint: endpoint_zero,
+            root_public_bft_key: static_private_keys[0].verification_key().into(),
+        }
     };
 
     if i == usize::MAX {
         // let _joins: [; N];
         for j in 0..N {
             if j == 0 {
-                rt.spawn(instance(static_private_keys[j], Some(static_keypair_zero), Some(endpoint_zero), roster.clone(), vec![evidence_zero], None));
+                rt.spawn(instance(
+                    static_private_keys[j],
+                    Some(static_keypair_zero),
+                    Some(endpoint_zero),
+                    roster.clone(),
+                    vec![evidence_zero],
+                    None,
+                ));
             } else {
-                rt.spawn(instance(static_private_keys[j], None, None, roster.clone(), vec![evidence_zero], None));
+                rt.spawn(instance(
+                    static_private_keys[j],
+                    None,
+                    None,
+                    roster.clone(),
+                    vec![evidence_zero],
+                    None,
+                ));
             }
         }
     } else if i == 999 {
         // let _joins: [; N];
         for j in 0..N - 1 {
             if j == 0 {
-                rt.spawn(instance(static_private_keys[j], Some(static_keypair_zero), Some(endpoint_zero), roster.clone(), vec![evidence_zero], None));
+                rt.spawn(instance(
+                    static_private_keys[j],
+                    Some(static_keypair_zero),
+                    Some(endpoint_zero),
+                    roster.clone(),
+                    vec![evidence_zero],
+                    None,
+                ));
             } else {
-                rt.spawn(instance(static_private_keys[j], None, None, roster.clone(), vec![evidence_zero], None));
+                rt.spawn(instance(
+                    static_private_keys[j],
+                    None,
+                    None,
+                    roster.clone(),
+                    vec![evidence_zero],
+                    None,
+                ));
             }
         }
     } else {
         if i == 0 {
-            rt.spawn(instance(static_private_keys[i], Some(static_keypair_zero), Some(endpoint_zero), roster.clone(), vec![evidence_zero], None));
-        }
-        else if i < N {
-            rt.spawn(instance(static_private_keys[i], None, None, roster.clone(), vec![evidence_zero], None));
-        }
-        else {
+            rt.spawn(instance(
+                static_private_keys[i],
+                Some(static_keypair_zero),
+                Some(endpoint_zero),
+                roster.clone(),
+                vec![evidence_zero],
+                None,
+            ));
+        } else if i < N {
+            rt.spawn(instance(
+                static_private_keys[i],
+                None,
+                None,
+                roster.clone(),
+                vec![evidence_zero],
+                None,
+            ));
+        } else {
             let mut secret_key = [0u8; 32];
             crypto_rng.fill_bytes(&mut secret_key);
-            rt.spawn(instance(SigningKey::from(secret_key), None, None, roster.clone(), vec![evidence_zero], None));
+            rt.spawn(instance(
+                SigningKey::from(secret_key),
+                None,
+                None,
+                roster.clone(),
+                vec![evidence_zero],
+                None,
+            ));
         }
     }
     rt.block_on(std::future::pending::<()>())
@@ -3579,30 +5285,98 @@ mod tests {
     #[test]
     fn check_proposer_from_height_round() {
         let roster_ = [
-            SortedRosterMember{ pub_key: PubKeyID([1;32]), stake: 2000, cumulative_stake: 2000 },
-            SortedRosterMember{ pub_key: PubKeyID([2;32]), stake: 1000, cumulative_stake: 3000 },
-            SortedRosterMember{ pub_key: PubKeyID([2;32]), stake: 1000, cumulative_stake: 4000 },
-            SortedRosterMember{ pub_key: PubKeyID([3;32]), stake: 0000, cumulative_stake: 4000 },
+            SortedRosterMember {
+                pub_key: PubKeyID([1; 32]),
+                stake: 2000,
+                cumulative_stake: 2000,
+            },
+            SortedRosterMember {
+                pub_key: PubKeyID([2; 32]),
+                stake: 1000,
+                cumulative_stake: 3000,
+            },
+            SortedRosterMember {
+                pub_key: PubKeyID([2; 32]),
+                stake: 1000,
+                cumulative_stake: 4000,
+            },
+            SortedRosterMember {
+                pub_key: PubKeyID([3; 32]),
+                stake: 0000,
+                cumulative_stake: 4000,
+            },
         ];
         let roster = [
-            SortedRosterMember{ pub_key: PubKeyID([1;32]), stake: 2, cumulative_stake: 2 },
-            SortedRosterMember{ pub_key: PubKeyID([2;32]), stake: 1, cumulative_stake: 3 },
-            SortedRosterMember{ pub_key: PubKeyID([2;32]), stake: 1, cumulative_stake: 4 },
-            SortedRosterMember{ pub_key: PubKeyID([3;32]), stake: 0, cumulative_stake: 4 },
+            SortedRosterMember {
+                pub_key: PubKeyID([1; 32]),
+                stake: 2,
+                cumulative_stake: 2,
+            },
+            SortedRosterMember {
+                pub_key: PubKeyID([2; 32]),
+                stake: 1,
+                cumulative_stake: 3,
+            },
+            SortedRosterMember {
+                pub_key: PubKeyID([2; 32]),
+                stake: 1,
+                cumulative_stake: 4,
+            },
+            SortedRosterMember {
+                pub_key: PubKeyID([3; 32]),
+                stake: 0,
+                cumulative_stake: 4,
+            },
         ];
         let roster0 = [
-            SortedRosterMember{ pub_key: PubKeyID([1;32]), stake: 0, cumulative_stake: 0 },
-            SortedRosterMember{ pub_key: PubKeyID([2;32]), stake: 0, cumulative_stake: 0 },
-            SortedRosterMember{ pub_key: PubKeyID([3;32]), stake: 0, cumulative_stake: 0 },
+            SortedRosterMember {
+                pub_key: PubKeyID([1; 32]),
+                stake: 0,
+                cumulative_stake: 0,
+            },
+            SortedRosterMember {
+                pub_key: PubKeyID([2; 32]),
+                stake: 0,
+                cumulative_stake: 0,
+            },
+            SortedRosterMember {
+                pub_key: PubKeyID([3; 32]),
+                stake: 0,
+                cumulative_stake: 0,
+            },
         ];
-        assert!((None, PubKeyID::NIL) == TMState::proposer_from_height_round(&HashKeys::default(), &[], 2, 1));
+        assert!(
+            (None, PubKeyID::NIL)
+                == TMState::proposer_from_height_round(&HashKeys::default(), &[], 2, 1)
+        );
         for height in 0..8 {
             for round in 0..6 {
-                let (Some(i), _) = TMState::proposer_from_height_round(&HashKeys::default(), &roster_[..], height, round) else { panic!(); };
+                let (Some(i), _) = TMState::proposer_from_height_round(
+                    &HashKeys::default(),
+                    &roster_[..],
+                    height,
+                    round,
+                ) else {
+                    panic!();
+                };
                 println!("BFT Proposer at {}.{}: {}", height, round, i);
-                let (Some(i), _) = TMState::proposer_from_height_round(&HashKeys::default(), &roster[..], height, round) else { panic!(); };
+                let (Some(i), _) = TMState::proposer_from_height_round(
+                    &HashKeys::default(),
+                    &roster[..],
+                    height,
+                    round,
+                ) else {
+                    panic!();
+                };
                 println!("BFT Proposer at {}.{}: {}", height, round, i);
-                let (Some(i), _) = TMState::proposer_from_height_round(&HashKeys::default(), &roster[..1], height, round) else { panic!(); };
+                let (Some(i), _) = TMState::proposer_from_height_round(
+                    &HashKeys::default(),
+                    &roster[..1],
+                    height,
+                    round,
+                ) else {
+                    panic!();
+                };
                 println!("BFT Proposer at {}.{}: {}", height, round, i);
                 // assert!(TMState::proposer_from_height_round(&roster0, 100, height, round).0.is_none());
             }
@@ -3621,17 +5395,38 @@ mod tests {
     #[test]
     fn check_gen_rngs() {
         struct Test {
-            arr: &'static[u8],
-            rngs: &'static[[usize; 2]],
+            arr: &'static [u8],
+            rngs: &'static [[usize; 2]],
         }
         let tests = [
-            Test { arr: b"00000000",  rngs: &[[0,8]] },
-            Test { arr: b"00010000",  rngs: &[[0,8]] },
-            Test { arr: b"10010000",  rngs: &[[1,8]] },
-            Test { arr: b"10010001",  rngs: &[[1,7]] },
-            Test { arr: b"10011001",  rngs: &[[1,3], [5,7]] },
-            Test { arr: b"101101100", rngs: &[[1,2], [4,5], [7,9]] },
-            Test { arr: b"101111100", rngs: &[[1,2],        [7,9]] },
+            Test {
+                arr: b"00000000",
+                rngs: &[[0, 8]],
+            },
+            Test {
+                arr: b"00010000",
+                rngs: &[[0, 8]],
+            },
+            Test {
+                arr: b"10010000",
+                rngs: &[[1, 8]],
+            },
+            Test {
+                arr: b"10010001",
+                rngs: &[[1, 7]],
+            },
+            Test {
+                arr: b"10011001",
+                rngs: &[[1, 3], [5, 7]],
+            },
+            Test {
+                arr: b"101101100",
+                rngs: &[[1, 2], [4, 5], [7, 9]],
+            },
+            Test {
+                arr: b"101111100",
+                rngs: &[[1, 2], [7, 9]],
+            },
         ];
 
         for (test_i, test) in tests.iter().enumerate() {

--- a/tenderlink/src/main.rs
+++ b/tenderlink/src/main.rs
@@ -1,8 +1,6 @@
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    if args.len() > 2 {
-        
-    }
+    if args.len() > 2 {}
     let mut i: usize = usize::MAX;
     if args.len() > 1 {
         i = args[1].parse().unwrap_or(usize::MAX);

--- a/zebra-crosslink/wallet/src/lib.rs
+++ b/zebra-crosslink/wallet/src/lib.rs
@@ -1,25 +1,24 @@
 //! Internal wallet
 #![allow(warnings)]
 
-const AUTO_SPEND:    bool = false; // automatically make spends without requiring GUI interaction
-const DUMP_ACTIONS:  bool = false;
-const DUMP_FAUCET:   bool = false;
-const DUMP_NOTES:    bool = false;
-const DUMP_ROSTER:   bool = false;
-const DUMP_SYNC:     bool = true;
-const DUMP_TREES:    bool = false;
+const AUTO_SPEND: bool = false; // automatically make spends without requiring GUI interaction
+const DUMP_ACTIONS: bool = false;
+const DUMP_FAUCET: bool = false;
+const DUMP_NOTES: bool = false;
+const DUMP_ROSTER: bool = false;
+const DUMP_SYNC: bool = true;
+const DUMP_TREES: bool = false;
 const DUMP_TX_BUILD: bool = false;
-const DUMP_TX_RECV:  bool = false;
-const DUMP_TX_SEND:  bool = false;
-const AUDIT_TXS:     bool = true;
+const DUMP_TX_RECV: bool = false;
+const DUMP_TX_SEND: bool = false;
+const AUDIT_TXS: bool = true;
 
+use orchard::note_encryption::{CompactAction as OrchardCompactAction, OrchardDomain};
 use rand::seq::SliceRandom;
-use zcash_client_backend::data_api::WalletCommitmentTrees;
-use orchard::note_encryption::{ CompactAction as OrchardCompactAction, OrchardDomain };
+use rand::{thread_rng, Rng};
 use rand_chacha::rand_core::SeedableRng;
 use rand_core::OsRng;
-use rand::{Rng, thread_rng};
-use secrecy::{ExposeSecret,SecretVec,Secret};
+use secrecy::{ExposeSecret, Secret, SecretVec};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::convert::{identity, Infallible};
 use std::future::Future;
@@ -31,24 +30,34 @@ use tonic::client::GrpcService;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint};
 use tonic::IntoRequest;
 use zcash_client_backend::data_api::chain::{BlockCache, CommitmentTreeRoot};
-use zcash_client_backend::data_api::wallet::{ConfirmationsPolicy, TargetHeight, create_proposed_transactions, propose_shielding, shield_transparent_funds};
-use zcash_client_backend::proto::service::{GetSubtreeRootsArg, RawTransaction, FaucetRequest, TreeState, TxFilter};
+use zcash_client_backend::data_api::wallet::{
+    create_proposed_transactions, propose_shielding, shield_transparent_funds, ConfirmationsPolicy,
+    TargetHeight,
+};
+use zcash_client_backend::data_api::WalletCommitmentTrees;
+use zcash_client_backend::proto::service::{
+    FaucetRequest, GetSubtreeRootsArg, RawTransaction, TreeState, TxFilter,
+};
 use zcash_client_backend::wallet::WalletTransparentOutput;
 use zcash_client_sqlite::error::SqliteClientError;
 use zcash_client_sqlite::util::SystemClock;
 use zcash_client_sqlite::{AccountUuid, WalletDb};
-use zcash_note_encryption::{try_compact_note_decryption, try_note_decryption, try_output_recovery_with_ovk, ShieldedOutput};
-use zcash_primitives::transaction::builder::{self, BuildConfig, Builder as TxBuilder, BuildResult as TxBuildResult};
-use zcash_primitives::transaction::components::TxOut;
-use zcash_primitives::transaction::fees::{
-    self,
-    FeeRule,
-    zip317,
+use zcash_note_encryption::{
+    try_compact_note_decryption, try_note_decryption, try_output_recovery_with_ovk, ShieldedOutput,
 };
+use zcash_primitives::transaction::builder::{
+    self, BuildConfig, BuildResult as TxBuildResult, Builder as TxBuilder,
+};
+use zcash_primitives::transaction::components::TxOut;
+use zcash_primitives::transaction::fees::{self, zip317, FeeRule};
 use zcash_primitives::transaction::sighash::{signature_hash, SignableInput};
 use zcash_primitives::transaction::txid::TxIdDigester;
-use zcash_primitives::transaction::{Authorized, StakingAction_BeginDelegationUnbonding, StakingAction_CreateNewDelegationBond, StakingAction_RetargetDelegationBond, StakingAction_WithdrawDelegationBond, Transaction, TransactionData, TxVersion, Unauthorized};
-use zcash_primitives::transaction::{RosterMember, StakingAction, StakingActionKind, StakeTxId};
+use zcash_primitives::transaction::{
+    Authorized, StakingAction_BeginDelegationUnbonding, StakingAction_CreateNewDelegationBond,
+    StakingAction_RetargetDelegationBond, StakingAction_WithdrawDelegationBond, Transaction,
+    TransactionData, TxVersion, Unauthorized,
+};
+use zcash_primitives::transaction::{RosterMember, StakeTxId, StakingAction, StakingActionKind};
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::consensus::{BlockHeight as LRZBlockHeight, BranchId};
 use zcash_protocol::memo::MemoBytes;
@@ -58,7 +67,7 @@ use zcash_transparent::{
     address::TransparentAddress,
     builder::{InputKind as TransparentInputKind, TransparentInputInfo, TransparentSigningSet},
     bundle::OutPoint,
-    keys::{IncomingViewingKey, TransparentKeyScope, NonHardenedChildIndex},
+    keys::{IncomingViewingKey, NonHardenedChildIndex, TransparentKeyScope},
 };
 
 use rustls::client::danger::ServerCertVerified;
@@ -76,16 +85,18 @@ use zcash_client_backend::{
         self,
         chain::{error::Error as ChainError, scan_cached_blocks, ChainState},
         scanning::{ScanPriority, ScanRange},
-        Balance,
-        wallet, Account as APIAccount, AccountBirthday, AccountPurpose, WalletRead, WalletWrite,
-        Zip32Derivation,
+        wallet, Account as APIAccount, AccountBirthday, AccountPurpose, Balance, WalletRead,
+        WalletWrite, Zip32Derivation,
     },
     encoding::AddressCodec,
     keys::{
         UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedIncomingViewingKey, UnifiedSpendingKey,
     },
     proto::{
-        compact_formats::{CompactBlock, CompactTx, CompactSaplingSpend, CompactSaplingOutput, CompactOrchardAction},
+        compact_formats::{
+            CompactBlock, CompactOrchardAction, CompactSaplingOutput, CompactSaplingSpend,
+            CompactTx,
+        },
         service::{
             compact_tx_streamer_client::CompactTxStreamerClient, BlockId, BlockRange, ChainSpec,
             Empty, GetAddressUtxosArg, LightdInfo, TransparentAddressBlockFilter,
@@ -96,7 +107,9 @@ use zcash_client_backend::{
 use zcash_protocol::consensus::{NetworkType, Parameters, MAIN_NETWORK, TEST_NETWORK};
 
 #[derive(Clone)]
-pub struct FaucetRequestClosure(pub Arc<dyn Fn(String) -> Result<u64, String> + Sync + Send + 'static>);
+pub struct FaucetRequestClosure(
+    pub Arc<dyn Fn(String) -> Result<u64, String> + Sync + Send + 'static>,
+);
 pub static FAUCET_REQUEST: Mutex<Option<FaucetRequestClosure>> = Mutex::new(None);
 
 // NOTE: this has slightly different semantics from the protocol version, hence the different type
@@ -107,11 +120,11 @@ impl BlockHeight {
     // NOTE: these constants corresponds to the semantic that the lower-down it is,
     // the more sure we are about its continued existence
     pub const INVALID: Self = Self(u32::MAX); // NOTE: here for headroom for +1 to fake <= using <
-    // ALT: maybe better to go the other way round: use <= and saturating_sub(1)
-    pub const PROPOSED: Self = Self(u32::MAX-1); // NOTE: no valid txid here
-    pub const BUILT:    Self = Self(u32::MAX-2);
-    pub const SENT:     Self = Self(u32::MAX-3);
-    pub const MEMPOOL:  Self = Self(u32::MAX-4);
+                                              // ALT: maybe better to go the other way round: use <= and saturating_sub(1)
+    pub const PROPOSED: Self = Self(u32::MAX - 1); // NOTE: no valid txid here
+    pub const BUILT: Self = Self(u32::MAX - 2);
+    pub const SENT: Self = Self(u32::MAX - 3);
+    pub const MEMPOOL: Self = Self(u32::MAX - 4);
 
     pub fn is_in_block(&self) -> bool {
         self.0 < Self::MEMPOOL.0
@@ -142,12 +155,12 @@ impl std::fmt::Debug for BlockHeight {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "BlockHeight(")?;
         match *self {
-            Self::INVALID  => write!(f, "<invalid>"),
+            Self::INVALID => write!(f, "<invalid>"),
             Self::PROPOSED => write!(f, "<proposed>"),
-            Self::BUILT    => write!(f, "<built>"),
-            Self::SENT     => write!(f, "<sent>"),
-            Self::MEMPOOL  => write!(f, "<mempool>"),
-            _ => self.0.fmt(f)
+            Self::BUILT => write!(f, "<built>"),
+            Self::SENT => write!(f, "<sent>"),
+            Self::MEMPOOL => write!(f, "<mempool>"),
+            _ => self.0.fmt(f),
         }?;
         write!(f, ")")
     }
@@ -155,12 +168,12 @@ impl std::fmt::Debug for BlockHeight {
 impl std::fmt::Display for BlockHeight {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
-            Self::INVALID  => write!(f, "<invalid>"),
+            Self::INVALID => write!(f, "<invalid>"),
             Self::PROPOSED => write!(f, "<proposed>"),
-            Self::BUILT    => write!(f, "<built>"),
-            Self::SENT     => write!(f, "<sent>"),
-            Self::MEMPOOL  => write!(f, "<mempool>"),
-            _ => self.0.fmt(f)
+            Self::BUILT => write!(f, "<built>"),
+            Self::SENT => write!(f, "<sent>"),
+            Self::MEMPOOL => write!(f, "<mempool>"),
+            _ => self.0.fmt(f),
         }
     }
 }
@@ -171,7 +184,7 @@ impl std::fmt::Display for LESlice<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let n = usize::min(self.0.len(), f.precision().unwrap_or(self.0.len()));
         for i in 0..n {
-            write!(f, "{:02x}", self.0[31-i])?;
+            write!(f, "{:02x}", self.0[31 - i])?;
         }
         Ok(())
     }
@@ -223,7 +236,9 @@ impl<T: std::fmt::Debug> std::fmt::Debug for NL<'_, T> {
 // NOTE: only a function because from() isn't const
 // This is u64::MAX in large part to operate correctly on anchor comparison
 // ALT: Option
-fn unknown_tree_position() -> incrementalmerkletree::Position { incrementalmerkletree::Position::from(u64::MAX) }
+fn unknown_tree_position() -> incrementalmerkletree::Position {
+    incrementalmerkletree::Position::from(u64::MAX)
+}
 
 // ALT: collapse into Txo with internal enum(s)
 #[derive(Clone, Copy, PartialEq)]
@@ -241,21 +256,27 @@ struct OrchardNote {
 }
 impl std::fmt::Debug for OrchardNote {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "OrchardNote{{ recv:{:?}, spent:{:?}, txid:{}, nf:{:?}, value:{}, pos:{}}}",
-            self.recv_h, self.spent_h, self.txid, self.nf, self.note.value().inner(),
-            u64::from(self.position)
-            // u64::from(self.witness.witnessed_position()), self.witness.root()
-            )
+        write!(
+            f,
+            "OrchardNote{{ recv:{:?}, spent:{:?}, txid:{}, nf:{:?}, value:{}, pos:{}}}",
+            self.recv_h,
+            self.spent_h,
+            self.txid,
+            self.nf,
+            self.note.value().inner(),
+            u64::from(self.position) // u64::from(self.witness.witnessed_position()), self.witness.root()
+        )
     }
 }
 
 impl OrchardNote {
     fn monotonically_update(&mut self, mut new_note: OrchardNote) {
         if new_note.position < unknown_tree_position() {
-            if (self.position < unknown_tree_position() &&
-                self.position != new_note.position)
-            {
-                println!("ERROR: orchard note has 2 different valid positions: {:?} vs {:?}", self.position, new_note.position);
+            if (self.position < unknown_tree_position() && self.position != new_note.position) {
+                println!(
+                    "ERROR: orchard note has 2 different valid positions: {:?} vs {:?}",
+                    self.position, new_note.position
+                );
             }
             // println!("updating note position at {:?} {:?} => {:?}", self.recv_h, self.position, new_note.position);
             self.position = new_note.position;
@@ -264,7 +285,10 @@ impl OrchardNote {
         }
 
         if self != &new_note {
-            println!("ERROR: orchard_note mismatch:\n  {:?} vs\n  {:?}", self, new_note);
+            println!(
+                "ERROR: orchard_note mismatch:\n  {:?} vs\n  {:?}",
+                self, new_note
+            );
         }
     }
 
@@ -310,31 +334,35 @@ impl BuildPrep {
     fn fee_required(&self) -> Result<Zatoshis, builder::FeeError<zip317::FeeError>> {
         // NOTE: we can impl these ourselves
         use zcash_primitives::transaction::fees::transparent::{InputView, OutputView};
-        let orchard_actions = orchard::builder::BundleType::DEFAULT.num_actions(
-            self.o_inputs.len(), self.o_outputs.len()
-        ).map_err(|e| builder::FeeError::Bundle(e))?;
+        let orchard_actions = orchard::builder::BundleType::DEFAULT
+            .num_actions(self.o_inputs.len(), self.o_outputs.len())
+            .map_err(|e| builder::FeeError::Bundle(e))?;
 
-        zip317::FeeRule::standard().fee_required(
-            &TEST_NETWORK,
-            LRZBlockHeight::from_u32(self.block_h),
-            self.t_inputs.iter().map(|input| input.serialized_size()),
-            self.t_outputs.iter().map(|output| 8 + output.dst.script().0.len()), // DUP from zcash_primitives/src/transaction/fees/transparent.rs
-            0, 0, // sapling
-            orchard_actions
-        ).map_err(|e| builder::FeeError::FeeRule(e))
+        zip317::FeeRule::standard()
+            .fee_required(
+                &TEST_NETWORK,
+                LRZBlockHeight::from_u32(self.block_h),
+                self.t_inputs.iter().map(|input| input.serialized_size()),
+                self.t_outputs
+                    .iter()
+                    .map(|output| 8 + output.dst.script().0.len()), // DUP from zcash_primitives/src/transaction/fees/transparent.rs
+                0,
+                0, // sapling
+                orchard_actions,
+            )
+            .map_err(|e| builder::FeeError::FeeRule(e))
     }
 }
-
 
 struct ProposedTx {
     pub tx: WalletTx,
     pub prep: Option<BuildPrep>,
     pub tx_res: Option<TxBuildResult>,
     pub is_user_faucet: bool, // and NOT an RPC faucet
-    // pub orchard_anchor_h: u32,
-    // pub orchard_fvk: Option<orchard::keys::FullViewingKey>,
-    // pub src_usk: UnifiedSpendingKey,
-    // pub outputs: Vec<TxOutput>,
+                              // pub orchard_anchor_h: u32,
+                              // pub orchard_fvk: Option<orchard::keys::FullViewingKey>,
+                              // pub src_usk: UnifiedSpendingKey,
+                              // pub outputs: Vec<TxOutput>,
 }
 impl ProposedTx {
     const EMPTY: Self = Self {
@@ -345,7 +373,8 @@ impl ProposedTx {
     };
 
     fn is_in_progress(&self) -> bool {
-        let result = BlockHeight::SENT <= self.tx.h && self.tx.h <= BlockHeight::PROPOSED
+        let result = BlockHeight::SENT <= self.tx.h
+            && self.tx.h <= BlockHeight::PROPOSED
             && self.tx.is_on_bc();
         result
     }
@@ -382,18 +411,25 @@ async fn wait_for_zainod() {
             }
         }
 
-
         interval.tick().await;
     }
 }
 
-struct Timer<'a> { t_bgn: std::time::Instant, name: &'a str, loud: bool }
+struct Timer<'a> {
+    t_bgn: std::time::Instant,
+    name: &'a str,
+    loud: bool,
+}
 impl<'a> Timer<'a> {
     pub fn scope_(name: &'a str, loud: bool) -> Self {
         if loud {
             println!("started {}", name);
         }
-        Self { name, t_bgn: std::time::Instant::now(), loud }
+        Self {
+            name,
+            t_bgn: std::time::Instant::now(),
+            loud,
+        }
     }
 
     pub fn scope(name: &'a str) -> Self {
@@ -407,7 +443,6 @@ impl Drop for Timer<'_> {
         }
     }
 }
-
 
 // fn block_policy_10() -> ConfirmationsPolicy { ConfirmationsPolicy::new(std::num::NonZeroU32::new(5).unwrap(), std::num::NonZeroU32::new(5).unwrap(), false).unwrap() }
 
@@ -476,19 +511,32 @@ impl WalletTxPart {
                 StakingActionKind::Null => (),
 
                 StakingActionKind::CreateNewDelegationBond => {
-                    b.sent(Zatoshis::from_u64(staking_action.amount_zats).expect("already converted"), true).unwrap();
-                    b.recv(Zatoshis::from_u64(staking_action.amount_zats).expect("already converted"), true).unwrap();
-                },
+                    b.sent(
+                        Zatoshis::from_u64(staking_action.amount_zats).expect("already converted"),
+                        true,
+                    )
+                    .unwrap();
+                    b.recv(
+                        Zatoshis::from_u64(staking_action.amount_zats).expect("already converted"),
+                        true,
+                    )
+                    .unwrap();
+                }
 
-                StakingActionKind::BeginDelegationUnbonding | StakingActionKind::RetargetDelegationBond => {},
+                StakingActionKind::BeginDelegationUnbonding
+                | StakingActionKind::RetargetDelegationBond => {}
 
                 StakingActionKind::WithdrawDelegationBond => {
-                    b.spent(Zatoshis::from_u64(staking_action.amount_zats).expect("already converted"), true).unwrap();
-                },
+                    b.spent(
+                        Zatoshis::from_u64(staking_action.amount_zats).expect("already converted"),
+                        true,
+                    )
+                    .unwrap();
+                }
 
-                StakingActionKind::RegisterFinalizer |
-                    StakingActionKind::ConvertFinalizerRewardToDelegationBond |
-                    StakingActionKind::UpdateFinalizerKey => todo!("remaining staking actions"),
+                StakingActionKind::RegisterFinalizer
+                | StakingActionKind::ConvertFinalizerRewardToDelegationBond
+                | StakingActionKind::UpdateFinalizerKey => todo!("remaining staking actions"),
             }
         }
 
@@ -498,22 +546,22 @@ impl WalletTxPart {
     pub fn checked_add(&self, rhs: &WalletTxPart) -> Option<WalletTxPart> {
         Some(WalletTxPart {
             spent_note_count: (self.spent_note_count + rhs.spent_note_count),
-            sent_note_count:  (self.sent_note_count  + rhs.sent_note_count),
-            recv_note_count:  (self.recv_note_count  + rhs.recv_note_count),
-            spent_zats:       (self.spent_zats       + rhs.spent_zats)?,
-            sent_zats:        (self.sent_zats        + rhs.sent_zats)?,
-            recv_zats:        (self.recv_zats        + rhs.recv_zats)?,
+            sent_note_count: (self.sent_note_count + rhs.sent_note_count),
+            recv_note_count: (self.recv_note_count + rhs.recv_note_count),
+            spent_zats: (self.spent_zats + rhs.spent_zats)?,
+            sent_zats: (self.sent_zats + rhs.sent_zats)?,
+            recv_zats: (self.recv_zats + rhs.recv_zats)?,
         })
     }
 
     pub fn unchecked_add(&self, rhs: &WalletTxPart) -> WalletTxPart {
         WalletTxPart {
             spent_note_count: (self.spent_note_count + rhs.spent_note_count),
-            sent_note_count:  (self.sent_note_count  + rhs.sent_note_count),
-            recv_note_count:  (self.recv_note_count  + rhs.recv_note_count),
-            spent_zats:       (self.spent_zats       + rhs.spent_zats).expect("already checked"),
-            sent_zats:        (self.sent_zats        + rhs.sent_zats).expect("already checked"),
-            recv_zats:        (self.recv_zats        + rhs.recv_zats).expect("already checked"),
+            sent_note_count: (self.sent_note_count + rhs.sent_note_count),
+            recv_note_count: (self.recv_note_count + rhs.recv_note_count),
+            spent_zats: (self.spent_zats + rhs.spent_zats).expect("already checked"),
+            sent_zats: (self.sent_zats + rhs.sent_zats).expect("already checked"),
+            recv_zats: (self.recv_zats + rhs.recv_zats).expect("already checked"),
         }
     }
 
@@ -533,7 +581,6 @@ impl WalletTxPart {
         v
     }
 
-
     pub fn spent(&mut self, zats: Zatoshis, loud: bool) -> Option<()> {
         self.spent_note_count += 1;
         match self.spent_zats + zats {
@@ -543,7 +590,10 @@ impl WalletTxPart {
             }
             None => {
                 if loud {
-                    println!("note spend error: couldn't add {:?} to {:?}", self.spent_zats, zats);
+                    println!(
+                        "note spend error: couldn't add {:?} to {:?}",
+                        self.spent_zats, zats
+                    );
                 }
                 None
             }
@@ -559,7 +609,10 @@ impl WalletTxPart {
             }
             None => {
                 if loud {
-                    println!("note send error: couldn't add {:?} to {:?}", self.sent_zats, zats);
+                    println!(
+                        "note send error: couldn't add {:?} to {:?}",
+                        self.sent_zats, zats
+                    );
                 }
                 None
             }
@@ -575,7 +628,10 @@ impl WalletTxPart {
             }
             None => {
                 if loud {
-                    println!("note receive error: couldn't add {:?} to {:?}", self.recv_zats, zats);
+                    println!(
+                        "note receive error: couldn't add {:?} to {:?}",
+                        self.recv_zats, zats
+                    );
                 }
                 None
             }
@@ -583,14 +639,19 @@ impl WalletTxPart {
     }
     pub fn maybe_recv(&mut self, is_me: bool, zats: Zatoshis, loud: bool) -> Option<()> {
         self.recv_note_count += is_me as usize; // allow branchless
-        match self.recv_zats + Zatoshis::from_u64(zats.into_u64() * is_me as u64).expect("prev val or 0") {
+        match self.recv_zats
+            + Zatoshis::from_u64(zats.into_u64() * is_me as u64).expect("prev val or 0")
+        {
             Some(v) => {
                 self.recv_zats = v;
                 Some(())
             }
             None => {
                 if loud {
-                    println!("note receive error: couldn't add {:?} to {:?}", self.recv_zats, zats);
+                    println!(
+                        "note receive error: couldn't add {:?} to {:?}",
+                        self.recv_zats, zats
+                    );
                 }
                 None
             }
@@ -601,24 +662,25 @@ impl WalletTxPart {
 type TxPartFlags = u8;
 pub struct TxParts(pub TxPartFlags);
 impl TxParts {
-    pub const NONE:           TxPartFlags = 0;
-    pub const TRANSPARENT:    TxPartFlags = 1 << WalletTxPart::TRANSPARENT;
-    pub const SHIELDED_RECV:  TxPartFlags = 1 << WalletTxPart::SHIELDED;
-    pub const SHIELDED_SENT:  TxPartFlags = 1 << 2;
-    pub const MEMO:           TxPartFlags = 1 << 3;
+    pub const NONE: TxPartFlags = 0;
+    pub const TRANSPARENT: TxPartFlags = 1 << WalletTxPart::TRANSPARENT;
+    pub const SHIELDED_RECV: TxPartFlags = 1 << WalletTxPart::SHIELDED;
+    pub const SHIELDED_SENT: TxPartFlags = 1 << 2;
+    pub const MEMO: TxPartFlags = 1 << 3;
     pub const STAKING_ACTION: TxPartFlags = 1 << 4;
 
-    pub const FULL_TX: TxPartFlags = (
-        Self::TRANSPARENT | Self::SHIELDED_RECV | Self::SHIELDED_SENT | Self::MEMO | Self::STAKING_ACTION
-    );
+    pub const FULL_TX: TxPartFlags = (Self::TRANSPARENT
+        | Self::SHIELDED_RECV
+        | Self::SHIELDED_SENT
+        | Self::MEMO
+        | Self::STAKING_ACTION);
 }
-
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ErrBuf(pub [u8; 128]);
 impl ErrBuf {
     pub fn from_str(err_str: &str) -> ErrBuf {
-        let mut buf = ErrBuf([0;128]);
+        let mut buf = ErrBuf([0; 128]);
         let err_bytes = err_str.as_bytes();
         let len = err_bytes.len().min(buf.0.len());
         buf.0.copy_from_slice(&err_bytes[..len]);
@@ -670,7 +732,7 @@ pub enum DevNote {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DevNoteAction {
-    pub seq:   u64,
+    pub seq: u64,
     pub action_h: BlockHeight,
     pub kind: DevNoteActionKind,
     pub note: DevNote,
@@ -683,7 +745,7 @@ pub struct WalletTx {
     pub account_id: usize,
     pub txid: zcash_protocol::TxId,
     pub expiry_h: Option<BlockHeight>,
-    pub h: BlockHeight,  // this is a logical height that is focused on ordering
+    pub h: BlockHeight, // this is a logical height that is focused on ordering
 
     // TODO: track whether full Transaction has been read
     pub is_coinbase: bool,
@@ -698,8 +760,11 @@ pub struct WalletTx {
     pub status: TxStatus,
     pub staking_action: Option<StakingAction>,
 }
-impl Default for WalletTx { fn default() -> Self { WalletTx::EMPTY } }
-
+impl Default for WalletTx {
+    fn default() -> Self {
+        WalletTx::EMPTY
+    }
+}
 
 impl WalletTx {
     const EMPTY: WalletTx = WalletTx {
@@ -724,38 +789,56 @@ impl WalletTx {
         self.status.is_on_bc()
     }
 
-    pub fn with_fake_data(kind: WalletTxKind, sent: u64, recv: u64, shielding: bool, is_outside_bc: bool, memo: &str, mined_h: u32) -> Self {
+    pub fn with_fake_data(
+        kind: WalletTxKind,
+        sent: u64,
+        recv: u64,
+        shielding: bool,
+        is_outside_bc: bool,
+        memo: &str,
+        mined_h: u32,
+    ) -> Self {
         let mut memo_as_bytes = EMPTY_MEMO_BYTES;
         &memo_as_bytes[0..memo.len()].copy_from_slice(memo.as_bytes());
 
         Self {
-            account_id: 0,//AccountUuid::default(),
+            account_id: 0, //AccountUuid::default(),
             txid: TxId::from_bytes([0; 32]),
             expiry_h: None,
-            h: if mined_h != 0 { (BlockHeight(mined_h)) } else { BlockHeight::MEMPOOL },
+            h: if mined_h != 0 {
+                (BlockHeight(mined_h))
+            } else {
+                BlockHeight::MEMPOOL
+            },
             part_flags: TxParts::FULL_TX,
             parts: [
-                WalletTxPart { // Transparent
+                WalletTxPart {
+                    // Transparent
                     spent_note_count: (sent > 0 && shielding) as usize,
-                    sent_note_count:  (sent > 0 && shielding) as usize,
-                    recv_note_count:  0,
+                    sent_note_count: (sent > 0 && shielding) as usize,
+                    recv_note_count: 0,
                     spent_zats: Zatoshis::from_u64(sent * shielding as u64).unwrap(),
-                    sent_zats:  Zatoshis::from_u64(sent * shielding as u64).unwrap(),
-                    recv_zats:  Zatoshis::ZERO,
+                    sent_zats: Zatoshis::from_u64(sent * shielding as u64).unwrap(),
+                    recv_zats: Zatoshis::ZERO,
                 },
-                WalletTxPart { // Shielded
+                WalletTxPart {
+                    // Shielded
                     spent_note_count: (sent > 0 && !shielding) as usize,
-                    sent_note_count:  (sent > 0 && !shielding) as usize,
-                    recv_note_count:  (recv > 0) as usize,
+                    sent_note_count: (sent > 0 && !shielding) as usize,
+                    recv_note_count: (recv > 0) as usize,
                     spent_zats: Zatoshis::from_u64(sent * !shielding as u64).unwrap(),
-                    sent_zats:  Zatoshis::from_u64(sent * !shielding as u64).unwrap(),
+                    sent_zats: Zatoshis::from_u64(sent * !shielding as u64).unwrap(),
                     recv_zats: Zatoshis::from_u64(if shielding { sent } else { recv }).unwrap(),
                 },
             ],
             memo_count: if memo.len() != 0 { 1 } else { 0 },
             memo: memo_as_bytes,
             is_coinbase: false,
-            status: if is_outside_bc { TxStatus::SoftFail(BlockHeight(mined_h)) } else { TxStatus::OnBc }, // may need to change...
+            status: if is_outside_bc {
+                TxStatus::SoftFail(BlockHeight(mined_h))
+            } else {
+                TxStatus::OnBc
+            }, // may need to change...
             staking_action: None,
         }
     }
@@ -773,7 +856,8 @@ impl WalletTx {
     pub fn account_value_delta(&self, include_staking: bool) -> ZatBalance {
         let all = self.totals(include_staking);
         // NOTE: into_i64 isn't pub...
-        ZatBalance::from_i64(all.recv_zats.into_u64() as i64 - all.spent_zats.into_u64() as i64).expect("checked before")
+        ZatBalance::from_i64(all.recv_zats.into_u64() as i64 - all.spent_zats.into_u64() as i64)
+            .expect("checked before")
     }
 
     pub fn fee(&self) -> Option<Zatoshis> {
@@ -821,7 +905,7 @@ impl WalletTx {
         // ALT: only consider it change if a single note is received (per pool?)
         let is_self_send = all.sent_zats == all.recv_zats;
         if is_self_send {
-            let all_spent_is_t     = self.parts[0].spent_zats == all.spent_zats;
+            let all_spent_is_t = self.parts[0].spent_zats == all.spent_zats;
             let all_recv_is_shield = self.parts[1].recv_zats == all.recv_zats;
             if all_spent_is_t && all_recv_is_shield && all.recv_zats > Zatoshis::ZERO {
                 WalletTxKind::Shield
@@ -835,24 +919,24 @@ impl WalletTx {
         }
     }
 
-//     pub fn loc(&self, finalized_h: BlockHeight, bc_tip_h: BlockHeight) -> (WalletTxLoc, u32, bool/*finalized*/, bool/*outside_bc*/) {
-//         match self.h {
-//             BlockHeight::MEMPOOL  => (WalletTxLoc::Mempool,  falsself.is_outside_bc),
-//             BlockHeight::INTERNAL => (WalletTxLoc::Internal, falsself.is_outside_bc),
-//             _ => {
-//                 if self.is_outside_bc {
-//                     (WalletTxLoc::Block(0), self.is_outside_bc)
-//                 } else if self.h > bc_tip_h {
-//                     println!("ERROR: mined h on best chain ({}) higher than tip ({})", self.h, bc_tip_h);
-//                     return (WalletTxLoc::Block(0), true);
-//                 } else if self.h <= finalized_h {
-//                     (WalletTxLoc::Finalized, self.is_outside_bc)
-//                 } else {
-//                     (WalletTxLoc::Block(bc_tip_h - self.h), self.is_outside_bc)
-//                 }
-//             }
-//         }
-//     }
+    //     pub fn loc(&self, finalized_h: BlockHeight, bc_tip_h: BlockHeight) -> (WalletTxLoc, u32, bool/*finalized*/, bool/*outside_bc*/) {
+    //         match self.h {
+    //             BlockHeight::MEMPOOL  => (WalletTxLoc::Mempool,  falsself.is_outside_bc),
+    //             BlockHeight::INTERNAL => (WalletTxLoc::Internal, falsself.is_outside_bc),
+    //             _ => {
+    //                 if self.is_outside_bc {
+    //                     (WalletTxLoc::Block(0), self.is_outside_bc)
+    //                 } else if self.h > bc_tip_h {
+    //                     println!("ERROR: mined h on best chain ({}) higher than tip ({})", self.h, bc_tip_h);
+    //                     return (WalletTxLoc::Block(0), true);
+    //                 } else if self.h <= finalized_h {
+    //                     (WalletTxLoc::Finalized, self.is_outside_bc)
+    //                 } else {
+    //                     (WalletTxLoc::Block(bc_tip_h - self.h), self.is_outside_bc)
+    //                 }
+    //             }
+    //         }
+    //     }
 }
 
 // @note(judah): needed so the visualizer doesn't take a dependency on zcash_primitives
@@ -870,21 +954,20 @@ pub struct WalletState {
     pub miner_shielded_pending_funds: u64,
     pub miner_shielded_spendable_funds: u64,
     // pub faucet_funds_available: u64,
-
     pub user_unshielded_funds: u64,
     pub user_shielded_pending_funds: u64,
     pub user_shielded_spendable_funds: u64,
 
-    pub staked_balance:  u64, // in zats
-    pub withdrawable_balance:  u64, // in zats
+    pub staked_balance: u64,       // in zats
+    pub withdrawable_balance: u64, // in zats
 
     pub user_local_txs_n: usize,
     pub user_local_txs: [WalletTx; 3],
-    pub user_txs:      Vec<WalletTx>,
+    pub user_txs: Vec<WalletTx>,
     pub miner_local_txs_n: usize,
     pub miner_local_txs: [WalletTx; 3],
-    pub miner_txs:     Vec<WalletTx>,
-    pub roster:        Vec<WalletRosterMember>,
+    pub miner_txs: Vec<WalletTx>,
+    pub roster: Vec<WalletRosterMember>,
 
     pub waiting_for_faucet: bool,
     pub waiting_for_stake_to_finalizer: bool,
@@ -897,8 +980,16 @@ pub struct WalletState {
 
     pub actions_in_flight: VecDeque<WalletAction>,
 
-    pub stake_positions_bonded: Vec<([u8; 32] /* bond key */, [u8; 32] /* target finalizer */, u64 /* initial */)>,
-    pub stake_positions_unbonded: Vec<([u8; 32] /* bond key */, [u8; 32] /* target finalizer */, u64 /* initial */)>,
+    pub stake_positions_bonded: Vec<(
+        [u8; 32], /* bond key */
+        [u8; 32], /* target finalizer */
+        u64,      /* initial */
+    )>,
+    pub stake_positions_unbonded: Vec<(
+        [u8; 32], /* bond key */
+        [u8; 32], /* target finalizer */
+        u64,      /* initial */
+    )>,
 }
 
 impl WalletState {
@@ -908,52 +999,117 @@ impl WalletState {
         }
     }
 
-    pub fn user_balance(&self)          -> u64 { self.user_unshielded_funds + self.user_shielded_spendable_funds + self.user_shielded_pending_funds }
-    pub fn user_pending_balance(&self)  -> u64 { self.user_shielded_pending_funds }
-    pub fn miner_balance(&self)         -> u64 { self.miner_unshielded_funds + self.miner_shielded_spendable_funds + self.miner_shielded_pending_funds }
-    pub fn miner_pending_balance(&self) -> u64 { self.miner_shielded_pending_funds }
+    pub fn user_balance(&self) -> u64 {
+        self.user_unshielded_funds
+            + self.user_shielded_spendable_funds
+            + self.user_shielded_pending_funds
+    }
+    pub fn user_pending_balance(&self) -> u64 {
+        self.user_shielded_pending_funds
+    }
+    pub fn miner_balance(&self) -> u64 {
+        self.miner_unshielded_funds
+            + self.miner_shielded_spendable_funds
+            + self.miner_shielded_pending_funds
+    }
+    pub fn miner_pending_balance(&self) -> u64 {
+        self.miner_shielded_pending_funds
+    }
 
     pub fn request_from_faucet(&mut self) {
         self.waiting_for_faucet = true;
 
-        if self.actions_in_flight.iter().filter(|a| match a { WalletAction::RequestFromFaucet => true, _ => false }).count() != 0 {
+        if self
+            .actions_in_flight
+            .iter()
+            .filter(|a| match a {
+                WalletAction::RequestFromFaucet => true,
+                _ => false,
+            })
+            .count()
+            != 0
+        {
             return;
         }
 
-        self.actions_in_flight.push_back(WalletAction::RequestFromFaucet);
+        self.actions_in_flight
+            .push_back(WalletAction::RequestFromFaucet);
     }
 
     pub fn stake_to_finalizer(&mut self, amount: u64, target_finalizer: [u8; 32]) {
-        if self.actions_in_flight.iter().filter(|a| match a { WalletAction::StakeToFinalizer(_,_) => true, _ => false }).count() != 0 {
+        if self
+            .actions_in_flight
+            .iter()
+            .filter(|a| match a {
+                WalletAction::StakeToFinalizer(_, _) => true,
+                _ => false,
+            })
+            .count()
+            != 0
+        {
             return;
         }
 
         self.waiting_for_stake_to_finalizer = true;
-        self.actions_in_flight.push_back(WalletAction::StakeToFinalizer(Zatoshis::from_u64(amount).expect("Invalid amount given to stake_to_finalizer"), target_finalizer));
+        self.actions_in_flight
+            .push_back(WalletAction::StakeToFinalizer(
+                Zatoshis::from_u64(amount).expect("Invalid amount given to stake_to_finalizer"),
+                target_finalizer,
+            ));
     }
 
     pub fn unstake_from_finalizer(&mut self, txid: [u8; 32]) {
         let txid = TxId::from_bytes(txid);
-        if self.actions_in_flight.iter().filter(|a| match a { WalletAction::UnstakeFromFinalizer(id) if id.eq(&txid) => true, _ => false }).count() != 0 {
+        if self
+            .actions_in_flight
+            .iter()
+            .filter(|a| match a {
+                WalletAction::UnstakeFromFinalizer(id) if id.eq(&txid) => true,
+                _ => false,
+            })
+            .count()
+            != 0
+        {
             return;
         }
-        self.actions_in_flight.push_back(WalletAction::UnstakeFromFinalizer(txid));
+        self.actions_in_flight
+            .push_back(WalletAction::UnstakeFromFinalizer(txid));
     }
 
     pub fn retarget_bond(&mut self, txid: [u8; 32], new_target: [u8; 32]) {
         let txid = TxId::from_bytes(txid);
-        if self.actions_in_flight.iter().filter(|a| match a { WalletAction::RetargetBond(id, _to) if id.eq(&txid) => true, _ => false }).count() != 0 {
+        if self
+            .actions_in_flight
+            .iter()
+            .filter(|a| match a {
+                WalletAction::RetargetBond(id, _to) if id.eq(&txid) => true,
+                _ => false,
+            })
+            .count()
+            != 0
+        {
             return;
         }
-        self.actions_in_flight.push_back(WalletAction::RetargetBond(txid, new_target));
+        self.actions_in_flight
+            .push_back(WalletAction::RetargetBond(txid, new_target));
     }
 
     pub fn claim_bond(&mut self, txid: [u8; 32]) {
         let txid = TxId::from_bytes(txid);
-        if self.actions_in_flight.iter().filter(|a| match a { WalletAction::ClaimBond(id) if id.eq(&txid) => true, _ => false }).count() != 0 {
+        if self
+            .actions_in_flight
+            .iter()
+            .filter(|a| match a {
+                WalletAction::ClaimBond(id) if id.eq(&txid) => true,
+                _ => false,
+            })
+            .count()
+            != 0
+        {
             return;
         }
-        self.actions_in_flight.push_back(WalletAction::ClaimBond(txid));
+        self.actions_in_flight
+            .push_back(WalletAction::ClaimBond(txid));
     }
 
     pub fn send_to_address(&mut self, address: String, amount: u64) {
@@ -962,15 +1118,29 @@ impl WalletState {
             return;
         };
 
-        if self.actions_in_flight.iter().filter(|a| match a {
-            WalletAction::SendToAddress(addr, amt) if amt.into_u64() == amount && addr.eq(&address) => true,
-            _ => false
-        }).count() != 0 {
+        if self
+            .actions_in_flight
+            .iter()
+            .filter(|a| match a {
+                WalletAction::SendToAddress(addr, amt)
+                    if amt.into_u64() == amount && addr.eq(&address) =>
+                {
+                    true
+                }
+                _ => false,
+            })
+            .count()
+            != 0
+        {
             return;
         }
 
         self.waiting_for_send = true;
-        self.actions_in_flight.push_back(WalletAction::SendToAddress(address, Zatoshis::from_u64(amount).expect("Invalid amount given to stake_to_finalizer")));
+        self.actions_in_flight
+            .push_back(WalletAction::SendToAddress(
+                address,
+                Zatoshis::from_u64(amount).expect("Invalid amount given to stake_to_finalizer"),
+            ));
     }
 }
 
@@ -994,7 +1164,7 @@ enum TxOutput {
         dst: orchard::Address,
         zats: Zatoshis,
         memo: MemoBytes,
-    }
+    },
 }
 
 struct TxOptions<'a> {
@@ -1016,7 +1186,7 @@ impl<'a> Default for TxOptions<'a> {
     }
 }
 
-pub static wallet_main_zaino_port : Mutex<u16> = Mutex::new(0);
+pub static wallet_main_zaino_port: Mutex<u16> = Mutex::new(0);
 
 pub enum TxPool<'a> {
     Transparent,
@@ -1026,24 +1196,39 @@ pub enum TxPool<'a> {
     Orchard(&'a OrchardShardTree),
 }
 
-fn transparent_keys_from_usk(usk: &UnifiedSpendingKey, index: u32) -> Option<(secp256k1::PublicKey, secp256k1::SecretKey)> {
+fn transparent_keys_from_usk(
+    usk: &UnifiedSpendingKey,
+    index: u32,
+) -> Option<(secp256k1::PublicKey, secp256k1::SecretKey)> {
     let transparent = usk.transparent();
     let account_pubkey = transparent.to_account_pubkey();
     let child_index = NonHardenedChildIndex::const_from_index(index);
-    let address_pubkey = account_pubkey.derive_address_pubkey(TransparentKeyScope::EXTERNAL, child_index).ok()?;
+    let address_pubkey = account_pubkey
+        .derive_address_pubkey(TransparentKeyScope::EXTERNAL, child_index)
+        .ok()?;
     let address_privkey = transparent.derive_external_secret_key(child_index).ok()?;
     Some((address_pubkey, address_privkey))
 }
 
-fn addrs_from_account(account: &ManualAccount, index: u32) -> Option<(TransparentAddress, UnifiedAddress)> {
+fn addrs_from_account(
+    account: &ManualAccount,
+    index: u32,
+) -> Option<(TransparentAddress, UnifiedAddress)> {
     // NOTE: the wallet auto-increments the child index so this isn't recognized
     let ufvk = &account.ufvk;
-    let (ua, di_) = ufvk.find_address(orchard::keys::DiversifierIndex::new(), UnifiedAddressRequest::ORCHARD).ok()?;
+    let (ua, di_) = ufvk
+        .find_address(
+            orchard::keys::DiversifierIndex::new(),
+            UnifiedAddressRequest::ORCHARD,
+        )
+        .ok()?;
     let account_pubkey = ufvk.transparent()?;
     let child_index = NonHardenedChildIndex::const_from_index(index);
-    let address_pubkey = account_pubkey.derive_address_pubkey(TransparentKeyScope::EXTERNAL, child_index).ok()?;
+    let address_pubkey = account_pubkey
+        .derive_address_pubkey(TransparentKeyScope::EXTERNAL, child_index)
+        .ok()?;
     Some((TransparentAddress::from_pubkey(&address_pubkey), ua))
-        // Some(account.default_address().ok()??.0)
+    // Some(account.default_address().ok()??.0)
 }
 
 fn update_insert_i(txs: &[WalletTx], insert_i: &mut usize, block_h: BlockHeight) {
@@ -1053,23 +1238,27 @@ fn update_insert_i(txs: &[WalletTx], insert_i: &mut usize, block_h: BlockHeight)
 }
 
 fn update_with_tx(wallet: &mut ManualWallet, mut new_tx: WalletTx, insert_i: &mut usize) {
-    if AUDIT_TXS { wallet.audit_tx(&new_tx); } // pre-edit
+    if AUDIT_TXS {
+        wallet.audit_tx(&new_tx);
+    } // pre-edit
 
     let txid = new_tx.txid;
     // find if there's an existing height/transaction for this txid
     // NOTE: we ignore staking here because we don't track if they're ours properly without
     // signatures, and we always spend for fee or receive in orchard with them
     let new_totals = new_tx.totals(false);
-    if (new_totals.spent_note_count == 0 &&
-        new_totals.recv_note_count == 0 &&
-        new_totals.sent_note_count == 0)
+    if (new_totals.spent_note_count == 0
+        && new_totals.recv_note_count == 0
+        && new_totals.sent_note_count == 0)
     {
         // not our transaction; ignore
         return;
     }
     // TODO: more specifics on the staking action check
     // debug_assert!(new_totals.sent_zats == Zatoshis::const_from_u64(0) || new_totals.sent_zats < new_totals.spent_zats, "must spend for send");
-    if !(new_totals.sent_zats == Zatoshis::const_from_u64(0) || new_totals.sent_zats < new_totals.spent_zats) {
+    if !(new_totals.sent_zats == Zatoshis::const_from_u64(0)
+        || new_totals.sent_zats < new_totals.spent_zats)
+    {
         println!("TX ERROR: no spend seen for send {new_totals:?}")
     }
 
@@ -1084,27 +1273,37 @@ fn update_with_tx(wallet: &mut ManualWallet, mut new_tx: WalletTx, insert_i: &mu
                 }
 
                 if DUMP_TX_RECV {
-                    println!("{} wallet updated existing transaction {txid} {:?} => {:?}", wallet.name, old_tx.h, new_tx.h);
+                    println!(
+                        "{} wallet updated existing transaction {txid} {:?} => {:?}",
+                        wallet.name, old_tx.h, new_tx.h
+                    );
                 }
                 // println!("{} wallet updated existing transaction {txid} {old_tx:?} => {new_tx:?}", wallet.name);
 
                 // leave the tx-parts from the components not provided here
                 if (new_tx.part_flags & TxParts::TRANSPARENT) == 0 {
-                    new_tx.parts[WalletTxPart::TRANSPARENT] = old_tx.parts[WalletTxPart::TRANSPARENT];
+                    new_tx.parts[WalletTxPart::TRANSPARENT] =
+                        old_tx.parts[WalletTxPart::TRANSPARENT];
                 }
                 if (new_tx.part_flags & TxParts::SHIELDED_RECV) == 0 {
-                    new_tx.parts[WalletTxPart::SHIELDED].recv_note_count = old_tx.parts[WalletTxPart::SHIELDED].recv_note_count;
-                    new_tx.parts[WalletTxPart::SHIELDED].recv_zats = old_tx.parts[WalletTxPart::SHIELDED].recv_zats;
+                    new_tx.parts[WalletTxPart::SHIELDED].recv_note_count =
+                        old_tx.parts[WalletTxPart::SHIELDED].recv_note_count;
+                    new_tx.parts[WalletTxPart::SHIELDED].recv_zats =
+                        old_tx.parts[WalletTxPart::SHIELDED].recv_zats;
                 }
                 if (new_tx.part_flags & TxParts::SHIELDED_SENT) == 0 {
-                    new_tx.parts[WalletTxPart::SHIELDED].spent_note_count = old_tx.parts[WalletTxPart::SHIELDED].spent_note_count;
-                    new_tx.parts[WalletTxPart::SHIELDED].spent_zats       = old_tx.parts[WalletTxPart::SHIELDED].spent_zats;
-                    new_tx.parts[WalletTxPart::SHIELDED].sent_note_count  = old_tx.parts[WalletTxPart::SHIELDED].sent_note_count;
-                    new_tx.parts[WalletTxPart::SHIELDED].sent_zats        = old_tx.parts[WalletTxPart::SHIELDED].sent_zats;
+                    new_tx.parts[WalletTxPart::SHIELDED].spent_note_count =
+                        old_tx.parts[WalletTxPart::SHIELDED].spent_note_count;
+                    new_tx.parts[WalletTxPart::SHIELDED].spent_zats =
+                        old_tx.parts[WalletTxPart::SHIELDED].spent_zats;
+                    new_tx.parts[WalletTxPart::SHIELDED].sent_note_count =
+                        old_tx.parts[WalletTxPart::SHIELDED].sent_note_count;
+                    new_tx.parts[WalletTxPart::SHIELDED].sent_zats =
+                        old_tx.parts[WalletTxPart::SHIELDED].sent_zats;
                 }
                 if (new_tx.part_flags & TxParts::MEMO) == 0 {
                     new_tx.memo_count = old_tx.memo_count;
-                    new_tx.memo       = old_tx.memo;
+                    new_tx.memo = old_tx.memo;
                 }
                 if (new_tx.part_flags & TxParts::STAKING_ACTION) == 0 {
                     new_tx.staking_action = old_tx.staking_action;
@@ -1133,15 +1332,22 @@ fn update_with_tx(wallet: &mut ManualWallet, mut new_tx: WalletTx, insert_i: &mu
     } else {
         wallet.tx_h_map.insert(txid, new_tx.h);
         if DUMP_TX_RECV {
-            println!("{} wallet inserted new transaction {txid} at {:?}", wallet.name, new_tx.h);
+            println!(
+                "{} wallet inserted new transaction {txid} at {:?}",
+                wallet.name, new_tx.h
+            );
         }
     }
 
-    if AUDIT_TXS { wallet.audit_tx(&new_tx); } // post-edit
+    if AUDIT_TXS {
+        wallet.audit_tx(&new_tx);
+    } // post-edit
     wallet.txs.insert(*insert_i, new_tx);
     *insert_i += 1;
 
-    if AUDIT_TXS { wallet.audit_txs(); }
+    if AUDIT_TXS {
+        wallet.audit_txs();
+    }
 }
 
 fn to_zats_or_dump_err(src: &str, z: u64) -> Option<Zatoshis> {
@@ -1190,11 +1396,19 @@ pub struct ManualAccount {
 }
 
 #[cfg(debug_assertions)]
-pub struct NoteLog(Option<HashMap<(TxId, &'static str), Vec<DevNoteAction>>>, u64);
+pub struct NoteLog(
+    Option<HashMap<(TxId, &'static str), Vec<DevNoteAction>>>,
+    u64,
+);
 
 #[cfg(debug_assertions)]
 impl NoteLog {
-    pub fn get_expected<'a>(&'a mut self, wallet_name: &'static str, txid: &TxId, action: &str) -> Option<(&'a mut Vec<DevNoteAction>, u64)> {
+    pub fn get_expected<'a>(
+        &'a mut self,
+        wallet_name: &'static str,
+        txid: &TxId,
+        action: &str,
+    ) -> Option<(&'a mut Vec<DevNoteAction>, u64)> {
         if self.0.is_none() {
             self.0 = Some(HashMap::new());
         }
@@ -1209,22 +1423,30 @@ impl NoteLog {
         }
     }
 
-    pub fn get_or_new<'a>(&'a mut self, wallet_name: &'static str, txid: &TxId, action: &str) -> (&'a mut Vec<DevNoteAction>, u64) {
+    pub fn get_or_new<'a>(
+        &'a mut self,
+        wallet_name: &'static str,
+        txid: &TxId,
+        action: &str,
+    ) -> (&'a mut Vec<DevNoteAction>, u64) {
         if self.0.is_none() {
             self.0 = Some(HashMap::new());
         }
 
         let seq = self.1;
         self.1 += 1;
-        let log = self.0.as_mut().unwrap().entry((*txid, wallet_name)).or_insert(Vec::new());
+        let log = self
+            .0
+            .as_mut()
+            .unwrap()
+            .entry((*txid, wallet_name))
+            .or_insert(Vec::new());
         (log, seq)
     }
 }
 
 #[cfg(debug_assertions)]
 static NOTE_LOG: Mutex<NoteLog> = Mutex::new(NoteLog(None, 0));
-
-
 
 // NOTE: WalletDb doesn't store spending key, so we'll do the same here...
 #[derive(Clone, Debug)]
@@ -1251,13 +1473,14 @@ pub struct ManualWallet {
     // - any best-chain block
     // - best-chain block confirmed by N
     // - finalized block
-
     pub seen_bond_values: HashMap<[u8; 32], u64>,
     pub care_about_bonds: Vec<[u8; 32]>,
 }
 // N.B. using some of the same API as WalletDb to allow smooth transition/comparison
 impl ManualWallet {
-    pub fn chain_height(&self)          -> BlockHeight { self.chain_tip_h }
+    pub fn chain_height(&self) -> BlockHeight {
+        self.chain_tip_h
+    }
     pub fn fully_detected_height(&self) -> BlockHeight {
         let mut h = BlockHeight(0);
         for account in &self.accounts {
@@ -1275,10 +1498,16 @@ impl ManualWallet {
     }
 
     // TODO: confirmations_policy should be overridden by finalized height
-    pub fn get_wallet_summary(&self, confirmations_policy: ConfirmationsPolicy) -> Result<Option<data_api::WalletSummary<usize>>, Infallible> {
+    pub fn get_wallet_summary(
+        &self,
+        confirmations_policy: ConfirmationsPolicy,
+    ) -> Result<Option<data_api::WalletSummary<usize>>, Infallible> {
         let mut account_balances = HashMap::with_capacity(self.accounts.len());
         for account_i in 0..self.accounts.len() {
-            account_balances.insert(account_i, self.accounts[account_i].balance_changes.last().unwrap().1);
+            account_balances.insert(
+                account_i,
+                self.accounts[account_i].balance_changes.last().unwrap().1,
+            );
         }
 
         Ok(Some(data_api::WalletSummary::new(
@@ -1286,19 +1515,28 @@ impl ManualWallet {
             LRZBlockHeight::from_u32(self.chain_tip_h.0),
             LRZBlockHeight::from_u32(self.fully_decoded_height().0), // TODO: fully_detected_height?
             // ignored:
-            data_api::Progress::new(data_api::Ratio::new(0,0), None),
-            0,// sapling subtree
-            0,// orchard subtree
+            data_api::Progress::new(data_api::Ratio::new(0, 0), None),
+            0, // sapling subtree
+            0, // orchard subtree
         )))
     }
 
     // TODO: always return full tx if created
-    async fn send_built_tx<P: Parameters>(&mut self, network: P, client: &mut CompactTxStreamerClient<Channel>, wallet_tx: &mut WalletTx, tx: &Transaction) -> bool {
+    async fn send_built_tx<P: Parameters>(
+        &mut self,
+        network: P,
+        client: &mut CompactTxStreamerClient<Channel>,
+        wallet_tx: &mut WalletTx,
+        tx: &Transaction,
+    ) -> bool {
         let tz = Timer::scope_("send_built_tx", DUMP_TX_SEND);
 
         //-- EXPENSIVE NETWORK SEND
         // TODO: don't block, maybe return a future?
-        let mut raw_tx = RawTransaction{ data: Vec::new(), height: 0 };
+        let mut raw_tx = RawTransaction {
+            data: Vec::new(),
+            height: 0,
+        };
         if let Err(err) = tx.write(&mut raw_tx.data) {
             println!("couldn't serialize transaction for network send: {err:?}");
             let err_buf = ErrBuf::from_str(&format!("couldn't serialize: {err:?}"));
@@ -1306,7 +1544,9 @@ impl ManualWallet {
             wallet_tx.h = self.chain_tip_h; // TODO: this should maybe be "sync'd height"
         } else {
             let res = client.send_transaction(raw_tx).await;
-            if DUMP_TX_SEND { println!("******* res for {:?}: {:?}", tx.txid(), res); }
+            if DUMP_TX_SEND {
+                println!("******* res for {:?}: {:?}", tx.txid(), res);
+            }
             // TODO: distinguish sends that weren't network issues
             if res.is_ok() {
                 wallet_tx.h = BlockHeight::SENT;
@@ -1319,14 +1559,25 @@ impl ManualWallet {
         wallet_tx.is_on_bc()
     }
 
-    fn build_tx_from_prep<P: Parameters>(&mut self, network: P, tx: &mut ProposedTx, prep: BuildPrep) -> bool {
+    fn build_tx_from_prep<P: Parameters>(
+        &mut self,
+        network: P,
+        tx: &mut ProposedTx,
+        prep: BuildPrep,
+    ) -> bool {
         let tz = Timer::scope_("build_tx_from_prep", DUMP_TX_SEND | DUMP_TX_BUILD);
         let prep_fee = prep.fee_required();
 
-        let BuildPrep{
-            block_h, build_config,
-            t_keys, s_keys, o_keys,
-            t_inputs, t_outputs, o_inputs, o_outputs,
+        let BuildPrep {
+            block_h,
+            build_config,
+            t_keys,
+            s_keys,
+            o_keys,
+            t_inputs,
+            t_outputs,
+            o_inputs,
+            o_outputs,
             staking_action,
         } = prep;
 
@@ -1335,48 +1586,78 @@ impl ManualWallet {
         for t_input in t_inputs {
             let (outpoint, coin) = (t_input.outpoint().clone(), t_input.coin().clone());
             if let Err(err) = match t_input.kind() {
-                &TransparentInputKind::P2pkh{ pubkey } => txb.add_transparent_input(pubkey, outpoint, coin),
-                TransparentInputKind::P2sh{ redeem_script } => txb.add_transparent_p2sh_input(redeem_script.clone(), outpoint, coin),
+                &TransparentInputKind::P2pkh { pubkey } => {
+                    txb.add_transparent_input(pubkey, outpoint, coin)
+                }
+                TransparentInputKind::P2sh { redeem_script } => {
+                    txb.add_transparent_p2sh_input(redeem_script.clone(), outpoint, coin)
+                }
             } {
-                if DUMP_TX_BUILD { println!("constructing transparent input: {err:?}"); }
+                if DUMP_TX_BUILD {
+                    println!("constructing transparent input: {err:?}");
+                }
                 return false;
             }
         }
 
-        for ProposedTransparentOutput{ dst, zats } in t_outputs {
+        for ProposedTransparentOutput { dst, zats } in t_outputs {
             if let Err(err) = txb.add_transparent_output(&dst, zats) {
-                if DUMP_TX_BUILD { println!("constructing transparent output: {err:?}"); }
+                if DUMP_TX_BUILD {
+                    println!("constructing transparent output: {err:?}");
+                }
                 return false;
             }
         }
 
-        for ProposedOrchardSpend{ fvk, note, witness_merkle_path } in o_inputs {
-            if let Err(err) = txb.add_orchard_spend::<zip317::FeeError>(fvk, note.note, witness_merkle_path) {
-                if DUMP_TX_BUILD { println!("constructing orchard spend: {err:?}"); }
+        for ProposedOrchardSpend {
+            fvk,
+            note,
+            witness_merkle_path,
+        } in o_inputs
+        {
+            if let Err(err) =
+                txb.add_orchard_spend::<zip317::FeeError>(fvk, note.note, witness_merkle_path)
+            {
+                if DUMP_TX_BUILD {
+                    println!("constructing orchard spend: {err:?}");
+                }
                 return false;
             }
         }
 
-        for ProposedOrchardOutput{ ovk, dst, zats, memo: spend_memo } in o_outputs {
-            if let Err(err) = txb.add_orchard_output::<zip317::FeeError>(ovk, dst, zats.into_u64(), spend_memo) {
-                if DUMP_TX_BUILD { println!("constructing orchard output: {err:?}"); }
+        for ProposedOrchardOutput {
+            ovk,
+            dst,
+            zats,
+            memo: spend_memo,
+        } in o_outputs
+        {
+            if let Err(err) =
+                txb.add_orchard_output::<zip317::FeeError>(ovk, dst, zats.into_u64(), spend_memo)
+            {
+                if DUMP_TX_BUILD {
+                    println!("constructing orchard output: {err:?}");
+                }
                 return false;
             }
         }
 
         if let Some(staking_action) = staking_action {
             if let Err(err) = txb.put_staking_action(staking_action) {
-                if DUMP_TX_BUILD { println!("constructing staking action: {err:?}"); }
+                if DUMP_TX_BUILD {
+                    println!("constructing staking action: {err:?}");
+                }
                 return false;
             }
         }
 
         if let Ok(txb_fee) = txb.get_fee(&zip317::FeeRule::standard()) {
             if prep_fee.is_err() || &txb_fee != prep_fee.as_ref().unwrap() {
-                println!("WARNING: fees calculated in 2 ways don't match: {txb_fee:?} vs {prep_fee:?}");
+                println!(
+                    "WARNING: fees calculated in 2 ways don't match: {txb_fee:?} vs {prep_fee:?}"
+                );
             }
         }
-
 
         //-- VERY EXPENSIVE TX CREATION (PARTICULARLY IF SHIELDED OUTPUT)
         use rand_chacha::ChaCha20Rng;
@@ -1410,15 +1691,18 @@ impl ManualWallet {
         }
     }
 
-
     // TODO: fee API (need to account for paying for fee forcing more notes, changing the fee)
     // TODO: allow one destination to have an empty value for "send the rest here" (this could be
     // change or normal recipient)
     pub fn send_zats_no_insert<P: Parameters>(
-        &mut self, network: P, tx: &mut ProposedTx, client: &mut CompactTxStreamerClient<Channel>, outputs: &[TxOutput],
-        src_usk: &UnifiedSpendingKey, opts: &TxOptions<'_>
-    ) -> Option<()>
-    {
+        &mut self,
+        network: P,
+        tx: &mut ProposedTx,
+        client: &mut CompactTxStreamerClient<Channel>,
+        outputs: &[TxOutput],
+        src_usk: &UnifiedSpendingKey,
+        opts: &TxOptions<'_>,
+    ) -> Option<()> {
         let block_h = self.chain_tip_h.0 + 1;
 
         let account_id = 0;
@@ -1458,7 +1742,10 @@ impl ManualWallet {
                     // - spendable note heights (must be higher than all needed)
                     //   - more notes needed if fees change -> change in anchor
                     orchard_anchor_h = self.chain_tip_h.sat_sub(1);
-                    orchard_anchor = match shardtree.root_at_checkpoint_id(&orchard_anchor_h).expect("Infallible MemoryShardStore") {
+                    orchard_anchor = match shardtree
+                        .root_at_checkpoint_id(&orchard_anchor_h)
+                        .expect("Infallible MemoryShardStore")
+                    {
                         Some(root) => orchard::Anchor::from(root),
                         None => {
                             println!("tx build: couldn't get anchor at {orchard_anchor_h:?}");
@@ -1474,7 +1761,9 @@ impl ManualWallet {
         let mut t_pubkey = None;
         if has_transparent_src {
             let Some((pubkey, privkey)) = transparent_keys_from_usk(&src_usk, 0) else {
-                println!("tried to send from transparent source without available transparent keys");
+                println!(
+                    "tried to send from transparent source without available transparent keys"
+                );
                 return None;
             };
             signing_set.add_key(privkey);
@@ -1482,7 +1771,10 @@ impl ManualWallet {
         }
 
         let mut prep = BuildPrep {
-            build_config: BuildConfig::Standard { sapling_anchor, orchard_anchor: Some(orchard_anchor), },
+            build_config: BuildConfig::Standard {
+                sapling_anchor,
+                orchard_anchor: Some(orchard_anchor),
+            },
             block_h,
 
             t_keys: signing_set,
@@ -1499,7 +1791,7 @@ impl ManualWallet {
         let mut txb = TxBuilder::new(
             network,
             LRZBlockHeight::from_u32(block_h),
-            prep.build_config
+            prep.build_config,
         );
 
         let (mut t, mut s, mut b) = (WalletTxPart::ZERO, WalletTxPart::ZERO, WalletTxPart::ZERO);
@@ -1512,10 +1804,21 @@ impl ManualWallet {
             StakingActionKind::Null => (),
 
             StakingActionKind::CreateNewDelegationBond => {
-                b.sent(to_zats_or_dump_err("tx build: new bond", staking_action.amount_zats)?, true)?;
-                b.recv(to_zats_or_dump_err("tx build: new bond", staking_action.amount_zats)?, true)?;
-                if DUMP_TX_BUILD { println!("  added new staking position: {}", staking_action.amount_zats); }
-            },
+                b.sent(
+                    to_zats_or_dump_err("tx build: new bond", staking_action.amount_zats)?,
+                    true,
+                )?;
+                b.recv(
+                    to_zats_or_dump_err("tx build: new bond", staking_action.amount_zats)?,
+                    true,
+                )?;
+                if DUMP_TX_BUILD {
+                    println!(
+                        "  added new staking position: {}",
+                        staking_action.amount_zats
+                    );
+                }
+            }
 
             StakingActionKind::BeginDelegationUnbonding => {
                 // let txid = TxId::from_bytes(staking_action.arg32_0);
@@ -1526,8 +1829,10 @@ impl ManualWallet {
                 // };
                 // no direct send - fee for transitioning between 2 pools we don't touch directly
                 // TODO: (fallback to) pay for fee from bond?
-                if DUMP_TX_BUILD { println!("  unstaking bond: {}", staking_action.amount_zats); }
-            },
+                if DUMP_TX_BUILD {
+                    println!("  unstaking bond: {}", staking_action.amount_zats);
+                }
+            }
 
             StakingActionKind::RetargetDelegationBond => {
                 // let txid = TxId::from_bytes(staking_action.arg32_0);
@@ -1538,26 +1843,42 @@ impl ManualWallet {
                 // };
                 // no direct send - fee for transitioning between 2 pools we don't touch directly
                 // TODO: (fallback to) pay for fee from bond?
-                if DUMP_TX_BUILD { println!("  unstaking bond: {}", staking_action.amount_zats); }
-            },
+                if DUMP_TX_BUILD {
+                    println!("  unstaking bond: {}", staking_action.amount_zats);
+                }
+            }
 
             StakingActionKind::WithdrawDelegationBond => {
                 let bond_key = &staking_action.arg32_0; // TODO is this always true?
-                // TODO: check it hasn't already been unbonded
-                let Some(bond_tx) = self.txs.iter().find(|t| t.staking_action.filter(|s| s.kind == StakingActionKind::BeginDelegationUnbonding).map(|s| s.arg32_0).unwrap_or_default() == *bond_key) else {
-                    println!("Could not find bond {:?} that was ready to claim.", bond_key);
+                                                        // TODO: check it hasn't already been unbonded
+                let Some(bond_tx) = self.txs.iter().find(|t| {
+                    t.staking_action
+                        .filter(|s| s.kind == StakingActionKind::BeginDelegationUnbonding)
+                        .map(|s| s.arg32_0)
+                        .unwrap_or_default()
+                        == *bond_key
+                }) else {
+                    println!(
+                        "Could not find bond {:?} that was ready to claim.",
+                        bond_key
+                    );
                     return None;
                 };
 
                 // fee comes from bond itself
                 // TODO: does this now have the correct amount?
-                b.spent(to_zats_or_dump_err("tx build: new bond", staking_action.amount_zats)?, true)?;
-                if DUMP_TX_BUILD { println!("  withdrawing bond: {}", staking_action.amount_zats); }
-            },
+                b.spent(
+                    to_zats_or_dump_err("tx build: new bond", staking_action.amount_zats)?,
+                    true,
+                )?;
+                if DUMP_TX_BUILD {
+                    println!("  withdrawing bond: {}", staking_action.amount_zats);
+                }
+            }
 
-            StakingActionKind::RegisterFinalizer |
-            StakingActionKind::ConvertFinalizerRewardToDelegationBond |
-            StakingActionKind::UpdateFinalizerKey => todo!("remaining staking actions"),
+            StakingActionKind::RegisterFinalizer
+            | StakingActionKind::ConvertFinalizerRewardToDelegationBond
+            | StakingActionKind::UpdateFinalizerKey => todo!("remaining staking actions"),
         }
 
         let staking_action = if staking_action.kind != StakingActionKind::Null {
@@ -1574,7 +1895,7 @@ impl ManualWallet {
 
         for output in outputs {
             match output {
-                &TxOutput::Transparent{ dst, zats } => {
+                &TxOutput::Transparent { dst, zats } => {
                     t.sent(zats, true)?;
                     let is_to_me = (dst == t_addr); // TODO: more comprehensive address matching
                     t.maybe_recv(is_to_me, zats, true)?;
@@ -1583,10 +1904,17 @@ impl ManualWallet {
                         println!("tx build error: {err:?}");
                         return None;
                     }
-                    prep.t_outputs.push(ProposedTransparentOutput{ dst, zats });
-                    if DUMP_TX_BUILD { println!("  added transparent output: {}", zats.into_u64()); }
+                    prep.t_outputs.push(ProposedTransparentOutput { dst, zats });
+                    if DUMP_TX_BUILD {
+                        println!("  added transparent output: {}", zats.into_u64());
+                    }
                 }
-                &TxOutput::Orchard{ ref ovk, dst, zats, memo: ref note_memo } => {
+                &TxOutput::Orchard {
+                    ref ovk,
+                    dst,
+                    zats,
+                    memo: ref note_memo,
+                } => {
                     s.sent(zats, true)?;
                     let is_to_me = (dst == *orchard_addr); // TODO: more comprehensive address matching
                     s.maybe_recv(is_to_me, zats, true)?;
@@ -1594,17 +1922,27 @@ impl ManualWallet {
                     tx.tx.memo_count += !memo_is_empty(note_memo.as_array()) as usize;
                     tx.tx.memo = *note_memo.as_array(); // TODO: handle multiple memos
 
-                    if let Err(err) = txb.add_orchard_output::<zip317::FeeError>(ovk.clone(), dst.clone(), zats.into_u64(), note_memo.clone()) {
+                    if let Err(err) = txb.add_orchard_output::<zip317::FeeError>(
+                        ovk.clone(),
+                        dst.clone(),
+                        zats.into_u64(),
+                        note_memo.clone(),
+                    ) {
                         println!("tx build error: {err:?}");
                         return None;
                     }
-                    prep.o_outputs.push(ProposedOrchardOutput{ ovk: ovk.clone(), dst: dst.clone(), zats, memo: note_memo.clone() });
-                    if DUMP_TX_BUILD { println!("  added orchard output: {}", zats.into_u64()); }
+                    prep.o_outputs.push(ProposedOrchardOutput {
+                        ovk: ovk.clone(),
+                        dst: dst.clone(),
+                        zats,
+                        memo: note_memo.clone(),
+                    });
+                    if DUMP_TX_BUILD {
+                        println!("  added orchard output: {}", zats.into_u64());
+                    }
                 }
             }
         }
-
-
 
         //- SPENDS
         // TODO: use fee_required with our own data directly
@@ -1614,8 +1952,8 @@ impl ManualWallet {
             let prep_fee = prep.fee_required();
             let dbg_prep_fee = prep_fee.as_ref().map(|z| z.into_u64()).unwrap_or(0);
             debug_assert!(
-                (prep_fee.is_err() && txb_fee.is_err()) ||
-                (prep_fee.as_ref().unwrap() == txb_fee.as_ref().unwrap()),
+                (prep_fee.is_err() && txb_fee.is_err())
+                    || (prep_fee.as_ref().unwrap() == txb_fee.as_ref().unwrap()),
                 "prep_fee {prep_fee:?}, txb_fee {txb_fee:?}"
             );
 
@@ -1635,17 +1973,20 @@ impl ManualWallet {
                 // TODO: account for notes that shouldn't be spent yet
                 // - not enough confirmations
                 // - used in another transaction that we've built
-
                 TxPool::Transparent => {
                     let t_pubkey = t_pubkey.expect("checked above");
                     // "greedy strategy"
                     for utxo in &account.utxos {
-                        if let Err(err) = txb.add_transparent_input(t_pubkey, utxo.id.clone(), utxo.txout()) {
+                        if let Err(err) =
+                            txb.add_transparent_input(t_pubkey, utxo.id.clone(), utxo.txout())
+                        {
                             println!("tx build: transparent/UTXO spend failed: {err:?}");
                             continue;
                         }
                         t.spent(utxo.value, true)?;
-                        if DUMP_TX_BUILD { println!("  added transparent spend: {}", utxo.value.into_u64()); }
+                        if DUMP_TX_BUILD {
+                            println!("  added transparent spend: {}", utxo.value.into_u64());
+                        }
 
                         prep.t_inputs = txb.transparent_inputs().to_vec(); // ALT: do something *not* bad
 
@@ -1674,9 +2015,13 @@ impl ManualWallet {
                         shuffled_notes.shuffle(&mut OsRng);
 
                         for &note in &shuffled_notes {
-                            if note.recv_h > orchard_anchor_h { continue; }
+                            if note.recv_h > orchard_anchor_h {
+                                continue;
+                            }
 
-                            let witness = match tree.witness_at_checkpoint_id(note.position, &orchard_anchor_h) {
+                            let witness = match tree
+                                .witness_at_checkpoint_id(note.position, &orchard_anchor_h)
+                            {
                                 // NOTE: presumably can fail from too-recent note
                                 Ok(Some(witness)) => witness,
                                 Ok(None) => {
@@ -1689,19 +2034,31 @@ impl ManualWallet {
                                 }
                             };
                             let merkle_path = orchard::tree::MerklePath::from(witness);
-                            if let Err(err) = txb.add_orchard_spend::<zip317::FeeError>(fvk.clone(), note.note, merkle_path.clone()) {
+                            if let Err(err) = txb.add_orchard_spend::<zip317::FeeError>(
+                                fvk.clone(),
+                                note.note,
+                                merkle_path.clone(),
+                            ) {
                                 println!("tx build: orchard note spend failed: {err:?} ({note:?})");
                                 continue;
                             }
                             let note_val = note.note.value().inner();
 
-                            s.spent(to_zats_or_dump_err("tx build orchard note", note_val)?, true)?;
-                            if DUMP_TX_BUILD { println!("  added orchard spend: {}", note_val); }
+                            s.spent(
+                                to_zats_or_dump_err("tx build orchard note", note_val)?,
+                                true,
+                            )?;
+                            if DUMP_TX_BUILD {
+                                println!("  added orchard spend: {}", note_val);
+                            }
 
-                            prep.o_inputs.push(ProposedOrchardSpend{ fvk: fvk.clone(), note, witness_merkle_path: merkle_path });
+                            prep.o_inputs.push(ProposedOrchardSpend {
+                                fvk: fvk.clone(),
+                                note,
+                                witness_merkle_path: merkle_path,
+                            });
 
-
-                            total_spend   += note_val;
+                            total_spend += note_val;
                             if (total_spend >= target_send + calc_fee::<P>(&txb, &prep)?) {
                                 break 'src_pool;
                             }
@@ -1715,8 +2072,8 @@ impl ManualWallet {
         let change = match total_spend.cmp(&min_spend) {
             std::cmp::Ordering::Less => {
                 println!("tx build error: can't afford {min_spend}; only {total_spend} available from given sources");
-                return None
-            }, // can't afford
+                return None;
+            } // can't afford
             std::cmp::Ordering::Equal => Zatoshis::const_from_u64(0),
             std::cmp::Ordering::Greater => {
                 // TODO: prefer shielded output
@@ -1724,12 +2081,24 @@ impl ManualWallet {
                 if let Some(ovk) = keys.orchard_ovk {
                     s.sent(change, true)?;
                     s.recv(change, true)?;
-                    if let Err(err) = txb.add_orchard_output::<zip317::FeeError>(Some(ovk.clone()), orchard_addr.clone(), change.into_u64(), MemoBytes::empty()) {
+                    if let Err(err) = txb.add_orchard_output::<zip317::FeeError>(
+                        Some(ovk.clone()),
+                        orchard_addr.clone(),
+                        change.into_u64(),
+                        MemoBytes::empty(),
+                    ) {
                         println!("tx build: failed to add change: {err:?}");
                         return None;
                     };
-                    prep.o_outputs.push(ProposedOrchardOutput{ ovk: Some(ovk), dst: orchard_addr.clone(), zats: change, memo: MemoBytes::empty() });
-                    if DUMP_TX_BUILD { println!("  added orchard change: {}", change.into_u64()); }
+                    prep.o_outputs.push(ProposedOrchardOutput {
+                        ovk: Some(ovk),
+                        dst: orchard_addr.clone(),
+                        zats: change,
+                        memo: MemoBytes::empty(),
+                    });
+                    if DUMP_TX_BUILD {
+                        println!("  added orchard change: {}", change.into_u64());
+                    }
                 } else {
                     t.sent(change, true)?;
                     t.recv(change, true)?;
@@ -1737,8 +2106,13 @@ impl ManualWallet {
                         println!("tx build: failed to add change: {err:?}");
                         return None;
                     };
-                    prep.t_outputs.push(ProposedTransparentOutput{ dst: t_addr, zats: change });
-                    if DUMP_TX_BUILD { println!("  added transparent change: {}", change.into_u64()); }
+                    prep.t_outputs.push(ProposedTransparentOutput {
+                        dst: t_addr,
+                        zats: change,
+                    });
+                    if DUMP_TX_BUILD {
+                        println!("  added transparent change: {}", change.into_u64());
+                    }
                 }
                 change
             }
@@ -1756,10 +2130,14 @@ impl ManualWallet {
     }
 
     pub fn send_zats<P: Parameters>(
-        &mut self, network: P, tx: &mut ProposedTx, client: &mut CompactTxStreamerClient<Channel>, outputs: &[TxOutput],
-        src_usk: &UnifiedSpendingKey, opts: &TxOptions<'_>
-    ) -> Option<()>
-    {
+        &mut self,
+        network: P,
+        tx: &mut ProposedTx,
+        client: &mut CompactTxStreamerClient<Channel>,
+        outputs: &[TxOutput],
+        src_usk: &UnifiedSpendingKey,
+        opts: &TxOptions<'_>,
+    ) -> Option<()> {
         let res = self.send_zats_no_insert(network, tx, client, outputs, src_usk, opts);
         // let mut insert_i = 0;
         // update_insert_i(&self.txs, &mut insert_i, tx.tx.h);
@@ -1770,19 +2148,31 @@ impl ManualWallet {
     // NOTE: because we get 2 grace actions, we don't need to try and special-case getting all
     // change outputs within a single output, although that might be better for later note use...
     pub fn shield_transparent_zats<P: Parameters>(
-        &mut self, network: P, tx: &mut ProposedTx, client: &mut CompactTxStreamerClient<Channel>,
-        src_usk: &UnifiedSpendingKey, min_zats_to_shield: u64, orchard_tree: &OrchardShardTree,
-        memo: MemoBytes
-    ) -> Option<()>
-    {
+        &mut self,
+        network: P,
+        tx: &mut ProposedTx,
+        client: &mut CompactTxStreamerClient<Channel>,
+        src_usk: &UnifiedSpendingKey,
+        min_zats_to_shield: u64,
+        orchard_tree: &OrchardShardTree,
+        memo: MemoBytes,
+    ) -> Option<()> {
         let tz = Timer::scope("shield_transparent_zats");
         let account = &self.accounts[0];
         let keys = PreparedKeys::from_ufvk_all(&account.ufvk);
         let (t_addr, ua) = addrs_from_account(account, 0).unwrap(); // @Hack
         if let (Some(ovk), Some(&dst)) = (keys.orchard_ovk, ua.orchard()) {
             let zats = to_zats_or_dump_err("shielding zats", min_zats_to_shield)?;
-            let out = &[TxOutput::Orchard{ ovk: Some(ovk), dst, zats, memo }];
-            let opts = &TxOptions{ src_pools: &[TxPool::Transparent], ..TxOptions::default() };
+            let out = &[TxOutput::Orchard {
+                ovk: Some(ovk),
+                dst,
+                zats,
+                memo,
+            }];
+            let opts = &TxOptions {
+                src_pools: &[TxPool::Transparent],
+                ..TxOptions::default()
+            };
             self.send_zats(network, tx, client, out, src_usk, opts)
         } else {
             None
@@ -1790,31 +2180,48 @@ impl ManualWallet {
     }
 
     pub fn send_orchard_to_orchard_zats<P: Parameters>(
-        &mut self, network: P, tx: &mut ProposedTx, client: &mut CompactTxStreamerClient<Channel>,
-        src_usk: &UnifiedSpendingKey, exact_amount_to_send: u64, orchard_tree: &OrchardShardTree, dst: orchard::Address,
-        memo: MemoBytes
-    ) -> Option<()>
-    {
+        &mut self,
+        network: P,
+        tx: &mut ProposedTx,
+        client: &mut CompactTxStreamerClient<Channel>,
+        src_usk: &UnifiedSpendingKey,
+        exact_amount_to_send: u64,
+        orchard_tree: &OrchardShardTree,
+        dst: orchard::Address,
+        memo: MemoBytes,
+    ) -> Option<()> {
         let tz = Timer::scope("send_orchard_to_orchard_zats");
         let account = &self.accounts[0];
         let keys = PreparedKeys::from_ufvk_all(&account.ufvk);
         let (t_addr, ua) = addrs_from_account(account, 0).unwrap(); // @Hack
         if let Some(ovk) = keys.orchard_ovk {
             let zats = to_zats_or_dump_err("shielding zats", exact_amount_to_send)?;
-            let out = &[TxOutput::Orchard{ ovk: Some(ovk), dst, zats, memo }];
-            let opts = &TxOptions{ src_pools: &[TxPool::Orchard(orchard_tree)], ..TxOptions::default() };
+            let out = &[TxOutput::Orchard {
+                ovk: Some(ovk),
+                dst,
+                zats,
+                memo,
+            }];
+            let opts = &TxOptions {
+                src_pools: &[TxPool::Orchard(orchard_tree)],
+                ..TxOptions::default()
+            };
             self.send_zats(network, tx, client, out, src_usk, opts)
         } else {
             None
         }
     }
 
-
     pub fn stake_orchard_to_finalizer<P: Parameters>(
-        &mut self, network: P, tx: &mut ProposedTx, client: &mut CompactTxStreamerClient<Channel>,
-        src_usk: &UnifiedSpendingKey, exact_amount_to_send: u64, orchard_tree: &OrchardShardTree, target_finalizer: [u8; 32],
-    ) -> Option<()>
-    {
+        &mut self,
+        network: P,
+        tx: &mut ProposedTx,
+        client: &mut CompactTxStreamerClient<Channel>,
+        src_usk: &UnifiedSpendingKey,
+        exact_amount_to_send: u64,
+        orchard_tree: &OrchardShardTree,
+        target_finalizer: [u8; 32],
+    ) -> Option<()> {
         let tz = Timer::scope("stake_orchard_to_finalizer");
         let account = &self.accounts[0];
         let keys = PreparedKeys::from_ufvk_all(&account.ufvk);
@@ -1823,15 +2230,18 @@ impl ManualWallet {
             let mut pretend_pub_key = [0u8; 32];
             rand::rngs::OsRng.fill_bytes(&mut pretend_pub_key);
 
-            let opts = &TxOptions{
+            let opts = &TxOptions {
                 src_pools: &[TxPool::Orchard(orchard_tree)],
-                staking_action: Some(StakingAction_CreateNewDelegationBond {
-                    amount_zats: exact_amount_to_send,
-                    unique_pubkey: pretend_pub_key,
-                    challenge: [0u8; 32],
-                    target_finalizer,
-                    signature: [0u8; 64]
-                }.to_union()),
+                staking_action: Some(
+                    StakingAction_CreateNewDelegationBond {
+                        amount_zats: exact_amount_to_send,
+                        unique_pubkey: pretend_pub_key,
+                        challenge: [0u8; 32],
+                        target_finalizer,
+                        signature: [0u8; 64],
+                    }
+                    .to_union(),
+                ),
             };
             self.send_zats(network, tx, client, &[], src_usk, opts)
         } else {
@@ -1840,53 +2250,77 @@ impl ManualWallet {
     }
 
     pub fn begin_unbonding_using_orchard<P: Parameters>(
-        &mut self, network: P, tx: &mut ProposedTx, client: &mut CompactTxStreamerClient<Channel>,
-        src_usk: &UnifiedSpendingKey, orchard_tree: &OrchardShardTree, bond_key: [u8; 32],
-    ) -> Option<()>
-    {
+        &mut self,
+        network: P,
+        tx: &mut ProposedTx,
+        client: &mut CompactTxStreamerClient<Channel>,
+        src_usk: &UnifiedSpendingKey,
+        orchard_tree: &OrchardShardTree,
+        bond_key: [u8; 32],
+    ) -> Option<()> {
         let tz = Timer::scope("begin_unbonding_using_orchard");
         let account = &self.accounts[0];
-        let opts = &TxOptions{
+        let opts = &TxOptions {
             src_pools: &[TxPool::Orchard(orchard_tree)],
-            staking_action: Some(StakingAction_BeginDelegationUnbonding {
-                unique_pubkey: bond_key,
-                challenge: [0u8; 32],
-                signature: [0u8; 64]
-            }.to_union()),
+            staking_action: Some(
+                StakingAction_BeginDelegationUnbonding {
+                    unique_pubkey: bond_key,
+                    challenge: [0u8; 32],
+                    signature: [0u8; 64],
+                }
+                .to_union(),
+            ),
         };
         self.send_zats(network, tx, client, &[], src_usk, opts)
     }
 
     pub fn retarget_bond_using_orchard<P: Parameters>(
-        &mut self, network: P, tx: &mut ProposedTx, client: &mut CompactTxStreamerClient<Channel>,
-        src_usk: &UnifiedSpendingKey, orchard_tree: &OrchardShardTree, bond_key: [u8; 32], new_target: [u8; 32],
-    ) -> Option<()>
-    {
+        &mut self,
+        network: P,
+        tx: &mut ProposedTx,
+        client: &mut CompactTxStreamerClient<Channel>,
+        src_usk: &UnifiedSpendingKey,
+        orchard_tree: &OrchardShardTree,
+        bond_key: [u8; 32],
+        new_target: [u8; 32],
+    ) -> Option<()> {
         let tz = Timer::scope("begin_unbonding_using_orchard");
         let account = &self.accounts[0];
-        let opts = &TxOptions{
+        let opts = &TxOptions {
             src_pools: &[TxPool::Orchard(orchard_tree)],
-            staking_action: Some(StakingAction_RetargetDelegationBond {
-                unique_pubkey: bond_key,
-                challenge: [0u8; 32],
-                signature: [0u8; 64],
-                target_finalizer: new_target,
-            }.to_union()),
+            staking_action: Some(
+                StakingAction_RetargetDelegationBond {
+                    unique_pubkey: bond_key,
+                    challenge: [0u8; 32],
+                    signature: [0u8; 64],
+                    target_finalizer: new_target,
+                }
+                .to_union(),
+            ),
         };
         self.send_zats(network, tx, client, &[], src_usk, opts)
     }
 
     pub async fn claim_bond_using_orchard<P: Parameters>(
-        &mut self, network: P, tx: &mut ProposedTx, client: &mut CompactTxStreamerClient<Channel>,
-        src_usk: &UnifiedSpendingKey, orchard_tree: &OrchardShardTree, bond_key: [u8; 32],
-    ) -> Option<()>
-    {
+        &mut self,
+        network: P,
+        tx: &mut ProposedTx,
+        client: &mut CompactTxStreamerClient<Channel>,
+        src_usk: &UnifiedSpendingKey,
+        orchard_tree: &OrchardShardTree,
+        bond_key: [u8; 32],
+    ) -> Option<()> {
         let tz = Timer::scope("claim_bond_using_orchard");
         let account = &self.accounts[0];
         let keys = PreparedKeys::from_ufvk_all(&account.ufvk);
         let (_t_addr, ua) = addrs_from_account(account, 0).unwrap(); // @Hack
         if let (Some(ovk), Some(&dst)) = (keys.orchard_ovk, ua.orchard()) {
-            let amount_zats = match client.get_bond_info(zcash_client_backend::proto::service::BondInfoRequest { bond_key: bond_key.to_vec(), }).await {
+            let amount_zats = match client
+                .get_bond_info(zcash_client_backend::proto::service::BondInfoRequest {
+                    bond_key: bond_key.to_vec(),
+                })
+                .await
+            {
                 Ok(response) => {
                     let info = response.into_inner();
                     info.amount
@@ -1900,15 +2334,23 @@ impl ManualWallet {
 
             let memo = MemoBytes::from_bytes("Claimed bond".as_bytes()).unwrap();
             let zats = to_zats_or_dump_err("claim bond", amount_zats)?;
-            let out = &[TxOutput::Orchard{ ovk: Some(ovk), dst, zats, memo }];
-            let opts = &TxOptions{
+            let out = &[TxOutput::Orchard {
+                ovk: Some(ovk),
+                dst,
+                zats,
+                memo,
+            }];
+            let opts = &TxOptions {
                 src_pools: &[],
-                staking_action: Some(StakingAction_WithdrawDelegationBond {
-                    amount_zats,
-                    unique_pubkey: bond_key,
-                    challenge: [0u8; 32],
-                    signature: [0u8; 64]
-                }.to_union()),
+                staking_action: Some(
+                    StakingAction_WithdrawDelegationBond {
+                        amount_zats,
+                        unique_pubkey: bond_key,
+                        challenge: [0u8; 32],
+                        signature: [0u8; 64],
+                    }
+                    .to_union(),
+                ),
             };
             self.send_zats(network, tx, client, &[], src_usk, opts)
         } else {
@@ -1917,9 +2359,7 @@ impl ManualWallet {
     }
 
     pub fn audit_tx(&self, tx: &WalletTx) {
-        if tx.is_coinbase ||
-            !(tx.reported_height() < BlockHeight::MEMPOOL && tx.is_on_bc())
-        {
+        if tx.is_coinbase || !(tx.reported_height() < BlockHeight::MEMPOOL && tx.is_on_bc()) {
             return;
         }
         // println!("auditing {}", tx.txid);
@@ -1960,8 +2400,13 @@ impl ManualWallet {
         let checks = [t, s, b];
         if let Some(check_all) = WalletTxPart::checked_sum(&checks) {
             let part_strs = ["transparent", "shielded", "bonded"];
-            let tx_parts = [tx.parts[0], tx.parts[1], WalletTxPart::from_staking_action(tx.staking_action)];
-            for i in 1..2 { // ignore bonded for now
+            let tx_parts = [
+                tx.parts[0],
+                tx.parts[1],
+                WalletTxPart::from_staking_action(tx.staking_action),
+            ];
+            for i in 1..2 {
+                // ignore bonded for now
                 let mut ok = true;
                 ok &= tx_parts[i].recv_zats == checks[i].recv_zats;
                 ok &= tx_parts[i].recv_note_count == checks[i].recv_note_count;
@@ -1970,11 +2415,15 @@ impl ManualWallet {
                 // ok &= tx_parts[i].sent_zats == checks[i].sent_zats;
                 // ok &= tx_parts[i].sent_note_count == checks[i].sent_note_count;
                 if !ok {
-                    println!("TX SYNC ERROR in {}/{} {} part mismatches check:\n  {:?} vs\n  {:?}", self.name, tx.txid, part_strs[i], tx_parts[i], checks[i]);
+                    println!(
+                        "TX SYNC ERROR in {}/{} {} part mismatches check:\n  {:?} vs\n  {:?}",
+                        self.name, tx.txid, part_strs[i], tx_parts[i], checks[i]
+                    );
                     #[cfg(debug_assertions)]
                     {
                         let mut g_log = NOTE_LOG.lock().unwrap();
-                        if let Some((tx_log, seq)) = g_log.get_expected(self.name, &tx.txid, "read") {
+                        if let Some((tx_log, seq)) = g_log.get_expected(self.name, &tx.txid, "read")
+                        {
                             println!("Note log: {:?}", NL(&tx_log));
                         }
                     }
@@ -1982,7 +2431,10 @@ impl ManualWallet {
                 ok = true; // breakpoint
             }
         } else {
-            println!("TX SYNC ERROR in {}/{}: invalid sum for [{t:?}, {s:?}, {b:?}]", self.name, tx.txid);
+            println!(
+                "TX SYNC ERROR in {}/{}: invalid sum for [{t:?}, {s:?}, {b:?}]",
+                self.name, tx.txid
+            );
         }
     }
 
@@ -2022,14 +2474,14 @@ impl PoWCache {
         }
         self.next_tip_h = h + 1;
     }
-    pub fn hash_at_h(&self, h: u64) -> Option<[u8;32]> {
+    pub fn hash_at_h(&self, h: u64) -> Option<[u8; 32]> {
         if h < self.next_tip_h {
             Some(self.hashes[h as usize])
         } else {
             None
         }
     }
-    pub fn tip_hash(&self) -> [u8;32] {
+    pub fn tip_hash(&self) -> [u8; 32] {
         self.hashes[self.next_tip_h as usize - 1]
     }
 }
@@ -2049,7 +2501,12 @@ fn orchard_recv_h_insert(notes: &mut Vec<OrchardNote>, note: OrchardNote) {
             i = notes.partition_point(|n| n.recv_h <= note.recv_h);
         }
     }
-    debug_assert!(i == 0 || notes[i-1].recv_h <= note.recv_h, "{} <= {}", notes[i-1].recv_h, note.recv_h);
+    debug_assert!(
+        i == 0 || notes[i - 1].recv_h <= note.recv_h,
+        "{} <= {}",
+        notes[i - 1].recv_h,
+        note.recv_h
+    );
     notes.insert(i, note);
 }
 fn orchard_spent_h_insert(notes: &mut Vec<OrchardNote>, note: OrchardNote) {
@@ -2059,7 +2516,12 @@ fn orchard_spent_h_insert(notes: &mut Vec<OrchardNote>, note: OrchardNote) {
             i = notes.partition_point(|n| n.spent_h <= note.spent_h);
         }
     }
-    debug_assert!(i == 0 || notes[i-1].spent_h <= note.spent_h, "{} <= {}", notes[i-1].spent_h, note.spent_h);
+    debug_assert!(
+        i == 0 || notes[i - 1].spent_h <= note.spent_h,
+        "{} <= {}",
+        notes[i - 1].spent_h,
+        note.spent_h
+    );
     notes.insert(i, note);
 }
 fn txo_recv_h_insert(notes: &mut Vec<Txo>, note: Txo) {
@@ -2069,7 +2531,12 @@ fn txo_recv_h_insert(notes: &mut Vec<Txo>, note: Txo) {
             i = notes.partition_point(|n| n.recv_h <= note.recv_h);
         }
     }
-    debug_assert!(i == 0 || notes[i-1].recv_h <= note.recv_h, "{} <= {}", notes[i-1].recv_h, note.recv_h);
+    debug_assert!(
+        i == 0 || notes[i - 1].recv_h <= note.recv_h,
+        "{} <= {}",
+        notes[i - 1].recv_h,
+        note.recv_h
+    );
     notes.insert(i, note);
 }
 fn txo_spent_h_insert(notes: &mut Vec<Txo>, note: Txo) {
@@ -2079,12 +2546,21 @@ fn txo_spent_h_insert(notes: &mut Vec<Txo>, note: Txo) {
             i = notes.partition_point(|n| n.spent_h <= note.spent_h);
         }
     }
-    debug_assert!(i == 0 || notes[i-1].spent_h <= note.spent_h, "{} <= {}", notes[i-1].spent_h, note.spent_h);
+    debug_assert!(
+        i == 0 || notes[i - 1].spent_h <= note.spent_h,
+        "{} <= {}",
+        notes[i - 1].spent_h,
+        note.spent_h
+    );
     notes.insert(i, note);
 }
 
 /// GET NOTE/TX INDEXES WITH KNOWN HEIGHTS IN SORTED SLICES
-fn orchard_recv_h_position(notes: &[OrchardNote], block_h: BlockHeight, nf: &orchard::note::Nullifier) -> Option<usize> {
+fn orchard_recv_h_position(
+    notes: &[OrchardNote],
+    block_h: BlockHeight,
+    nf: &orchard::note::Nullifier,
+) -> Option<usize> {
     let mut i = notes.partition_point(|txo| txo.recv_h < block_h);
     while i < notes.len() && notes[i].recv_h == block_h {
         if &notes[i].nf == nf {
@@ -2094,7 +2570,11 @@ fn orchard_recv_h_position(notes: &[OrchardNote], block_h: BlockHeight, nf: &orc
     }
     None
 }
-fn orchard_spent_h_position(notes: &[OrchardNote], block_h: BlockHeight, nf: &orchard::note::Nullifier) -> Option<usize> {
+fn orchard_spent_h_position(
+    notes: &[OrchardNote],
+    block_h: BlockHeight,
+    nf: &orchard::note::Nullifier,
+) -> Option<usize> {
     let mut i = notes.partition_point(|txo| txo.spent_h < block_h);
     while i < notes.len() && notes[i].spent_h == block_h {
         if &notes[i].nf == nf {
@@ -2194,7 +2674,10 @@ fn bc_h_from_raw_tx_h(height: u64) -> Option<Option<BlockHeight>> {
         return Some(None);
     }
     let Ok(height) = <u32>::try_from(height) else {
-        println!("transparent tx's height can't be represented in 32 bits: {}", height);
+        println!(
+            "transparent tx's height can't be represented in 32 bits: {}",
+            height
+        );
         return None;
     };
 
@@ -2207,7 +2690,17 @@ fn bc_h_from_raw_tx_h(height: u64) -> Option<Option<BlockHeight>> {
 
 // TODO: handle memo here instead of caller?
 // TODO: replace orchard_action_tree_position_by_cmx with position
-fn handle_orchard_action(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedKeys, position: incrementalmerkletree::Position, block_h: BlockHeight, txid: &TxId, spent_nf: &orchard::note::Nullifier, recv_note_addr: Option<(orchard::note::Note, orchard::Address)>, send_note_addr_memo: Option<(orchard::note::Note, orchard::Address, [u8; 512])>) -> Option<WalletTxPart> {
+fn handle_orchard_action(
+    wallet: &mut ManualWallet,
+    account_i: usize,
+    keys: &PreparedKeys,
+    position: incrementalmerkletree::Position,
+    block_h: BlockHeight,
+    txid: &TxId,
+    spent_nf: &orchard::note::Nullifier,
+    recv_note_addr: Option<(orchard::note::Note, orchard::Address)>,
+    send_note_addr_memo: Option<(orchard::note::Note, orchard::Address, [u8; 512])>,
+) -> Option<WalletTxPart> {
     let account = &mut wallet.accounts[account_i];
 
     //- HANDLE SPENT NOTES
@@ -2219,8 +2712,17 @@ fn handle_orchard_action(wallet: &mut ManualWallet, account_i: usize, keys: &Pre
             // this action is a spend by us with this note/nullifier: move it to spent
             let unspent_note = account.unspent_orchard_notes.remove(note_i);
 
-            s.spent(to_zats_or_dump_err("read orchard action spend", unspent_note.note.value().inner())?, true)?;
-            let spent_note = OrchardNote { spent_h: block_h, ..unspent_note };
+            s.spent(
+                to_zats_or_dump_err(
+                    "read orchard action spend",
+                    unspent_note.note.value().inner(),
+                )?,
+                true,
+            )?;
+            let spent_note = OrchardNote {
+                spent_h: block_h,
+                ..unspent_note
+            };
             orchard_spent_h_insert(&mut account.spent_orchard_notes, spent_note.clone());
             // println!("{} found new spent note at {block_h:?}, tree pos={:02}: spent_nf:{:?}", wallet.name, u64::from(position), *spent_nf);
 
@@ -2228,7 +2730,7 @@ fn handle_orchard_action(wallet: &mut ManualWallet, account_i: usize, keys: &Pre
             {
                 let mut g_log = NOTE_LOG.lock().unwrap();
                 let (tx_log, seq) = g_log.get_or_new(wallet.name, txid, "spend");
-                tx_log.push(DevNoteAction{
+                tx_log.push(DevNoteAction {
                     seq,
                     kind: DevNoteActionKind::Spend,
                     note: DevNote::OrchardNote(spent_note),
@@ -2243,7 +2745,10 @@ fn handle_orchard_action(wallet: &mut ManualWallet, account_i: usize, keys: &Pre
     if s.spent_note_count == 0 {
         for note in &account.spent_orchard_notes {
             if note.nf == *spent_nf {
-                s.spent(to_zats_or_dump_err("read orchard action spend", note.note.value().inner())?, true)?;
+                s.spent(
+                    to_zats_or_dump_err("read orchard action spend", note.note.value().inner())?,
+                    true,
+                )?;
                 // println!("{} found old spent note at {block_h:?}, tree pos={:02}", wallet.name, u64::from(position));
                 break;
             }
@@ -2252,19 +2757,25 @@ fn handle_orchard_action(wallet: &mut ManualWallet, account_i: usize, keys: &Pre
 
     //- HANDLE KNOWN-SENT
     if let Some((note, _addr, _memo)) = send_note_addr_memo {
-        s.sent(to_zats_or_dump_err("read orchard action send", note.value().inner())?, true)?;
+        s.sent(
+            to_zats_or_dump_err("read orchard action send", note.value().inner())?,
+            true,
+        )?;
     }
 
     //- PUSH NEW RECEIVED/UNSPENT NOTES
     if let Some((note, _recipient)) = recv_note_addr {
-        s.recv(to_zats_or_dump_err("read orchard action receive", note.value().inner())?, true)?;
+        s.recv(
+            to_zats_or_dump_err("read orchard action receive", note.value().inner())?,
+            true,
+        )?;
         // if s_spend_c > 0 && s_send_c  {
         //     s_send_c += 1;
         //     s_send_z += note.value().inner();
         // }
         // NOTE: s_send_c/s_send_z equivalent handled inside update_with_tx
 
-        let orchard_note = OrchardNote{
+        let orchard_note = OrchardNote {
             recv_h: block_h,
             spent_h: BlockHeight(0),
             txid: *txid,
@@ -2290,7 +2801,9 @@ fn handle_orchard_action(wallet: &mut ManualWallet, account_i: usize, keys: &Pre
         };
 
         // TODO: can we just check if we've seen the tx && tx.is_on_bc()
-        let have_seen = if let Some(i) = orchard_recv_h_position(&account.recv_orchard_notes, txid_h, &orchard_note.nf) {
+        let have_seen = if let Some(i) =
+            orchard_recv_h_position(&account.recv_orchard_notes, txid_h, &orchard_note.nf)
+        {
             account.recv_orchard_notes[i].monotonically_update(orchard_note);
             true
         } else {
@@ -2298,7 +2811,7 @@ fn handle_orchard_action(wallet: &mut ManualWallet, account_i: usize, keys: &Pre
             {
                 let mut g_log = NOTE_LOG.lock().unwrap();
                 let (tx_log, seq) = g_log.get_or_new(wallet.name, txid, "receive");
-                tx_log.push(DevNoteAction{
+                tx_log.push(DevNoteAction {
                     seq,
                     kind: DevNoteActionKind::Recv,
                     note: DevNote::OrchardNote(orchard_note.clone()),
@@ -2311,7 +2824,9 @@ fn handle_orchard_action(wallet: &mut ManualWallet, account_i: usize, keys: &Pre
             false
         };
 
-        if let Some(i) = orchard_recv_h_position(&account.unspent_orchard_notes, txid_h, &orchard_note.nf) {
+        if let Some(i) =
+            orchard_recv_h_position(&account.unspent_orchard_notes, txid_h, &orchard_note.nf)
+        {
             account.unspent_orchard_notes[i].monotonically_update(orchard_note);
         } else if !have_seen {
             orchard_recv_h_insert(&mut account.unspent_orchard_notes, orchard_note);
@@ -2321,7 +2836,15 @@ fn handle_orchard_action(wallet: &mut ManualWallet, account_i: usize, keys: &Pre
     Some(s)
 }
 
-fn read_full_tx(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedKeys, block_h: BlockHeight, tx: &Transaction, insert_i: &mut usize, status: TxStatus) -> Option<()> {
+fn read_full_tx(
+    wallet: &mut ManualWallet,
+    account_i: usize,
+    keys: &PreparedKeys,
+    block_h: BlockHeight,
+    tx: &Transaction,
+    insert_i: &mut usize,
+    status: TxStatus,
+) -> Option<()> {
     // TODO: we probably want to early-out if our existing tx data is complete
     // (after checking that this doesn't get modified)
 
@@ -2350,16 +2873,21 @@ fn read_full_tx(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedKeys
         if !is_coinbase {
             for input in &t_bundle.vin {
                 if let Some(&prevout_txid_h) = wallet.tx_h_map.get(input.prevout.txid()) {
-                    if let Some(utxo_i) = txo_recv_h_position(&account.utxos, prevout_txid_h, &input.prevout) {
+                    if let Some(utxo_i) =
+                        txo_recv_h_position(&account.utxos, prevout_txid_h, &input.prevout)
+                    {
                         let utxo = account.utxos.remove(utxo_i);
-                        let stxo = Txo { spent_h: block_h, ..utxo };
+                        let stxo = Txo {
+                            spent_h: block_h,
+                            ..utxo
+                        };
                         t.spent(stxo.value, true)?;
 
                         #[cfg(debug_assertions)]
                         {
                             let mut g_log = NOTE_LOG.lock().unwrap();
-                            let (tx_log, seq) = g_log.get_or_new(wallet.name,  &txid, "spend");
-                            tx_log.push(DevNoteAction{
+                            let (tx_log, seq) = g_log.get_or_new(wallet.name, &txid, "spend");
+                            tx_log.push(DevNoteAction {
                                 seq,
                                 kind: DevNoteActionKind::Spend,
                                 note: DevNote::Txo(stxo.clone()),
@@ -2375,7 +2903,9 @@ fn read_full_tx(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedKeys
                         //     debug_assert!(last_stxo.spent_h <= stxo.spent_h, "{} <= {}", last_stxo.spent_h, stxo.spent_h);
                         // }
                         txo_spent_h_insert(&mut account.stxos, stxo);
-                    } else if let Some(txo_i) = txo_recv_h_position(&account.recv_txos, prevout_txid_h, &input.prevout) {
+                    } else if let Some(txo_i) =
+                        txo_recv_h_position(&account.recv_txos, prevout_txid_h, &input.prevout)
+                    {
                         // NOTE: we need to use our own tracking of the TXO as otherwise we don't know the value
                         t.spent(account.recv_txos[txo_i].value, true)?;
                     } else {
@@ -2413,14 +2943,17 @@ fn read_full_tx(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedKeys
                     };
                     if let Some(utxo_i) = txo_recv_h_position(&account.utxos, txid_h, &utxo.id) {
                         if account.utxos[utxo_i] != utxo {
-                            println!("ERROR: UTXO mismatch: {:?} vs {:?}", account.utxos[utxo_i], &utxo);
+                            println!(
+                                "ERROR: UTXO mismatch: {:?} vs {:?}",
+                                account.utxos[utxo_i], &utxo
+                            );
                         }
                     } else if txo_recv_h_position(&account.recv_txos, txid_h, &utxo.id).is_none() {
                         #[cfg(debug_assertions)]
                         {
                             let mut g_log = NOTE_LOG.lock().unwrap();
                             let (tx_log, seq) = g_log.get_or_new(wallet.name, &txid, "receive");
-                            tx_log.push(DevNoteAction{
+                            tx_log.push(DevNoteAction {
                                 seq,
                                 kind: DevNoteActionKind::Recv,
                                 note: DevNote::Txo(utxo.clone()),
@@ -2431,12 +2964,22 @@ fn read_full_tx(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedKeys
 
                         // TODO: can we just check if we've seen the tx && tx.2 == false
                         if let Some(last_txo) = account.recv_txos.last() {
-                            debug_assert!(last_txo.recv_h <= utxo.recv_h, "{} <= {}", last_txo.recv_h, utxo.recv_h);
+                            debug_assert!(
+                                last_txo.recv_h <= utxo.recv_h,
+                                "{} <= {}",
+                                last_txo.recv_h,
+                                utxo.recv_h
+                            );
                         }
                         account.recv_txos.push(utxo.clone());
 
                         if let Some(last_utxo) = account.utxos.last() {
-                            debug_assert!(last_utxo.recv_h <= utxo.recv_h, "{} <= {}", last_utxo.recv_h, utxo.recv_h);
+                            debug_assert!(
+                                last_utxo.recv_h <= utxo.recv_h,
+                                "{} <= {}",
+                                last_utxo.recv_h,
+                                utxo.recv_h
+                            );
                         }
                         account.utxos.push(utxo);
                     }
@@ -2465,7 +3008,13 @@ fn read_full_tx(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedKeys
                 // TODO: do we get more useful info if we do both?
                 // we use the nullifier to detect spends anyway,
                 // and we've already got any memos from the above
-                try_output_recovery_with_ovk(&domain, ovk, action, action.cv_net(), &action.encrypted_note().out_ciphertext)
+                try_output_recovery_with_ovk(
+                    &domain,
+                    ovk,
+                    action,
+                    action.cv_net(),
+                    &action.encrypted_note().out_ciphertext,
+                )
             } else {
                 None
             };
@@ -2484,7 +3033,17 @@ fn read_full_tx(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedKeys
                 }
             }
 
-            let Some(part) = handle_orchard_action(wallet, account_i, keys, unknown_tree_position(), block_h, &txid, action.nullifier(), recv_note_addr, send_res) else {
+            let Some(part) = handle_orchard_action(
+                wallet,
+                account_i,
+                keys,
+                unknown_tree_position(),
+                block_h,
+                &txid,
+                action.nullifier(),
+                recv_note_addr,
+                send_res,
+            ) else {
                 // error creating zats (already printed)
                 // TODO: can we validly continue at all?
                 continue;
@@ -2519,24 +3078,33 @@ fn read_full_tx(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedKeys
     Some(())
 }
 
-type OrchardTree = incrementalmerkletree::frontier::CommitmentTree<orchard::tree::MerkleHashOrchard, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }>;
-type OrchardFrontier = incrementalmerkletree::frontier::Frontier<orchard::tree::MerkleHashOrchard, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }>;
-type OrchardWitness = incrementalmerkletree::witness::IncrementalWitness<orchard::tree::MerkleHashOrchard, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }>;
+type OrchardTree = incrementalmerkletree::frontier::CommitmentTree<
+    orchard::tree::MerkleHashOrchard,
+    { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+>;
+type OrchardFrontier = incrementalmerkletree::frontier::Frontier<
+    orchard::tree::MerkleHashOrchard,
+    { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+>;
+type OrchardWitness = incrementalmerkletree::witness::IncrementalWitness<
+    orchard::tree::MerkleHashOrchard,
+    { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+>;
 const SHARD_HEIGHT: u8 = 16; // default => 65536 leaves per shard
-type OrchardShardTree = shardtree::ShardTree::<
-    shardtree::store::memory::MemoryShardStore::<
+type OrchardShardTree = shardtree::ShardTree<
+    shardtree::store::memory::MemoryShardStore<
         orchard::tree::MerkleHashOrchard,
         // shardtree::Node<orchard::tree::MerkleHashOrchard, (), ()>,
-        BlockHeight
+        BlockHeight,
     >,
     { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
-    SHARD_HEIGHT
+    SHARD_HEIGHT,
 >;
 
 fn shard_tree_size(tree: &OrchardShardTree) -> u64 {
     tree.max_leaf_position(None)
         .expect("Infallible Memory Store")
-        .map_or(0, |pos| u64::from(pos)+1)
+        .map_or(0, |pos| u64::from(pos) + 1)
 }
 
 fn shard_tree_root(tree: &OrchardShardTree) -> orchard::tree::MerkleHashOrchard {
@@ -2572,19 +3140,33 @@ fn user_view_of_faucet_tx(tx: &WalletTx) -> WalletTx {
             WalletTxPart::ZERO,
             WalletTxPart {
                 recv_note_count: 1,
-                recv_zats: Zatoshis::from_u64(tx.parts[1].sent_zats.into_u64()
-                    .saturating_sub(tx.parts[1].recv_zats.into_u64()))
-                    .unwrap_or(Zatoshis::const_from_u64(0)),
-                    ..WalletTxPart::ZERO
-            }
+                recv_zats: Zatoshis::from_u64(
+                    tx.parts[1]
+                        .sent_zats
+                        .into_u64()
+                        .saturating_sub(tx.parts[1].recv_zats.into_u64()),
+                )
+                .unwrap_or(Zatoshis::const_from_u64(0)),
+                ..WalletTxPart::ZERO
+            },
         ],
         ..*tx
     }
 }
 
 /// NOTE: this *must* only be called in sequential order without gaps (including after reorg/truncate)
-fn read_compact_tx(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedKeys, block_h: BlockHeight, tx: &CompactTx, next_orchard_pos: &mut u64, insert_i: &mut usize, orchard_tree: &mut OrchardShardTree) -> (TxId, bool/*ours*/, bool/*ok*/) {
-    let txid = TxId::from_bytes(<[u8;32]>::try_from(&tx.hash[..]).expect("successfully converted above"));
+fn read_compact_tx(
+    wallet: &mut ManualWallet,
+    account_i: usize,
+    keys: &PreparedKeys,
+    block_h: BlockHeight,
+    tx: &CompactTx,
+    next_orchard_pos: &mut u64,
+    insert_i: &mut usize,
+    orchard_tree: &mut OrchardShardTree,
+) -> (TxId, bool /*ours*/, bool /*ok*/) {
+    let txid =
+        TxId::from_bytes(<[u8; 32]>::try_from(&tx.hash[..]).expect("successfully converted above"));
 
     let mut shielded_part = WalletTxPart::ZERO;
 
@@ -2594,17 +3176,20 @@ fn read_compact_tx(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedK
             Err(err) => {
                 // TODO: we can't keep position updated if we fail here
                 // TODO: should we fail validation for the entire block above if we can't do this?
-                println!("couldn't convert CompactOrchardAction to orchard::CompactAction: {err:?}");
+                println!(
+                    "couldn't convert CompactOrchardAction to orchard::CompactAction: {err:?}"
+                );
                 continue;
             }
         };
         let domain = OrchardDomain::for_compact_action(&action);
 
-        let note_addr: Option<(orchard::note::Note, orchard::Address)> = if let Some(ivk) = &keys.orchard_ivk {
-             try_compact_note_decryption(&domain, ivk, &action)
-        } else {
-            None
-        };
+        let note_addr: Option<(orchard::note::Note, orchard::Address)> =
+            if let Some(ivk) = &keys.orchard_ivk {
+                try_compact_note_decryption(&domain, ivk, &action)
+            } else {
+                None
+            };
 
         let orchard_pos = incrementalmerkletree::Position::from(*next_orchard_pos);
         //- GLOBAL-VIEW UPDATES
@@ -2626,16 +3211,40 @@ fn read_compact_tx(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedK
         // let res = orchard_tree.batch_insert(position, append_iter).expect("Infallible Memory Store");
         // println!("****** orchard_tree.batch_insert result {:?}", res);
         if *next_orchard_pos >= shard_tree_size(&orchard_tree) {
-            assert_eq!(*next_orchard_pos, shard_tree_size(&orchard_tree), "should be appending sequentially");
-            orchard_tree.append(orchard::tree::MerkleHashOrchard::from_cmx(&action.cmx()), retention).expect("Infallible Memory Store");
+            assert_eq!(
+                *next_orchard_pos,
+                shard_tree_size(&orchard_tree),
+                "should be appending sequentially"
+            );
+            orchard_tree
+                .append(
+                    orchard::tree::MerkleHashOrchard::from_cmx(&action.cmx()),
+                    retention,
+                )
+                .expect("Infallible Memory Store");
             if DUMP_TREES {
-                println!("new orchard root at {:?} tree size={:02} {:?}", block_h, shard_tree_size(orchard_tree), shard_tree_root(orchard_tree));
+                println!(
+                    "new orchard root at {:?} tree size={:02} {:?}",
+                    block_h,
+                    shard_tree_size(orchard_tree),
+                    shard_tree_root(orchard_tree)
+                );
             }
             // let position = orchard_tree.max_leaf_position(None).expect("Infallible Memory Store").expect("just appended");
         }
         *next_orchard_pos += 1;
 
-        let Some(part) = handle_orchard_action(wallet, account_i, keys, orchard_pos, block_h, &txid, &action.nullifier(), note_addr, None) else {
+        let Some(part) = handle_orchard_action(
+            wallet,
+            account_i,
+            keys,
+            orchard_pos,
+            block_h,
+            &txid,
+            &action.nullifier(),
+            note_addr,
+            None,
+        ) else {
             // error creating zats (already printed)
             // TODO: can we validly continue at all?
             continue;
@@ -2658,14 +3267,18 @@ fn read_compact_tx(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedK
     // TODO: decrypt our transactions & fill in actual data here
     // TODO: get full info with memos
 
-    if (shielded_part.spent_note_count | shielded_part.sent_note_count | shielded_part.recv_note_count) != 0 {
+    if (shielded_part.spent_note_count
+        | shielded_part.sent_note_count
+        | shielded_part.recv_note_count)
+        != 0
+    {
         let new_tx = WalletTx {
             account_id: account_i,
             txid,
             expiry_h: None, // TODO
             h: block_h,
             part_flags: TxParts::SHIELDED_RECV,
-            parts: [ WalletTxPart::ZERO, shielded_part ],
+            parts: [WalletTxPart::ZERO, shielded_part],
             memo_count: 0,
             memo: EMPTY_MEMO_BYTES,
             is_coinbase: false,
@@ -2680,12 +3293,11 @@ fn read_compact_tx(wallet: &mut ManualWallet, account_i: usize, keys: &PreparedK
     }
 }
 
-
 pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
-    fn stuff_from_seed_phrase<P: Parameters + 'static>(params:P, phrase: &str) -> (
-        SecretVec<u8>,
-        UnifiedSpendingKey,
-    ) {
+    fn stuff_from_seed_phrase<P: Parameters + 'static>(
+        params: P,
+        phrase: &str,
+    ) -> (SecretVec<u8>, UnifiedSpendingKey) {
         use secrecy::ExposeSecret;
 
         let mnemonic = bip39::Mnemonic::parse(phrase).unwrap();
@@ -2697,14 +3309,21 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
         let usk = UnifiedSpendingKey::from_seed(&params, seed.expose_secret(), account_id).unwrap();
         let birthday = &AccountBirthday::from_parts(
-            ChainState::empty(LRZBlockHeight::from_u32(0), zcash_primitives::block::BlockHash([0; 32])),
+            ChainState::empty(
+                LRZBlockHeight::from_u32(0),
+                zcash_primitives::block::BlockHash([0; 32]),
+            ),
             None,
         );
 
         (seed, usk)
     }
 
-    fn wallet_from_stuff<P: Parameters + 'static>(params: P, name: &'static str, seed: SecretVec<u8>) -> (ManualWallet, ManualAccount) {
+    fn wallet_from_stuff<P: Parameters + 'static>(
+        params: P,
+        name: &'static str,
+        seed: SecretVec<u8>,
+    ) -> (ManualWallet, ManualAccount) {
         // TODO: skip this by changing API slightly
         let account_id = zip32::AccountId::try_from(0).unwrap();
         let usk = UnifiedSpendingKey::from_seed(&params, seed.expose_secret(), account_id).unwrap();
@@ -2736,20 +3355,35 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
         (wallet, account)
     }
 
-    let addrs_from_wallet = |wallet: &ManualWallet| -> Option<(TransparentAddress, UnifiedAddress)> {
-        let Some(account) = wallet.accounts.first() else { return None; };
-        addrs_from_account(account, 0)
-    };
+    let addrs_from_wallet =
+        |wallet: &ManualWallet| -> Option<(TransparentAddress, UnifiedAddress)> {
+            let Some(account) = wallet.accounts.first() else {
+                return None;
+            };
+            addrs_from_account(account, 0)
+        };
 
     fn get_transaction_history(wallet: &ManualWallet) -> Result<Vec<WalletTx>, Infallible> {
         Ok(wallet.txs.clone())
     }
 
-    async fn get_received_memos_and_actions<P: zcash_protocol::consensus::Parameters>(client: &mut CompactTxStreamerClient<Channel>, wallet: &ManualWallet, params: P, history: &[WalletTx])
-        -> Option<(HashMap<TxId, (Option<StakingAction>, Vec<String>)>, HashMap<TxId, (Option<StakingAction>, Vec<String>)>)> {
-        fn try_get_orchard_memos(tx: &TransactionData<zcash_primitives::transaction::Authorized>, ivk: &orchard::keys::PreparedIncomingViewingKey) -> Vec<String> {
+    async fn get_received_memos_and_actions<P: zcash_protocol::consensus::Parameters>(
+        client: &mut CompactTxStreamerClient<Channel>,
+        wallet: &ManualWallet,
+        params: P,
+        history: &[WalletTx],
+    ) -> Option<(
+        HashMap<TxId, (Option<StakingAction>, Vec<String>)>,
+        HashMap<TxId, (Option<StakingAction>, Vec<String>)>,
+    )> {
+        fn try_get_orchard_memos(
+            tx: &TransactionData<zcash_primitives::transaction::Authorized>,
+            ivk: &orchard::keys::PreparedIncomingViewingKey,
+        ) -> Vec<String> {
             let mut memos = Vec::new();
-            let Some(bundle) = tx.orchard_bundle() else { return memos; };
+            let Some(bundle) = tx.orchard_bundle() else {
+                return memos;
+            };
 
             for action in bundle.actions() {
                 let domain = orchard::note_encryption::OrchardDomain::for_action(action);
@@ -2765,15 +3399,26 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
             return memos;
         }
-        fn try_get_orchard_sent_memos(tx: &TransactionData<zcash_primitives::transaction::Authorized>, ovk: &orchard::keys::OutgoingViewingKey) -> Vec<String> {
+        fn try_get_orchard_sent_memos(
+            tx: &TransactionData<zcash_primitives::transaction::Authorized>,
+            ovk: &orchard::keys::OutgoingViewingKey,
+        ) -> Vec<String> {
             // TODO: this is primarily for syncing txs that our wallet didn't observe sending; we
             // can optimize ones we sent directly
             let mut memos = Vec::new();
-            let Some(bundle) = tx.orchard_bundle() else { return memos; };
+            let Some(bundle) = tx.orchard_bundle() else {
+                return memos;
+            };
 
             for action in bundle.actions() {
                 let domain = orchard::note_encryption::OrchardDomain::for_action(action);
-                if let Some((_, _, memo)) = try_output_recovery_with_ovk(&domain, ovk, action, action.cv_net(), &action.encrypted_note().out_ciphertext) {
+                if let Some((_, _, memo)) = try_output_recovery_with_ovk(
+                    &domain,
+                    ovk,
+                    action,
+                    action.cv_net(),
+                    &action.encrypted_note().out_ciphertext,
+                ) {
                     let memo = String::from_utf8_lossy(&memo[..]);
                     if memo.len() == 0 {
                         continue;
@@ -2797,18 +3442,22 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
         //     .filter_map(|acc| acc.ok())
         //     .filter_map(|acc| acc)
         //     .collect();
-        let ufvks: Vec<UnifiedFullViewingKey> = wallet.accounts
-            .iter()
-            .map(|acc| acc.ufvk.clone())
-            .collect();
+        let ufvks: Vec<UnifiedFullViewingKey> =
+            wallet.accounts.iter().map(|acc| acc.ufvk.clone()).collect();
 
         for txid in &txids {
-            let filter = TxFilter{ hash: txid.as_ref().to_vec(), ..Default::default() };
-            let Ok(rawtx) = client.get_transaction(filter).await else { continue; };
+            let filter = TxFilter {
+                hash: txid.as_ref().to_vec(),
+                ..Default::default()
+            };
+            let Ok(rawtx) = client.get_transaction(filter).await else {
+                continue;
+            };
             let rawtx = rawtx.into_inner();
 
             let block_h = LRZBlockHeight::from_u32(rawtx.height as u32);
-            let Ok(tx) = Transaction::read(&*rawtx.data, BranchId::for_height(&params, block_h)) else {
+            let Ok(tx) = Transaction::read(&*rawtx.data, BranchId::for_height(&params, block_h))
+            else {
                 continue;
             };
 
@@ -2820,7 +3469,11 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
             let txdata = &tx.into_data();
             for ufvk in &ufvks {
                 let uivk = ufvk.to_unified_incoming_viewing_key();
-                let possible_orchard_ivk = if let Some(orchard_ivk) = uivk.orchard() { Some(orchard_ivk.prepare()) } else { None };
+                let possible_orchard_ivk = if let Some(orchard_ivk) = uivk.orchard() {
+                    Some(orchard_ivk.prepare())
+                } else {
+                    None
+                };
                 if let Some(orchard_ivk) = possible_orchard_ivk {
                     let m: Vec<String> = try_get_orchard_memos(txdata, &orchard_ivk)
                         .iter()
@@ -2834,10 +3487,11 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
             }
             txid_map.insert(*txid, (action.clone(), memos));
 
-
             let mut memos = Vec::new();
             for ufvk in &ufvks {
-                let Some(ufvk_orchard) = ufvk.orchard() else { continue; };
+                let Some(ufvk_orchard) = ufvk.orchard() else {
+                    continue;
+                };
                 let ovk = ufvk_orchard.to_ovk(orchard::keys::Scope::External);
                 let m: Vec<String> = try_get_orchard_sent_memos(txdata, &ovk)
                     .iter()
@@ -3010,42 +3664,45 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
     let network = &TEST_NETWORK;
 
-    *FAUCET_REQUEST.lock().unwrap() = Some(FaucetRequestClosure(Arc::new(|ua_str: String| -> Result<u64, String> {
-        // let ua = zcash_address::unified::Address::decode(&ua_str).map_err(|err|
-        //     Err(format!("invalid address: \"{ua_str}\" failed: {err}"))
-        // )?.1;
-        let ua = match zcash_keys::address::Address::decode(network, &ua_str) {
-            Some(zcash_keys::address::Address::Unified(ua)) => ua,
-            Some(_) => return Err(format!("must be an orchard-containing UA")),
-            None => return Err(format!("couldn't decode address")),
-        };
-        let Some(orchard_addr) = ua.orchard() else {
-            return Err(format!("must contain an orchard receiver"));
-        };
+    *FAUCET_REQUEST.lock().unwrap() = Some(FaucetRequestClosure(Arc::new(
+        |ua_str: String| -> Result<u64, String> {
+            // let ua = zcash_address::unified::Address::decode(&ua_str).map_err(|err|
+            //     Err(format!("invalid address: \"{ua_str}\" failed: {err}"))
+            // )?.1;
+            let ua = match zcash_keys::address::Address::decode(network, &ua_str) {
+                Some(zcash_keys::address::Address::Unified(ua)) => ua,
+                Some(_) => return Err(format!("must be an orchard-containing UA")),
+                None => return Err(format!("couldn't decode address")),
+            };
+            let Some(orchard_addr) = ua.orchard() else {
+                return Err(format!("must contain an orchard receiver"));
+            };
 
-        let mut q = FAUCET_Q.lock().unwrap();
-        if q.len() == q.data.len() {
-            return Err(format!("faucet too busy, come back later"));
-        }
-
-        for idx in 0..q.len() {
-            let i = (q.read_o as usize + idx) % q.data.len();
-            if let Some(existing_addr) = &q.data[i] {
-                if orchard_addr == existing_addr {
-                    return Err(format!("the last request for this address is still pending, come back later"));
-                }
-            } else {
-                println!("Faucet Q error: got None result where there should be valid data");
+            let mut q = FAUCET_Q.lock().unwrap();
+            if q.len() == q.data.len() {
+                return Err(format!("faucet too busy, come back later"));
             }
-        }
 
-        let i = q.write_o as usize % q.data.len();
-        q.write_o += 1;
-        q.data[i] = Some(orchard_addr.clone());
+            for idx in 0..q.len() {
+                let i = (q.read_o as usize + idx) % q.data.len();
+                if let Some(existing_addr) = &q.data[i] {
+                    if orchard_addr == existing_addr {
+                        return Err(format!(
+                            "the last request for this address is still pending, come back later"
+                        ));
+                    }
+                } else {
+                    println!("Faucet Q error: got None result where there should be valid data");
+                }
+            }
 
-        Ok(FAUCET_VALUE)
-    })));
+            let i = q.write_o as usize % q.data.len();
+            q.write_o += 1;
+            q.data[i] = Some(orchard_addr.clone());
 
+            Ok(FAUCET_VALUE)
+        },
+    )));
 
     let (
         mut miner_wallet,
@@ -3062,12 +3719,24 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
         let (seed, miner_usk) = stuff_from_seed_phrase(network,
             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
         );
-        let (miner_wallet, miner_account) = wallet_from_stuff(network, "miner", Secret::new(seed.expose_secret().clone()));
+        let (miner_wallet, miner_account) =
+            wallet_from_stuff(network, "miner", Secret::new(seed.expose_secret().clone()));
 
         let (miner_t_addr, miner_ua) = addrs_from_account(&miner_account, 0).unwrap();
         let miner_t_addr_str = miner_t_addr.encode(network);
         let (miner_pubkey, miner_privkey) = transparent_keys_from_usk(&miner_usk, 0).unwrap();
-        (miner_wallet, miner_account, seed, miner_usk, miner_pubkey, miner_privkey, miner_t_addr, miner_ua, HashMap::<TxId, (Option<StakingAction>, Vec<String>)>::new(), HashMap::<TxId, (Option<StakingAction>, Vec<String>)>::new())
+        (
+            miner_wallet,
+            miner_account,
+            seed,
+            miner_usk,
+            miner_pubkey,
+            miner_privkey,
+            miner_t_addr,
+            miner_ua,
+            HashMap::<TxId, (Option<StakingAction>, Vec<String>)>::new(),
+            HashMap::<TxId, (Option<StakingAction>, Vec<String>)>::new(),
+        )
     };
 
     let (
@@ -3082,11 +3751,17 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
         mut user_txid_map,
     ) = {
         // roundtrip seed through mnemonic phrase
-        let mnemonic = bip39::Mnemonic::from_entropy_in(bip39::Language::English, &global_seed).unwrap();
-        let phrase = mnemonic.words().map(|s| s.to_string()).collect::<Vec<String>>().join(" ");
+        let mnemonic =
+            bip39::Mnemonic::from_entropy_in(bip39::Language::English, &global_seed).unwrap();
+        let phrase = mnemonic
+            .words()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>()
+            .join(" ");
 
         let (seed, user_usk) = stuff_from_seed_phrase(network, &phrase);
-        let (user_wallet, user_account) = wallet_from_stuff(network, "user", Secret::new(seed.expose_secret().clone()));
+        let (user_wallet, user_account) =
+            wallet_from_stuff(network, "user", Secret::new(seed.expose_secret().clone()));
         let (user_t_addr, user_ua) = addrs_from_account(&user_account, 0).unwrap();
         let user_t_addr_str = user_t_addr.encode(network);
         let (user_pubkey, user_privkey) = transparent_keys_from_usk(&user_usk, 0).unwrap();
@@ -3095,20 +3770,32 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
         // NOTE: the default isn't the same as below, but I think this is because it forces a diversifier index
         // println!("User wallet: {}/{:?}", user_t_addr_str, user_t_addr1.encode(network));
 
-        (user_wallet, user_account, seed, user_usk, user_pubkey, user_privkey, user_t_addr, user_ua, HashMap::<TxId, (Option<StakingAction>, Vec<String>)>::new())
+        (
+            user_wallet,
+            user_account,
+            seed,
+            user_usk,
+            user_pubkey,
+            user_privkey,
+            user_t_addr,
+            user_ua,
+            HashMap::<TxId, (Option<StakingAction>, Vec<String>)>::new(),
+        )
     };
 
     let miner_ua_str = miner_ua.encode(network);
     let user_ua_str = user_ua.encode(network);
     println!("*************************");
-    println!("MINER WALLET T-ADDRESS: {}", miner_t_address.encode(network));
+    println!(
+        "MINER WALLET T-ADDRESS: {}",
+        miner_t_address.encode(network)
+    );
     println!("MINER WALLET ADDRESS:   {}", miner_ua_str);
     println!("USER WALLET T-ADDRESS:  {}", user_t_address.encode(network));
     println!("USER WALLET ADDRESS:    {}", user_ua_str);
     println!("*************************");
 
     wallet_state.lock().unwrap().user_recv_ua = user_ua_str.clone();
-
 
     println!("waiting for zaino to be ready...");
     wait_for_zainod().await;
@@ -3118,14 +3805,20 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
     let mut zaino_port = 0;
     loop {
         zaino_port = *wallet_main_zaino_port.lock().unwrap();
-        if zaino_port != 0 { break; }
+        if zaino_port != 0 {
+            break;
+        }
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
     }
 
     // @todo(judah): investigate why requests get randomly dropped in a strange way:
     // transport error, service not ready, etc.
     let mut client = loop {
-        if let Ok(channel) = Channel::from_shared(format!("http://localhost:{}", zaino_port)).unwrap().connect().await {
+        if let Ok(channel) = Channel::from_shared(format!("http://localhost:{}", zaino_port))
+            .unwrap()
+            .connect()
+            .await
+        {
             break CompactTxStreamerClient::new(channel);
         }
 
@@ -3133,24 +3826,62 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
     };
 
     if TEST_FAUCET {
-        println!("faucet: {:?}", client.request_faucet_donation(FaucetRequest{ address: user_ua_str.clone() }).await);
-        println!("faucet: {:?}", client.request_faucet_donation(FaucetRequest{ address: "arosienarsoienaroisetn".to_owned() }).await);
-        println!("faucet: {:?}", client.request_faucet_donation(FaucetRequest{ address: user_ua_str.clone() }).await);
+        println!(
+            "faucet: {:?}",
+            client
+                .request_faucet_donation(FaucetRequest {
+                    address: user_ua_str.clone()
+                })
+                .await
+        );
+        println!(
+            "faucet: {:?}",
+            client
+                .request_faucet_donation(FaucetRequest {
+                    address: "arosienarsoienaroisetn".to_owned()
+                })
+                .await
+        );
+        println!(
+            "faucet: {:?}",
+            client
+                .request_faucet_donation(FaucetRequest {
+                    address: user_ua_str.clone()
+                })
+                .await
+        );
         FAUCET_Q.lock().unwrap().read_o += 1; // fake read
-        println!("faucet: {:?}", client.request_faucet_donation(FaucetRequest{ address: user_ua_str.clone() }).await);
+        println!(
+            "faucet: {:?}",
+            client
+                .request_faucet_donation(FaucetRequest {
+                    address: user_ua_str.clone()
+                })
+                .await
+        );
     }
 
     // NOTE: current model is to reorg this many blocks back
     // ALT: have checkpoints every 16/32 blocks and always sync from the start of one of these
     const MAX_BLOCKS_TO_DOWNLOAD_AT_TIME: u64 = 64;
-    let mut time_since_last_transparent_shielded = std::time::Instant::now() - std::time::Duration::from_secs(1000);
+    let mut time_since_last_transparent_shielded =
+        std::time::Instant::now() - std::time::Duration::from_secs(1000);
 
-    let mut stupid_thing_because_judah_is_tired_and_wants_this_to_work_properly = Vec::<TxId>::new();
+    let mut stupid_thing_because_judah_is_tired_and_wants_this_to_work_properly =
+        Vec::<TxId>::new();
 
     let genesis_hash = loop {
-        match client.get_block(BlockId { height: 0, hash: Vec::new() }).await {
-            Ok(block) => { break <[u8;32]>::try_from(&block.into_inner().hash[..]).unwrap() },
-            Err(err) => { print!("failed to get genesis block") },
+        match client
+            .get_block(BlockId {
+                height: 0,
+                hash: Vec::new(),
+            })
+            .await
+        {
+            Ok(block) => break <[u8; 32]>::try_from(&block.into_inner().hash[..]).unwrap(),
+            Err(err) => {
+                print!("failed to get genesis block")
+            }
         }
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
     };
@@ -3159,7 +3890,10 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
     let mut pow_cache = PoWCache::new(0, genesis_hash);
     // NOTE: checkpoints allow us to reset the tree after a reorg & also create spend anchors
     const CHECKPOINTS_N: usize = 100;
-    let mut orchard_tree = OrchardShardTree::new(shardtree::store::memory::MemoryShardStore::empty(), CHECKPOINTS_N);
+    let mut orchard_tree = OrchardShardTree::new(
+        shardtree::store::memory::MemoryShardStore::empty(),
+        CHECKPOINTS_N,
+    );
     orchard_tree.checkpoint(BlockHeight(0)).unwrap();
 
     const MAX_TXS_TO_DOWNLOAD_AT_TIME: u64 = 64;
@@ -3185,7 +3919,9 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                             Ok(Some(tx)) => {
                                 // println!("MEMPOOL: got new message");
                                 if let Err(err) = mempool_send.send(tx).await {
-                                    println!("MEMPOOL ERROR: can't send message to channel: {err:?}");
+                                    println!(
+                                        "MEMPOOL ERROR: can't send message to channel: {err:?}"
+                                    );
                                     break;
                                 }
                             }
@@ -3225,8 +3961,22 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
     let mut resync_c = 0;
     'outer_sync: loop {
         if TEST_FAUCET {
-            println!("faucet: {:?}", client.request_faucet_donation(FaucetRequest{ address: user_ua_str.clone() }).await);
-            println!("faucet: {:?}", client.request_faucet_donation(FaucetRequest{ address: miner_ua_str.clone() }).await);
+            println!(
+                "faucet: {:?}",
+                client
+                    .request_faucet_donation(FaucetRequest {
+                        address: user_ua_str.clone()
+                    })
+                    .await
+            );
+            println!(
+                "faucet: {:?}",
+                client
+                    .request_faucet_donation(FaucetRequest {
+                        address: miner_ua_str.clone()
+                    })
+                    .await
+            );
         }
 
         if !just_init_new_tx && resync_c > 0 {
@@ -3237,29 +3987,42 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
         // NOTE: this is desynced from local_tip because we need to speculatively request blocks
         // further back than the chain divergence on reorg to find out where it occurred
-        let mut req_start_h = pow_cache.next_tip_h-1;
+        let mut req_start_h = pow_cache.next_tip_h - 1;
 
         // NOTE: if you're dealing with multiple wallets, you don't want to resync all blocks for each
         // of them. They can all sync from the same blocks.
         // TODO: this needs to be a bit more complicated to handle arbitrarily many transparent addresses
-        let (new_blocks, miner_t_txs, mut sync_from_i, req_rng, prev_tip_chain_state):
-            (Vec<CompactBlock>, Vec<(BlockHeight, Transaction)>, Option<usize>, (u64, u64), ChainState) =
-             'sync_find_continuation_point: loop
-        {
+        let (new_blocks, miner_t_txs, mut sync_from_i, req_rng, prev_tip_chain_state): (
+            Vec<CompactBlock>,
+            Vec<(BlockHeight, Transaction)>,
+            Option<usize>,
+            (u64, u64),
+            ChainState,
+        ) = 'sync_find_continuation_point: loop {
             // GET THE CURRENT STATE OF THE WORLD ////////////////////
             // BATCH NETWORK REQUESTS
             let (tree_state_res, lightd_res, block_range_res, t_txs_res, req_rng, t_req_rng) = {
                 use std::future::Ready;
                 // NOTE: clients are cheap to clone, and this is recommended in docs:
                 // REF: https://docs.rs/tonic/0.14.2/tonic/client/index.html
-                let (mut client0, mut client1, mut client2) = (client.clone(), client.clone(), client.clone());
+                let (mut client0, mut client1, mut client2) =
+                    (client.clone(), client.clone(), client.clone());
                 fn block_rng_from_heights(heights: (u64, u64)) -> BlockRange {
                     BlockRange {
-                        start: Some(BlockId { height: heights.0, hash: Vec::new() }),
-                        end:   Some(BlockId { height: heights.1, hash: Vec::new() }),
+                        start: Some(BlockId {
+                            height: heights.0,
+                            hash: Vec::new(),
+                        }),
+                        end: Some(BlockId {
+                            height: heights.1,
+                            hash: Vec::new(),
+                        }),
                     }
                 }
-                let req_rng = (req_start_h + 1, req_start_h + MAX_BLOCKS_TO_DOWNLOAD_AT_TIME);
+                let req_rng = (
+                    req_start_h + 1,
+                    req_start_h + MAX_BLOCKS_TO_DOWNLOAD_AT_TIME,
+                );
 
                 // ********************************************************************************
                 // TODO IMPORTANT: the indexer can "succeed" without actually giving us all the txs
@@ -3268,12 +4031,21 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                 // LRZ/Zaino/Zebra *should* return an error when iterating through the t_txs
                 // they also *shouldn't* return out-of-range responses
                 // ********************************************************************************
-                let t_req_rng = (req_rng.1.saturating_sub(2*MAX_BLOCKS_TO_DOWNLOAD_AT_TIME).max(1), req_rng.1);
+                let t_req_rng = (
+                    req_rng
+                        .1
+                        .saturating_sub(2 * MAX_BLOCKS_TO_DOWNLOAD_AT_TIME)
+                        .max(1),
+                    req_rng.1,
+                );
 
                 // println!("cache at {}, downloading blocks: {}-{}",
                 //     pow_cache.next_tip_h-1, block_range.start.clone().unwrap().height, block_range.end.clone().unwrap().height);
                 let (tree_state_res, lightd_res, block_range_res, t_txs_res) = tokio::join!(
-                    client.get_tree_state(BlockId {height: req_start_h, hash: Vec::new()}),
+                    client.get_tree_state(BlockId {
+                        height: req_start_h,
+                        hash: Vec::new()
+                    }),
                     client0.get_lightd_info(Empty {}),
                     client1.get_block_range(block_rng_from_heights(req_rng)),
                     client2.get_taddress_txids(TransparentAddressBlockFilter {
@@ -3281,15 +4053,22 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                         range: Some(block_rng_from_heights(t_req_rng)),
                     })
                 );
-                (tree_state_res, lightd_res, block_range_res, t_txs_res, req_rng, t_req_rng)
+                (
+                    tree_state_res,
+                    lightd_res,
+                    block_range_res,
+                    t_txs_res,
+                    req_rng,
+                    t_req_rng,
+                )
             };
 
             //- ROSTER
             // TODO: batch
-            match client.get_roster(Empty{}).await {
+            match client.get_roster(Empty {}).await {
                 Err(err) => println!("Get roster error: {err:?}"),
                 Ok(res) => {
-                    use std::io::{ Cursor,Read };
+                    use std::io::{Cursor, Read};
                     let roster_bytes = res.into_inner().data;
 
                     let mut ok = roster_bytes.len() > 0;
@@ -3298,7 +4077,11 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                     let mut new_roster = Vec::new();
                     let mut num_buf = [0u8; 8];
                     'read: while cur.position() < roster_bytes.len() as u64 {
-                        let mut m = RosterMember{ pub_key: [0;32], voting_power:0, txids: Vec::new() };
+                        let mut m = RosterMember {
+                            pub_key: [0; 32],
+                            voting_power: 0,
+                            txids: Vec::new(),
+                        };
                         if let Err(err) = cur.read_exact(&mut m.pub_key) {
                             println!("******* ROSTER DESERIALIZE ERROR: {err:?}");
                             ok = false;
@@ -3320,7 +4103,10 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                         let mut voting_power_check = 0;
                         let txids_n = u64::from_le_bytes(num_buf);
                         for _ in 0..txids_n {
-                            let mut stake_txid = StakeTxId{ txid:[0;32], zats:0 };
+                            let mut stake_txid = StakeTxId {
+                                txid: [0; 32],
+                                zats: 0,
+                            };
                             if let Err(err) = cur.read_exact(&mut stake_txid.txid) {
                                 println!("******* ROSTER DESERIALIZE ERROR: {err:?}");
                                 ok = false;
@@ -3338,7 +4124,12 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
                         if m.voting_power != voting_power_check {
                             // TODO: use manually-found one?
-                            if DUMP_ROSTER { println!("******* RECEIVED ROSTER VOTING POWER INACCURATE: {} vs {}", m.voting_power, voting_power_check); }
+                            if DUMP_ROSTER {
+                                println!(
+                                    "******* RECEIVED ROSTER VOTING POWER INACCURATE: {} vs {}",
+                                    m.voting_power, voting_power_check
+                                );
+                            }
                             // ok = false;
                             // break;
                         }
@@ -3352,19 +4143,22 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
                     let wallet_roster = roster
                         .iter()
-                        .map(|member| WalletRosterMember{
+                        .map(|member| WalletRosterMember {
                             pub_key: member.pub_key,
                             voting_power: member.voting_power,
-                            txids: member.txids.clone()
+                            txids: member.txids.clone(),
                         })
-                    .collect::<Vec<WalletRosterMember>>()
+                        .collect::<Vec<WalletRosterMember>>()
                         .clone();
-                    if DUMP_ROSTER { println!("*********** WALLET ROSTER: {wallet_roster:?}"); }
+                    if DUMP_ROSTER {
+                        println!("*********** WALLET ROSTER: {wallet_roster:?}");
+                    }
                     wallet_state.lock().unwrap().roster = wallet_roster;
                 }
             }
-            if DUMP_ROSTER { println!("*********** ROSTER: {roster:?}"); }
-
+            if DUMP_ROSTER {
+                println!("*********** ROSTER: {roster:?}");
+            }
 
             // NETWORK TIP HEIGHT
             // NOTE: I think this is only needed for telling the user how sync'd we are?
@@ -3381,13 +4175,12 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                     for wallet in [&mut miner_wallet, &mut user_wallet] {
                         wallet.chain_tip_h = BlockHeight(network_tip_h);
                     }
-                },
+                }
                 Err(err) => {
                     println!("Failed to get lightd info: {err:?}");
                     continue 'outer_sync; // TODO: don't continue if it's not actually critical
                 }
             }
-
 
             // PREV CHAIN STATE
             // TODO: do we need to redownload this? surely we have it locally (and catch reorgs without it)
@@ -3412,7 +4205,10 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
             // START DOWNLOADS FOR FULL TRANSACTIONS
             // TODO: fairer requests
-            for (wallet_i, wallet) in [&mut miner_wallet, &mut user_wallet].into_iter().enumerate() {
+            for (wallet_i, wallet) in [&mut miner_wallet, &mut user_wallet]
+                .into_iter()
+                .enumerate()
+            {
                 for tx in &wallet.txs {
                     // TODO: trigger whenever we see a tx we want more info on
                     if in_flight_tx_requests.len() >= MAX_TXS_TO_DOWNLOAD_AT_TIME as usize {
@@ -3428,7 +4224,10 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
                         let mut client = client.clone();
                         let txid = tx.txid;
-                        let filter = TxFilter{ hash: txid.as_ref().to_vec(), ..Default::default() };
+                        let filter = TxFilter {
+                            hash: txid.as_ref().to_vec(),
+                            ..Default::default()
+                        };
                         let _abort_handle = in_flight_tx_join_set.spawn(async move {
                             let str = format!("download {txid:?}");
                             let tz = Timer::scope(&str);
@@ -3440,8 +4239,8 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                                         println!("get transaction: {err:?}");
                                         None
                                     }
-                                    Ok(v) => Some(v.into_inner())
-                                }
+                                    Ok(v) => Some(v.into_inner()),
+                                },
                             )
                         });
                     }
@@ -3454,10 +4253,9 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                 Ok(blocks) => {
                     let mut block_stream = blocks.into_inner();
                     loop {
-                        match block_stream.message().await { // TODO: bulk await these?
-                            Ok(Some(block)) => {
-                                new_blocks.push(block)
-                            }
+                        match block_stream.message().await {
+                            // TODO: bulk await these?
+                            Ok(Some(block)) => new_blocks.push(block),
                             Ok(None) => break,
                             Err(err) => {
                                 if err.code() != tonic::Code::OutOfRange {
@@ -3487,26 +4285,36 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                     // and that also provides another race condition for out-of-sync data.
                     // TODO: determine whether we actually need tree/chain state (commitment trees etc) for syncing
                     // for i in 0..new_blocks.len()
-                    let Ok(prev_hash) = <[u8;32]>::try_from(&new_blocks[i].prev_hash[..]) else {
-                        println!("invalid prev_hash for compact block at height {}: {}", new_blocks[i].height, LESlice(&new_blocks[i].prev_hash));
+                    let Ok(prev_hash) = <[u8; 32]>::try_from(&new_blocks[i].prev_hash[..]) else {
+                        println!(
+                            "invalid prev_hash for compact block at height {}: {}",
+                            new_blocks[i].height,
+                            LESlice(&new_blocks[i].prev_hash)
+                        );
                         continue 'outer_sync;
                     };
 
-                    let expected_prev_hash = pow_cache.hash_at_h(new_blocks[i].height-1);
+                    let expected_prev_hash = pow_cache.hash_at_h(new_blocks[i].height - 1);
                     if i == 0 {
                         let mut needs_resync = false;
                         if prev_hash != prev_tip_chain_state.block_hash().0 {
                             println!("non-atomic API meant block range & chain-state are torn reads: {} vs {}", LEHash(prev_hash), LEHash(prev_tip_chain_state.block_hash().0));
-                            req_start_h = req_start_h.saturating_sub(MAX_BLOCKS_TO_DOWNLOAD_AT_TIME / 2);
+                            req_start_h =
+                                req_start_h.saturating_sub(MAX_BLOCKS_TO_DOWNLOAD_AT_TIME / 2);
                             needs_resync = true;
                         }
                         if Some(prev_hash) != expected_prev_hash {
-                            if DUMP_SYNC { println!("reorg occurred before height {}; hash mismatch {prev_hash:?} vs {expected_prev_hash:?}", new_blocks[0].height); }
-                            req_start_h = req_start_h.saturating_sub(MAX_BLOCKS_TO_DOWNLOAD_AT_TIME);
+                            if DUMP_SYNC {
+                                println!("reorg occurred before height {}; hash mismatch {prev_hash:?} vs {expected_prev_hash:?}", new_blocks[0].height);
+                            }
+                            req_start_h =
+                                req_start_h.saturating_sub(MAX_BLOCKS_TO_DOWNLOAD_AT_TIME);
                             needs_resync = true;
                         }
                         if needs_resync {
-                            if DUMP_SYNC { println!("hit discontinuity; handling reorg!"); }
+                            if DUMP_SYNC {
+                                println!("hit discontinuity; handling reorg!");
+                            }
                             continue 'sync_find_continuation_point;
                         }
                     }
@@ -3519,32 +4327,43 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                     // }
                 }
 
-
                 for block_i in first_new_block_i..new_blocks.len() {
                     // TODO: more data validation?
                     let mut data_is_invalid = false;
-                    let hash = if let Ok(hash) = <[u8;32]>::try_from(&new_blocks[block_i].hash[..]) {
+                    let hash = if let Ok(hash) = <[u8; 32]>::try_from(&new_blocks[block_i].hash[..])
+                    {
                         hash
                     } else {
-                        println!("invalid hash for compact block at height {}: {}", new_blocks[block_i].height, LESlice(&new_blocks[block_i].hash));
+                        println!(
+                            "invalid hash for compact block at height {}: {}",
+                            new_blocks[block_i].height,
+                            LESlice(&new_blocks[block_i].hash)
+                        );
                         data_is_invalid = true;
-                        [0;32]
+                        [0; 32]
                     };
                     if <u32>::try_from(new_blocks[block_i].height).is_err() {
-                        println!("block height cannot be stored in 32 bits: {}", new_blocks[block_i].height);
+                        println!(
+                            "block height cannot be stored in 32 bits: {}",
+                            new_blocks[block_i].height
+                        );
                         data_is_invalid = true;
                     }
                     for tx in &new_blocks[block_i].vtx {
-                        if <[u8;32]>::try_from(&new_blocks[block_i].hash[..]).is_err() {
+                        if <[u8; 32]>::try_from(&new_blocks[block_i].hash[..]).is_err() {
                             // TODO: are TxIds LE or BE?
-                            println!("invalid hash for compact tx at height {}: {:?}", new_blocks[block_i].height, tx.hash);
+                            println!(
+                                "invalid hash for compact tx at height {}: {:?}",
+                                new_blocks[block_i].height, tx.hash
+                            );
                             data_is_invalid = true;
                             break;
                         }
                     }
                     let new_tip_h = new_blocks[block_i].height;
-                    let cached_prev_hash = pow_cache.hash_at_h(new_tip_h-1);
-                    let pre_new_tip_hash = <[u8;32]>::try_from(&new_blocks[block_i].prev_hash[..]).unwrap();
+                    let cached_prev_hash = pow_cache.hash_at_h(new_tip_h - 1);
+                    let pre_new_tip_hash =
+                        <[u8; 32]>::try_from(&new_blocks[block_i].prev_hash[..]).unwrap();
                     // println!("pushing {} at {new_tip_h}, prev hash {pre_new_tip_hash:?} vs cached prev {cached_prev_hash:?}", LEHash(hash));
                     if let Some(cached_prev_hash) = cached_prev_hash {
                         if (cached_prev_hash != pre_new_tip_hash) {
@@ -3556,7 +4375,9 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                             // invalid res   ##--------
                             // valid 1       ##########
                             // valid 2       ----------
-                            if DUMP_SYNC { println!("reorg occurred in the middle of the returned blocks, caching up to the reorg, then we'll update to the other chain on the next iteration"); }
+                            if DUMP_SYNC {
+                                println!("reorg occurred in the middle of the returned blocks, caching up to the reorg, then we'll update to the other chain on the next iteration");
+                            }
                             data_is_invalid = true;
                         }
                     }
@@ -3574,9 +4395,24 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
             if sync_from_i.is_none() {
                 // println!("nothing to sync");
-                break (Vec::new(), Vec::new(), None, req_rng, ChainState::empty(LRZBlockHeight::from_u32(0), zcash_primitives::block::BlockHash([0; 32])));
+                break (
+                    Vec::new(),
+                    Vec::new(),
+                    None,
+                    req_rng,
+                    ChainState::empty(
+                        LRZBlockHeight::from_u32(0),
+                        zcash_primitives::block::BlockHash([0; 32]),
+                    ),
+                );
             }
-            if DUMP_SYNC { println!("downloaded compact blocks {}-{}", new_blocks.first().unwrap().height, new_blocks.last().unwrap().height); }
+            if DUMP_SYNC {
+                println!(
+                    "downloaded compact blocks {}-{}",
+                    new_blocks.first().unwrap().height,
+                    new_blocks.last().unwrap().height
+                );
+            }
 
             let compact_block_max_h = new_blocks.last().expect("non-empty vector").height;
 
@@ -3588,7 +4424,8 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                 Ok(t_txs) => {
                     let mut tx_stream = t_txs.into_inner();
                     loop {
-                        match tx_stream.message().await { // TODO: bulk await these?
+                        match tx_stream.message().await {
+                            // TODO: bulk await these?
                             Ok(Some(tx)) => {
                                 min_t_h = min_t_h.min(tx.height);
                                 max_t_h = max_t_h.max(tx.height);
@@ -3599,7 +4436,8 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                                 if err.code() != tonic::Code::OutOfRange {
                                     println!("failed to get transparent tx: {err:?}");
                                     // NOTE: this is overly conservative
-                                    t_failed_at_h = Some(new_raw_t_txs.last().map_or(0, |tx| tx.height+1));
+                                    t_failed_at_h =
+                                        Some(new_raw_t_txs.last().map_or(0, |tx| tx.height + 1));
                                 }
                                 break; // we can still update with the txs we got, we don't need to fully reset
                             }
@@ -3612,10 +4450,16 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                 }
             };
             if new_raw_t_txs.len() > 0 {
-                if DUMP_SYNC { println!("downloaded transparent txs at heights {}-{}", min_t_h, max_t_h); }
+                if DUMP_SYNC {
+                    println!(
+                        "downloaded transparent txs at heights {}-{}",
+                        min_t_h, max_t_h
+                    );
+                }
             }
 
-            let mut new_t_txs = Vec::<(BlockHeight, Transaction)>::with_capacity(new_raw_t_txs.len());
+            let mut new_t_txs =
+                Vec::<(BlockHeight, Transaction)>::with_capacity(new_raw_t_txs.len());
             for tx_i in 0..new_raw_t_txs.len() {
                 // ********************************************************************************
                 // TODO IMPORTANT: we can get the mined block hash for txs *individually* if we
@@ -3630,14 +4474,16 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
                 let h = match bc_h_from_raw_tx_h(raw_tx.height) {
                     Some(None) => {
-                        if DUMP_SYNC { println!("found sidechain transparent tx that we don't have height for, skipping..."); }
+                        if DUMP_SYNC {
+                            println!("found sidechain transparent tx that we don't have height for, skipping...");
+                        }
                         continue;
                     }
                     Some(Some(h)) => h,
                     None => break, // read error
                 };
 
-                if ! h.is_in_block() {
+                if !h.is_in_block() {
                     break;
                 }
                 if u64::from(h.0) > compact_block_max_h {
@@ -3645,7 +4491,10 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                     break;
                 }
 
-                let tx = match Transaction::read(&raw_tx.data[..], BranchId::for_height(network, LRZBlockHeight::from_u32(h.0))) {
+                let tx = match Transaction::read(
+                    &raw_tx.data[..],
+                    BranchId::for_height(network, LRZBlockHeight::from_u32(h.0)),
+                ) {
                     Ok(tx) => tx,
                     Err(err) => {
                         println!("failed to read transparent tx at height {h}");
@@ -3666,7 +4515,9 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
             // truncate compact blocks to match transparent // @in_step_sync
             if let Some(h) = t_failed_at_h {
-                if DUMP_SYNC { println!("truncating compact blocks to match transparent at {h}"); }
+                if DUMP_SYNC {
+                    println!("truncating compact blocks to match transparent at {h}");
+                }
                 // ALT: partition_point then truncate
                 while new_blocks.len() > 0 {
                     if new_blocks.last().unwrap().height < h {
@@ -3684,49 +4535,65 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                 }
             }
 
-            break (new_blocks, new_t_txs, sync_from_i, req_rng, prev_tip_chain_state);
+            break (
+                new_blocks,
+                new_t_txs,
+                sync_from_i,
+                req_rng,
+                prev_tip_chain_state,
+            );
         };
 
-        let wallets_sync_h = BlockHeight((pow_cache.next_tip_h-1).try_into().unwrap());
+        let wallets_sync_h = BlockHeight((pow_cache.next_tip_h - 1).try_into().unwrap());
         let network_tip_h = user_wallet.chain_tip_h;
 
         // let mut orchard_frontier = prev_tip_chain_state.final_orchard_tree().clone();
         // let mut orchard_tree = incrementalmerkletree::frontier::CommitmentTree::from_frontier(&orchard_frontier);
         // println!("orchard root at {:?} tree: size={} {:?}", prev_tip_chain_state.block_height(), shard_tree_size(orchard_tree), shard_tree_root(orchard_tree));
 
-
         //-- REORG
         // TODO: double check mempool invalidation sequences correctly with async read (account for tip height on downloaded tx)
         if let Some(start_block_i) = sync_from_i {
             // the regime is basically "always reorg", but that's often a no-op
             // truncate wallet for everything below height
-            let sync_start_h = <u32>::try_from(new_blocks[start_block_i].height).expect("successfully converted above");
+            let sync_start_h = <u32>::try_from(new_blocks[start_block_i].height)
+                .expect("successfully converted above");
             let block_h = BlockHeight(sync_start_h);
             let last_block_h = block_h.sat_sub(1);
 
             orchard_tree.truncate_to_checkpoint(&last_block_h); // N.B. checkpoints are at the *end* of their block
 
-            for (wallet_i, wallet) in [&mut miner_wallet, &mut user_wallet].into_iter().enumerate() {
+            for (wallet_i, wallet) in [&mut miner_wallet, &mut user_wallet]
+                .into_iter()
+                .enumerate()
+            {
                 //-- INVALIDATE TXS >= NEW BLOCKS HEIGHT
                 for account in &mut wallet.accounts {
                     account.fully_detected_h = account.fully_detected_h.min(last_block_h);
                     account.fully_decoded_h = account.fully_decoded_h.min(last_block_h);
 
                     // TODO: do we want to track balance changes or keep balances updated as chain changes occur?
-                    let truncate_to_i = account.balance_changes.partition_point(|(b,_)| *b < block_h);
+                    let truncate_to_i = account
+                        .balance_changes
+                        .partition_point(|(b, _)| *b < block_h);
                     account.balance_changes.truncate(truncate_to_i);
 
                     //- UNRECEIVE NOTES
                     {
-                        let utxos_at_h_start = account.utxos.partition_point(|txo| txo.recv_h < block_h);
+                        let utxos_at_h_start =
+                            account.utxos.partition_point(|txo| txo.recv_h < block_h);
                         account.utxos.truncate(utxos_at_h_start);
-                        let recv_txos_at_h_start = account.recv_txos.partition_point(|txo| txo.recv_h < block_h);
+                        let recv_txos_at_h_start = account
+                            .recv_txos
+                            .partition_point(|txo| txo.recv_h < block_h);
 
                         #[cfg(debug_assertions)]
                         for txo in &account.recv_txos[recv_txos_at_h_start..] {
                             let mut g_log = NOTE_LOG.lock().unwrap();
-                            if let Some((tx_log, seq)) = g_log.get_expected(wallet.name, &txo.txid(), "unreceive") {
-                                tx_log.push(DevNoteAction{
+                            if let Some((tx_log, seq)) =
+                                g_log.get_expected(wallet.name, &txo.txid(), "unreceive")
+                            {
+                                tx_log.push(DevNoteAction {
                                     seq,
                                     kind: DevNoteActionKind::Unrecv,
                                     note: DevNote::Txo(txo.clone()),
@@ -3740,14 +4607,22 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                     }
 
                     {
-                        let unspent_orchard_notes_at_h_start = account.unspent_orchard_notes.partition_point(|txo| txo.recv_h < block_h);
-                        account.unspent_orchard_notes.truncate(unspent_orchard_notes_at_h_start);
-                        let recv_orchard_notes_at_h_start = account.recv_orchard_notes.partition_point(|txo| txo.recv_h < block_h);
+                        let unspent_orchard_notes_at_h_start = account
+                            .unspent_orchard_notes
+                            .partition_point(|txo| txo.recv_h < block_h);
+                        account
+                            .unspent_orchard_notes
+                            .truncate(unspent_orchard_notes_at_h_start);
+                        let recv_orchard_notes_at_h_start = account
+                            .recv_orchard_notes
+                            .partition_point(|txo| txo.recv_h < block_h);
                         #[cfg(debug_assertions)]
                         for note in &account.recv_orchard_notes[recv_orchard_notes_at_h_start..] {
                             let mut g_log = NOTE_LOG.lock().unwrap();
-                            if let Some((tx_log, seq)) = g_log.get_expected(wallet.name, &note.txid, "unreceive") {
-                                tx_log.push(DevNoteAction{
+                            if let Some((tx_log, seq)) =
+                                g_log.get_expected(wallet.name, &note.txid, "unreceive")
+                            {
+                                tx_log.push(DevNoteAction {
                                     seq,
                                     kind: DevNoteActionKind::Unrecv,
                                     note: DevNote::OrchardNote(note.clone()),
@@ -3756,19 +4631,24 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                                 });
                             }
                         }
-                        account.recv_orchard_notes.truncate(recv_orchard_notes_at_h_start);
+                        account
+                            .recv_orchard_notes
+                            .truncate(recv_orchard_notes_at_h_start);
                     }
 
                     //- UNSPEND NOTES
                     // NOTE: spent notes are in spend_h order, NOT recv_h order
                     {
-                        let stxos_at_h_start = account.stxos.partition_point(|txo| txo.spent_h < block_h);
+                        let stxos_at_h_start =
+                            account.stxos.partition_point(|txo| txo.spent_h < block_h);
                         for stxo in &account.stxos[stxos_at_h_start..] {
                             #[cfg(debug_assertions)]
                             {
                                 let mut g_log = NOTE_LOG.lock().unwrap();
-                                if let Some((tx_log, seq)) = g_log.get_expected(wallet.name, &stxo.txid(), "unspend") {
-                                    tx_log.push(DevNoteAction{
+                                if let Some((tx_log, seq)) =
+                                    g_log.get_expected(wallet.name, &stxo.txid(), "unspend")
+                                {
+                                    tx_log.push(DevNoteAction {
                                         seq,
                                         kind: DevNoteActionKind::Unspend,
                                         note: DevNote::Txo(stxo.clone()),
@@ -3779,20 +4659,30 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                             }
 
                             if stxo.recv_h < block_h {
-                                txo_recv_h_insert(&mut account.utxos, Txo{ spent_h: BlockHeight(0), ..stxo.clone() });
+                                txo_recv_h_insert(
+                                    &mut account.utxos,
+                                    Txo {
+                                        spent_h: BlockHeight(0),
+                                        ..stxo.clone()
+                                    },
+                                );
                             }
                         }
                         account.stxos.truncate(stxos_at_h_start);
                     }
 
                     {
-                        let spent_orchard_notes_at_h_start = account.spent_orchard_notes.partition_point(|note| note.spent_h < block_h);
+                        let spent_orchard_notes_at_h_start = account
+                            .spent_orchard_notes
+                            .partition_point(|note| note.spent_h < block_h);
                         for note in &account.spent_orchard_notes[spent_orchard_notes_at_h_start..] {
                             #[cfg(debug_assertions)]
                             {
                                 let mut g_log = NOTE_LOG.lock().unwrap();
-                                if let Some((tx_log, seq)) = g_log.get_expected(wallet.name, &note.txid, "unspend") {
-                                    tx_log.push(DevNoteAction{
+                                if let Some((tx_log, seq)) =
+                                    g_log.get_expected(wallet.name, &note.txid, "unspend")
+                                {
+                                    tx_log.push(DevNoteAction {
                                         seq,
                                         kind: DevNoteActionKind::Unspend,
                                         note: DevNote::OrchardNote(note.clone()),
@@ -3803,10 +4693,18 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                             }
 
                             if note.recv_h < block_h {
-                                orchard_recv_h_insert(&mut account.unspent_orchard_notes, OrchardNote{ spent_h: BlockHeight(0), ..note.clone() });
+                                orchard_recv_h_insert(
+                                    &mut account.unspent_orchard_notes,
+                                    OrchardNote {
+                                        spent_h: BlockHeight(0),
+                                        ..note.clone()
+                                    },
+                                );
                             }
                         }
-                        account.spent_orchard_notes.truncate(spent_orchard_notes_at_h_start);
+                        account
+                            .spent_orchard_notes
+                            .truncate(spent_orchard_notes_at_h_start);
                     }
                 }
 
@@ -3827,7 +4725,6 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
             }
         }
 
-
         //-- ADD/REVALIDATE TRANSPARENT TXS (and attached shielded data)
         {
             // see note above on transparent syncing
@@ -3842,7 +4739,15 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                 // kinda @in_step_sync
                 let block_h = miner_t_txs[t_tx_i].0;
                 let tx = &miner_t_txs[t_tx_i].1;
-                read_full_tx(&mut miner_wallet, 0, &keys, block_h, tx, &mut insert_i, TxStatus::OnBc);
+                read_full_tx(
+                    &mut miner_wallet,
+                    0,
+                    &keys,
+                    block_h,
+                    tx,
+                    &mut insert_i,
+                    TxStatus::OnBc,
+                );
             }
         }
 
@@ -3860,10 +4765,16 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
             while let Ok(raw_tx) = mempool_recv.try_recv() {
                 if DUMP_SYNC {
-                    println!("got mempool tx with tip height: {} vs chain tip {}", raw_tx.height, wallets[0].chain_tip_h.0);
+                    println!(
+                        "got mempool tx with tip height: {} vs chain tip {}",
+                        raw_tx.height, wallets[0].chain_tip_h.0
+                    );
                 }
                 // NOTE: expected LRZ height different from abstract mempool height
-                match Transaction::read(&raw_tx.data[..], BranchId::for_height(network, LRZBlockHeight::from_u32(network_tip_h.0 + 1))) {
+                match Transaction::read(
+                    &raw_tx.data[..],
+                    BranchId::for_height(network, LRZBlockHeight::from_u32(network_tip_h.0 + 1)),
+                ) {
                     Err(err) => {
                         println!("invalid mempool tx: {err:?}");
                         // NOTE: as mempool txs are not sequenced, it seems reasonable to just ignore
@@ -3871,25 +4782,40 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                     }
                     Ok(tx) => {
                         for i in 0..2 {
-                            read_full_tx(wallets[i], 0, &keys[i], BlockHeight::MEMPOOL, &tx, insert_idxs[i], TxStatus::OnBc);
+                            read_full_tx(
+                                wallets[i],
+                                0,
+                                &keys[i],
+                                BlockHeight::MEMPOOL,
+                                &tx,
+                                insert_idxs[i],
+                                TxStatus::OnBc,
+                            );
                         }
                     }
                 }
             }
         }
 
-
         //-- ADD/REVALIDATE SHIELDED TXS FROM NEW BLOCKS -- CANONICAL "SPINE"
         if let Some(start_block_i) = sync_from_i {
-            let sync_start_h = <u32>::try_from(new_blocks[start_block_i].height).expect("successfully converted above");
+            let sync_start_h = <u32>::try_from(new_blocks[start_block_i].height)
+                .expect("successfully converted above");
             if DUMP_SYNC {
-                println!("cache at {}, new blocks: {}-{}; updating wallets...",
-                    pow_cache.next_tip_h-1, new_blocks.first().unwrap().height, new_blocks.last().unwrap().height);
+                println!(
+                    "cache at {}, new blocks: {}-{}; updating wallets...",
+                    pow_cache.next_tip_h - 1,
+                    new_blocks.first().unwrap().height,
+                    new_blocks.last().unwrap().height
+                );
             }
 
             let rng_start_orchard_tree_size = shard_tree_size(&orchard_tree);
 
-            for (wallet_i, wallet) in [&mut miner_wallet, &mut user_wallet].into_iter().enumerate() {
+            for (wallet_i, wallet) in [&mut miner_wallet, &mut user_wallet]
+                .into_iter()
+                .enumerate()
+            {
                 let mut next_orchard_pos = rng_start_orchard_tree_size;
                 let keys = PreparedKeys::from_ufvk_ivks(&wallet.accounts[0].ufvk); // NOTE: can't use ovk for CompactTx
                 let mut insert_i = 0;
@@ -3897,10 +4823,18 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                     let block_h = BlockHeight(block.height.try_into().unwrap());
                     update_insert_i(&wallet.txs, &mut insert_i, block_h);
 
-
                     //-- INCORPORATE SHIELDED TRANSACTIONS FROM COMPACT BLOCK
                     'tx_iter: for tx in &block.vtx {
-                        if let (txid, true, true) = read_compact_tx(wallet, 0, &keys, block_h, tx, &mut next_orchard_pos, &mut insert_i, &mut orchard_tree) {
+                        if let (txid, true, true) = read_compact_tx(
+                            wallet,
+                            0,
+                            &keys,
+                            block_h,
+                            tx,
+                            &mut next_orchard_pos,
+                            &mut insert_i,
+                            &mut orchard_tree,
+                        ) {
                             // println!("found our compact tx: {txid:?}");
                         }
                     }
@@ -3915,19 +4849,24 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
             }
         }
 
-
         //-- READ ANY DOWNLOADED FULL TXS
         if in_flight_tx_requests.len() > 0 {
-            if DUMP_SYNC { println!("before reading, there are {} in flight tx downloads", in_flight_tx_requests.len()); }
+            if DUMP_SYNC {
+                println!(
+                    "before reading, there are {} in flight tx downloads",
+                    in_flight_tx_requests.len()
+                );
+            }
             let wallets = [&mut miner_wallet, &mut user_wallet];
             while let Some(tx_completion) = in_flight_tx_join_set.try_join_next() {
-                let (txid, wallet_i, dl_result): (TxId, usize, Option<RawTransaction>) = match tx_completion {
-                    Ok(v) => v,
-                    Err(err) => {
-                        println!("tx completion join error: {err:?}");
-                        continue
-                    }
-                };
+                let (txid, wallet_i, dl_result): (TxId, usize, Option<RawTransaction>) =
+                    match tx_completion {
+                        Ok(v) => v,
+                        Err(err) => {
+                            println!("tx completion join error: {err:?}");
+                            continue;
+                        }
+                    };
 
                 // ALT: do (most of) this work in the task
                 // ALT: we have the option for best-chain/height info of:
@@ -3937,40 +4876,72 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                 //   * Choosing this because currently block-reading is the only way we detect
                 //     inconsistency around reorg; we don't want to add stale data here that never
                 //     gets fixed
-                if DUMP_SYNC { println!("download finished for {txid:?}"); }
+                if DUMP_SYNC {
+                    println!("download finished for {txid:?}");
+                }
                 in_flight_tx_requests.remove(&txid);
-                if let (Some(raw_tx), Some(existing_tx_i)) = (dl_result, tx_position(&wallets[wallet_i], &txid)) {
+                if let (Some(raw_tx), Some(existing_tx_i)) =
+                    (dl_result, tx_position(&wallets[wallet_i], &txid))
+                {
                     let existing_tx = &wallets[wallet_i].txs[existing_tx_i];
 
                     let found_h = match bc_h_from_raw_tx_h(raw_tx.height) {
                         Some(None) => existing_tx.h, // on sidechain: use previously-spec'd height
                         Some(Some(h)) => {
                             if h != existing_tx.h {
-                                println!("requested tx {txid:?} has moved from {:?} to {h:?}", existing_tx.h);
+                                println!(
+                                    "requested tx {txid:?} has moved from {:?} to {h:?}",
+                                    existing_tx.h
+                                );
                             }
                             h
-                        },
+                        }
                         None => continue, // read error
                     };
 
                     // NOTE: there's a potential inconsistency here around branch id changes if we
                     // see it both before and after the change
-                    let lrz_h = LRZBlockHeight::from_u32(if found_h.is_in_block() { found_h.0 } else { network_tip_h.0 });
-                    let tx = match Transaction::read(&raw_tx.data[..], BranchId::for_height(network, lrz_h)) {
+                    let lrz_h = LRZBlockHeight::from_u32(if found_h.is_in_block() {
+                        found_h.0
+                    } else {
+                        network_tip_h.0
+                    });
+                    let tx = match Transaction::read(
+                        &raw_tx.data[..],
+                        BranchId::for_height(network, lrz_h),
+                    ) {
                         Ok(tx) => tx,
                         Err(err) => {
-                            println!("failed to read tx at height {:?}/{found_h:?}/{lrz_h:?}", existing_tx.h);
+                            println!(
+                                "failed to read tx at height {:?}/{found_h:?}/{lrz_h:?}",
+                                existing_tx.h
+                            );
                             continue;
                         }
                     };
 
-                    if DUMP_SYNC { println!("reading downloaded full tx for {txid:?}"); }
+                    if DUMP_SYNC {
+                        println!("reading downloaded full tx for {txid:?}");
+                    }
                     let keys = PreparedKeys::from_ufvk_all(&wallets[wallet_i].accounts[0].ufvk);
 
-                    read_full_tx(wallets[wallet_i], 0, &keys, existing_tx.h, &tx, &mut 0, existing_tx.status);
+                    read_full_tx(
+                        wallets[wallet_i],
+                        0,
+                        &keys,
+                        existing_tx.h,
+                        &tx,
+                        &mut 0,
+                        existing_tx.status,
+                    );
                 }
             }
-            if DUMP_SYNC { println!("after  reading, there are {} in flight tx downloads", in_flight_tx_requests.len()); }
+            if DUMP_SYNC {
+                println!(
+                    "after  reading, there are {} in flight tx downloads",
+                    in_flight_tx_requests.len()
+                );
+            }
         }
 
         //-- SEND DATA TO UI
@@ -3978,10 +4949,22 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
             if DUMP_NOTES {
                 // println!("miner unspent UTXOs {:#?}", NL(&*miner_wallet.accounts[0].utxos));
                 // println!("miner spent   UTXOs {:#?}", NL(&*miner_wallet.accounts[0].stxos));
-                println!("miner unspent notes {:#?}", NL(&*miner_wallet.accounts[0].unspent_orchard_notes));
-                println!("miner spent   notes {:#?}", NL(&*miner_wallet.accounts[0].spent_orchard_notes));
-                println!("user  unspent notes {:#?}", NL(&*user_wallet.accounts[0].unspent_orchard_notes));
-                println!("user  spent   notes {:#?}", NL(&*user_wallet.accounts[0].spent_orchard_notes));
+                println!(
+                    "miner unspent notes {:#?}",
+                    NL(&*miner_wallet.accounts[0].unspent_orchard_notes)
+                );
+                println!(
+                    "miner spent   notes {:#?}",
+                    NL(&*miner_wallet.accounts[0].spent_orchard_notes)
+                );
+                println!(
+                    "user  unspent notes {:#?}",
+                    NL(&*user_wallet.accounts[0].unspent_orchard_notes)
+                );
+                println!(
+                    "user  spent   notes {:#?}",
+                    NL(&*user_wallet.accounts[0].spent_orchard_notes)
+                );
             }
 
             let mut miner_unshielded_funds = 0;
@@ -4020,26 +5003,57 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
             let mut stake_positions_bonded = Vec::new();
             let mut stake_positions_unbonded = Vec::new();
             for tx in &user_wallet.txs {
-                if !(tx.is_on_bc() && tx.h.is_in_block()) { continue; }
+                if !(tx.is_on_bc() && tx.h.is_in_block()) {
+                    continue;
+                }
                 if let Some(staking_action) = (&tx.staking_action) {
-                    if let Some(create_bond) = StakingAction_CreateNewDelegationBond::try_from_union(staking_action) {
-                        stake_positions_bonded.push((create_bond.unique_pubkey, create_bond.target_finalizer, create_bond.amount_zats));
+                    if let Some(create_bond) =
+                        StakingAction_CreateNewDelegationBond::try_from_union(staking_action)
+                    {
+                        stake_positions_bonded.push((
+                            create_bond.unique_pubkey,
+                            create_bond.target_finalizer,
+                            create_bond.amount_zats,
+                        ));
                     }
-                    if let Some(retarget) = StakingAction_RetargetDelegationBond::try_from_union(staking_action) {
-                        if let Some(existing_i) = stake_positions_bonded.iter().position(|p| p.0 == retarget.unique_pubkey) {
+                    if let Some(retarget) =
+                        StakingAction_RetargetDelegationBond::try_from_union(staking_action)
+                    {
+                        if let Some(existing_i) = stake_positions_bonded
+                            .iter()
+                            .position(|p| p.0 == retarget.unique_pubkey)
+                        {
                             stake_positions_bonded[existing_i].1 = retarget.target_finalizer;
                         }
                     }
-                    if let Some(unbond) = StakingAction_BeginDelegationUnbonding::try_from_union(staking_action) {
-                        if let Some(existing_i) = stake_positions_bonded.iter().position(|p| p.0 == unbond.unique_pubkey) {
-                            stake_positions_unbonded.push((unbond.unique_pubkey, stake_positions_bonded[existing_i].1, stake_positions_bonded[existing_i].2));
+                    if let Some(unbond) =
+                        StakingAction_BeginDelegationUnbonding::try_from_union(staking_action)
+                    {
+                        if let Some(existing_i) = stake_positions_bonded
+                            .iter()
+                            .position(|p| p.0 == unbond.unique_pubkey)
+                        {
+                            stake_positions_unbonded.push((
+                                unbond.unique_pubkey,
+                                stake_positions_bonded[existing_i].1,
+                                stake_positions_bonded[existing_i].2,
+                            ));
                             stake_positions_bonded.remove(existing_i);
                         } else {
-                            stake_positions_unbonded.push((unbond.unique_pubkey, [0; 32], u64::MAX));
+                            stake_positions_unbonded.push((
+                                unbond.unique_pubkey,
+                                [0; 32],
+                                u64::MAX,
+                            ));
                         }
                     }
-                    if let Some(unbond) = StakingAction_WithdrawDelegationBond::try_from_union(staking_action) {
-                        if let Some(existing_i) = stake_positions_unbonded.iter().position(|p| p.0 == unbond.unique_pubkey) {
+                    if let Some(unbond) =
+                        StakingAction_WithdrawDelegationBond::try_from_union(staking_action)
+                    {
+                        if let Some(existing_i) = stake_positions_unbonded
+                            .iter()
+                            .position(|p| p.0 == unbond.unique_pubkey)
+                        {
                             stake_positions_unbonded.remove(existing_i);
                         }
                     }
@@ -4059,10 +5073,22 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                 }
                 user_withdrawable_funds += p.2;
             }
-            user_wallet.care_about_bonds = stake_positions_bonded.iter().map(|p| p.0).chain(stake_positions_unbonded.iter().map(|p| p.0)).collect();
+            user_wallet.care_about_bonds = stake_positions_bonded
+                .iter()
+                .map(|p| p.0)
+                .chain(stake_positions_unbonded.iter().map(|p| p.0))
+                .collect();
 
-            fn push_if_proposed_tx(arr: &mut[WalletTx], n: &mut usize, proposed: &ProposedTx, min_stage: BlockHeight) -> bool {
-                if proposed.is_in_progress() && proposed.tx.h >= min_stage && proposed.tx.h != BlockHeight::INVALID {
+            fn push_if_proposed_tx(
+                arr: &mut [WalletTx],
+                n: &mut usize,
+                proposed: &ProposedTx,
+                min_stage: BlockHeight,
+            ) -> bool {
+                if proposed.is_in_progress()
+                    && proposed.tx.h >= min_stage
+                    && proposed.tx.h != BlockHeight::INVALID
+                {
                     // TODO: ordering by sequence number?
                     arr[*n] = proposed.tx;
                     *n += 1;
@@ -4075,10 +5101,30 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
             let mut user_local_txs_n = 0;
             let mut miner_local_txs = [WalletTx::EMPTY; 3];
             let mut miner_local_txs_n = 0;
-            let waiting_for_send = push_if_proposed_tx(&mut user_local_txs, &mut user_local_txs_n, &proposed_send, BlockHeight::PROPOSED);
-            let waiting_for_stake_to_finalizer = push_if_proposed_tx(&mut user_local_txs, &mut user_local_txs_n, &proposed_stake, BlockHeight::PROPOSED);
-            let waiting_for_faucet = push_if_proposed_tx(&mut miner_local_txs, &mut miner_local_txs_n, &proposed_faucet, BlockHeight::PROPOSED);
-            let waiting_for_shield = push_if_proposed_tx(&mut miner_local_txs, &mut miner_local_txs_n, &proposed_miner_shield, BlockHeight::PROPOSED);
+            let waiting_for_send = push_if_proposed_tx(
+                &mut user_local_txs,
+                &mut user_local_txs_n,
+                &proposed_send,
+                BlockHeight::PROPOSED,
+            );
+            let waiting_for_stake_to_finalizer = push_if_proposed_tx(
+                &mut user_local_txs,
+                &mut user_local_txs_n,
+                &proposed_stake,
+                BlockHeight::PROPOSED,
+            );
+            let waiting_for_faucet = push_if_proposed_tx(
+                &mut miner_local_txs,
+                &mut miner_local_txs_n,
+                &proposed_faucet,
+                BlockHeight::PROPOSED,
+            );
+            let waiting_for_shield = push_if_proposed_tx(
+                &mut miner_local_txs,
+                &mut miner_local_txs_n,
+                &proposed_miner_shield,
+                BlockHeight::PROPOSED,
+            );
 
             // CHEATING USER-VIEW OF FAUCET BUILD
             if proposed_faucet.is_user_faucet {
@@ -4088,7 +5134,12 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                     tx_res: None,
                     is_user_faucet: false,
                 };
-                push_if_proposed_tx(&mut user_local_txs, &mut user_local_txs_n, &user_view_of_faucet_tx, BlockHeight::PROPOSED);
+                push_if_proposed_tx(
+                    &mut user_local_txs,
+                    &mut user_local_txs_n,
+                    &user_view_of_faucet_tx,
+                    BlockHeight::PROPOSED,
+                );
             }
 
             let new_wallet_state_push_time = Instant::now();
@@ -4126,7 +5177,6 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
             lock.withdrawable_balance = user_withdrawable_funds;
         }
 
-
         // Anchor debugging
         // {
         //     for i in 0..miner_wallet.chain_tip_h.0 {
@@ -4142,15 +5192,34 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
         //     }
         // }
 
-        if faucet_shield_cooldown_instant.elapsed().as_secs() > 15 && !proposed_miner_shield.is_in_progress() {
+        if faucet_shield_cooldown_instant.elapsed().as_secs() > 15
+            && !proposed_miner_shield.is_in_progress()
+        {
             let memo = MemoBytes::from_bytes("shielding notes".as_bytes()).unwrap();
-            let ok = miner_wallet.shield_transparent_zats(network, &mut proposed_miner_shield, &mut client, &miner_usk, 1000000000, &orchard_tree, memo).is_some();
-            if DUMP_TX_BUILD { println!("Try miner shield {ok:?}"); }
+            let ok = miner_wallet
+                .shield_transparent_zats(
+                    network,
+                    &mut proposed_miner_shield,
+                    &mut client,
+                    &miner_usk,
+                    1000000000,
+                    &orchard_tree,
+                    memo,
+                )
+                .is_some();
+            if DUMP_TX_BUILD {
+                println!("Try miner shield {ok:?}");
+            }
             faucet_shield_cooldown_instant = Instant::now();
 
             // also inspect bonds
             for bond_key in &user_wallet.care_about_bonds {
-                match client.get_bond_info(zcash_client_backend::proto::service::BondInfoRequest { bond_key: bond_key.to_vec(), }).await {
+                match client
+                    .get_bond_info(zcash_client_backend::proto::service::BondInfoRequest {
+                        bond_key: bond_key.to_vec(),
+                    })
+                    .await
+                {
                     Ok(response) => {
                         let info = response.into_inner();
                         user_wallet.seen_bond_values.insert(*bond_key, info.amount);
@@ -4163,17 +5232,27 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
         }
 
         if AUTO_SPEND {
-            if /*user_wallet.accounts[0].unspent_orchard_notes.len() == 0 &&*/ !proposed_faucet.is_in_progress() {
+            if
+            /*user_wallet.accounts[0].unspent_orchard_notes.len() == 0 &&*/
+            !proposed_faucet.is_in_progress() {
                 // the user needs money, try to send some (doesn't matter if we fail until we've mined some)
-                let ok = miner_wallet.send_orchard_to_orchard_zats(network, &mut proposed_faucet, &mut client, &miner_usk, FAUCET_VALUE, &orchard_tree, *user_ua.orchard().unwrap(),
-                    MemoBytes::from_bytes("auto-sent from miner".as_bytes()).unwrap()
-                ).is_some();
-            } else if ! auto_spend.0 {
+                let ok = miner_wallet
+                    .send_orchard_to_orchard_zats(
+                        network,
+                        &mut proposed_faucet,
+                        &mut client,
+                        &miner_usk,
+                        FAUCET_VALUE,
+                        &orchard_tree,
+                        *user_ua.orchard().unwrap(),
+                        MemoBytes::from_bytes("auto-sent from miner".as_bytes()).unwrap(),
+                    )
+                    .is_some();
+            } else if !auto_spend.0 {
                 // auto_spend.0 = true;
                 // proposed_stake = user_wallet.stake_orchard_to_finalizer(network, &mut client, &user_usk, 100_000_000, &orchard_tree, [0xcd;32]);
             }
         }
-
 
         // @todo(judah): I'm thinking the weird frame hitch we get in the UI is caused by this loop,
         // since it's probably waiting for the wallet_state mutex to unlock.
@@ -4194,20 +5273,42 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
             let action: WalletAction = {
                 let mut wallet_state = wallet_state.lock().unwrap();
 
-                if DUMP_ACTIONS { println!("*** wallet has {:?} actions in flight", wallet_state.actions_in_flight.len()); }
+                if DUMP_ACTIONS {
+                    println!(
+                        "*** wallet has {:?} actions in flight",
+                        wallet_state.actions_in_flight.len()
+                    );
+                }
                 let Some(action) = wallet_state.actions_in_flight.front() else {
                     // if we're not doing anything else, process a faucet RPC request
-                    if ! proposed_faucet.is_in_progress() {
+                    if !proposed_faucet.is_in_progress() {
                         let mut q = FAUCET_Q.lock().unwrap();
-                        if DUMP_FAUCET { println!("faucet Q read_o: {}, write_o: {}", q.read_o, q.write_o); }
+                        if DUMP_FAUCET {
+                            println!("faucet Q read_o: {}, write_o: {}", q.read_o, q.write_o);
+                        }
                         if q.len() > 0 {
                             let i = q.read_o as usize % q.data.len();
-                            if DUMP_FAUCET { println!("faucet Q new element at {i}: {:?}", q.data[i]); }
+                            if DUMP_FAUCET {
+                                println!("faucet Q new element at {i}: {:?}", q.data[i]);
+                            }
                             if let Some(orchard_addr) = q.data[i] {
                                 let memo = MemoBytes::from_bytes("With love from your favourite faucet... Don't spend it all at once!".as_bytes()).unwrap();
-                                let ok = miner_wallet.send_orchard_to_orchard_zats(network, &mut proposed_faucet, &mut client, &miner_usk, FAUCET_VALUE, &orchard_tree, orchard_addr, memo).is_some();
+                                let ok = miner_wallet
+                                    .send_orchard_to_orchard_zats(
+                                        network,
+                                        &mut proposed_faucet,
+                                        &mut client,
+                                        &miner_usk,
+                                        FAUCET_VALUE,
+                                        &orchard_tree,
+                                        orchard_addr,
+                                        memo,
+                                    )
+                                    .is_some();
                                 proposed_faucet.is_user_faucet = false;
-                                if DUMP_ACTIONS { println!("Try RPC faucet send: {ok:?}"); }
+                                if DUMP_ACTIONS {
+                                    println!("Try RPC faucet send: {ok:?}");
+                                }
                                 just_init_new_tx |= ok;
                                 q.read_o += 1;
                             } else {
@@ -4223,16 +5324,43 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
             let ok: bool = match &action {
                 &WalletAction::RequestFromFaucet => {
-                    let memo = MemoBytes::from_bytes("With love from your favourite faucet... Don't spend it all at once!".as_bytes()).unwrap();
-                    let ok = miner_wallet.send_orchard_to_orchard_zats(network, &mut proposed_faucet, &mut client, &miner_usk, FAUCET_VALUE, &orchard_tree, *user_ua.orchard().unwrap(), memo).is_some();
+                    let memo = MemoBytes::from_bytes(
+                        "With love from your favourite faucet... Don't spend it all at once!"
+                            .as_bytes(),
+                    )
+                    .unwrap();
+                    let ok = miner_wallet
+                        .send_orchard_to_orchard_zats(
+                            network,
+                            &mut proposed_faucet,
+                            &mut client,
+                            &miner_usk,
+                            FAUCET_VALUE,
+                            &orchard_tree,
+                            *user_ua.orchard().unwrap(),
+                            memo,
+                        )
+                        .is_some();
                     proposed_faucet.is_user_faucet = true;
                     just_init_new_tx |= ok;
-                    if DUMP_ACTIONS { println!("Try miner send: {ok:?}"); }
+                    if DUMP_ACTIONS {
+                        println!("Try miner send: {ok:?}");
+                    }
                     true // ALT ok
                 }
 
                 &WalletAction::StakeToFinalizer(amount, target_finalizer) => {
-                    let ok = user_wallet.stake_orchard_to_finalizer(network, &mut proposed_stake, &mut client, &user_usk, amount.into_u64(), &orchard_tree, target_finalizer).is_some();
+                    let ok = user_wallet
+                        .stake_orchard_to_finalizer(
+                            network,
+                            &mut proposed_stake,
+                            &mut client,
+                            &user_usk,
+                            amount.into_u64(),
+                            &orchard_tree,
+                            target_finalizer,
+                        )
+                        .is_some();
                     println!("Try stake: {ok:?}");
                     just_init_new_tx |= ok;
                     ok
@@ -4240,10 +5368,24 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
 
                 WalletAction::SendToAddress(address, amount) => {
                     if let Some(orchard_address) = address.orchard() {
-                        let memo = MemoBytes::from_bytes("send from user wallet".as_bytes()).unwrap();
-                        let ok = user_wallet.send_orchard_to_orchard_zats(network, &mut proposed_send, &mut client, &user_usk, amount.into_u64(), &orchard_tree, *orchard_address, memo).is_some();
+                        let memo =
+                            MemoBytes::from_bytes("send from user wallet".as_bytes()).unwrap();
+                        let ok = user_wallet
+                            .send_orchard_to_orchard_zats(
+                                network,
+                                &mut proposed_send,
+                                &mut client,
+                                &user_usk,
+                                amount.into_u64(),
+                                &orchard_tree,
+                                *orchard_address,
+                                memo,
+                            )
+                            .is_some();
                         just_init_new_tx |= ok;
-                        if DUMP_ACTIONS { println!("Try user send: {ok:?}"); }
+                        if DUMP_ACTIONS {
+                            println!("Try user send: {ok:?}");
+                        }
                         true // ALT ok
                     } else {
                         false
@@ -4251,23 +5393,58 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                 }
 
                 &WalletAction::UnstakeFromFinalizer(txid) => {
-                    let ok = user_wallet.begin_unbonding_using_orchard(network, &mut proposed_stake, &mut client, &user_usk, &orchard_tree, *txid.as_ref()).is_some();
+                    let ok = user_wallet
+                        .begin_unbonding_using_orchard(
+                            network,
+                            &mut proposed_stake,
+                            &mut client,
+                            &user_usk,
+                            &orchard_tree,
+                            *txid.as_ref(),
+                        )
+                        .is_some();
                     just_init_new_tx |= ok;
-                    if DUMP_ACTIONS { println!("Try unstake: {ok:?}"); }
+                    if DUMP_ACTIONS {
+                        println!("Try unstake: {ok:?}");
+                    }
                     ok
                 }
 
                 &WalletAction::RetargetBond(txid, new_target) => {
-                    let ok = user_wallet.retarget_bond_using_orchard(network, &mut proposed_stake, &mut client, &user_usk, &orchard_tree, *txid.as_ref(), new_target).is_some();
+                    let ok = user_wallet
+                        .retarget_bond_using_orchard(
+                            network,
+                            &mut proposed_stake,
+                            &mut client,
+                            &user_usk,
+                            &orchard_tree,
+                            *txid.as_ref(),
+                            new_target,
+                        )
+                        .is_some();
                     just_init_new_tx |= ok;
-                    if DUMP_ACTIONS { println!("Try retarget: {ok:?}"); }
+                    if DUMP_ACTIONS {
+                        println!("Try retarget: {ok:?}");
+                    }
                     ok
                 }
 
                 &WalletAction::ClaimBond(txid) => {
-                    let ok = user_wallet.claim_bond_using_orchard(network, &mut proposed_stake, &mut client, &user_usk, &orchard_tree, *txid.as_ref()).await.is_some();
+                    let ok = user_wallet
+                        .claim_bond_using_orchard(
+                            network,
+                            &mut proposed_stake,
+                            &mut client,
+                            &user_usk,
+                            &orchard_tree,
+                            *txid.as_ref(),
+                        )
+                        .await
+                        .is_some();
                     just_init_new_tx |= ok;
-                    if DUMP_ACTIONS { println!("Try withdraw stake: {ok:?}"); }
+                    if DUMP_ACTIONS {
+                        println!("Try withdraw stake: {ok:?}");
+                    }
                     ok
                 }
 
@@ -4281,19 +5458,24 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
             wallet_state.lock().unwrap().actions_in_flight.pop_front();
         }
 
-
         //-- INCREMENTALLY SEND TXS
         // (we want to skip this slow work to send tx data to UI while this is still single-threaded to show the started tx immediately)
-        if ! just_init_new_tx {
-            async fn continue_proposed_tx<P: Parameters>(wallet: &mut ManualWallet, network: P, tx: &mut ProposedTx, client: &mut CompactTxStreamerClient<Channel>, desc: &str, loud: bool) -> WalletTx {
+        if !just_init_new_tx {
+            async fn continue_proposed_tx<P: Parameters>(
+                wallet: &mut ManualWallet,
+                network: P,
+                tx: &mut ProposedTx,
+                client: &mut CompactTxStreamerClient<Channel>,
+                desc: &str,
+                loud: bool,
+            ) -> WalletTx {
                 let pre_mined_h = tx.tx.h;
                 match tx.tx.h {
                     BlockHeight::PROPOSED => {
                         let mut ok = false;
-                        if let None = tx.tx.parts[0]
-                            .checked_add(&tx.tx.parts[1])
-                            .and_then(|a| a.checked_add(&WalletTxPart::from_staking_action(tx.tx.staking_action)))
-                        {
+                        if let None = tx.tx.parts[0].checked_add(&tx.tx.parts[1]).and_then(|a| {
+                            a.checked_add(&WalletTxPart::from_staking_action(tx.tx.staking_action))
+                        }) {
                             println!("tx build error: total values are too large to be represented by Zatoshis");
                         } else if let Some(prep) = tx.prep.take() {
                             ok = wallet.build_tx_from_prep(network, tx, prep);
@@ -4301,8 +5483,10 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                             println!("unexpectedly no prep ready for build");
                         };
 
-                        if ! ok { // give it a final failed height
-                            tx.tx.status = TxStatus::HardFail(tx.tx.h, ErrBuf::from_str("failed to build"));
+                        if !ok {
+                            // give it a final failed height
+                            tx.tx.status =
+                                TxStatus::HardFail(tx.tx.h, ErrBuf::from_str("failed to build"));
                             tx.tx.h = wallet.chain_tip_h;
                         }
                         let mut insert_i = 0;
@@ -4311,9 +5495,12 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                         let result = tx.tx;
 
                         if loud {
-                            println!("tried to build {desc}: ({ok}) was {pre_mined_h}, now {} ({:?})", tx.tx.h, tx.tx.status);
+                            println!(
+                                "tried to build {desc}: ({ok}) was {pre_mined_h}, now {} ({:?})",
+                                tx.tx.h, tx.tx.status
+                            );
                         }
-                        if ! ok {
+                        if !ok {
                             *tx = ProposedTx::EMPTY; // Meaningless to retry
                         }
                         result
@@ -4323,9 +5510,14 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                     BlockHeight::BUILT => {
                         let mut ok = false;
                         if let Some(tx_res) = &tx.tx_res {
-                            ok = wallet.send_built_tx(network, client, &mut tx.tx, tx_res.transaction()).await;
+                            ok = wallet
+                                .send_built_tx(network, client, &mut tx.tx, tx_res.transaction())
+                                .await;
                             if loud {
-                                println!("tried to send {desc}: ({ok}) was {pre_mined_h}, now {} ({:?})", tx.tx.h, tx.tx.status);
+                                println!(
+                                    "tried to send {desc}: ({ok}) was {pre_mined_h}, now {} ({:?})",
+                                    tx.tx.h, tx.tx.status
+                                );
                             }
                         } else {
                             *tx = ProposedTx::EMPTY; // not enough info to retry; bail
@@ -4350,17 +5542,49 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                 }
             }
 
-            let faucet_tx = continue_proposed_tx(&mut miner_wallet, network, &mut proposed_faucet, &mut client, "faucet send",  DUMP_TX_SEND).await;
-            if proposed_faucet.is_user_faucet && faucet_tx.txid != TxId::from_bytes([0;32]) {
+            let faucet_tx = continue_proposed_tx(
+                &mut miner_wallet,
+                network,
+                &mut proposed_faucet,
+                &mut client,
+                "faucet send",
+                DUMP_TX_SEND,
+            )
+            .await;
+            if proposed_faucet.is_user_faucet && faucet_tx.txid != TxId::from_bytes([0; 32]) {
                 let user_faucet_tx = user_view_of_faucet_tx(&faucet_tx);
                 let mut insert_i = 0;
                 update_insert_i(&user_wallet.txs, &mut insert_i, user_faucet_tx.h);
                 update_with_tx(&mut user_wallet, user_faucet_tx, &mut insert_i);
             }
 
-            continue_proposed_tx(&mut miner_wallet, network, &mut proposed_miner_shield, &mut client, "miner shield", DUMP_TX_SEND && false).await;
-            continue_proposed_tx(&mut user_wallet,  network, &mut proposed_stake,        &mut client, "stake",        DUMP_TX_SEND).await;
-            continue_proposed_tx(&mut user_wallet,  network, &mut proposed_send,         &mut client, "send",         DUMP_TX_SEND).await;
+            continue_proposed_tx(
+                &mut miner_wallet,
+                network,
+                &mut proposed_miner_shield,
+                &mut client,
+                "miner shield",
+                DUMP_TX_SEND && false,
+            )
+            .await;
+            continue_proposed_tx(
+                &mut user_wallet,
+                network,
+                &mut proposed_stake,
+                &mut client,
+                "stake",
+                DUMP_TX_SEND,
+            )
+            .await;
+            continue_proposed_tx(
+                &mut user_wallet,
+                network,
+                &mut proposed_send,
+                &mut client,
+                "send",
+                DUMP_TX_SEND,
+            )
+            .await;
         }
     }
 }

--- a/zebra-crosslink/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-crosslink/zebra-chain/src/primitives/zcash_primitives.rs
@@ -49,7 +49,7 @@ impl zcash_transparent::sighash::TransparentAuthorizingContext for TransparentAu
             .iter()
             .map(|prevout| {
                 zcash_transparent::address::Script(script::Code(
-                        prevout.lock_script.as_raw_bytes().into(),
+                    prevout.lock_script.as_raw_bytes().into(),
                 ))
             })
             .collect()

--- a/zebra-crosslink/zebra-chain/src/transaction.rs
+++ b/zebra-crosslink/zebra-chain/src/transaction.rs
@@ -1569,22 +1569,25 @@ impl Transaction {
     /// Return the staking value balance.
     pub fn staking_action_value_balance(&self) -> ValueBalance<NegativeAllowed> {
         match self {
-            Self::VCrosslink {
-                staking_action,
-                ..
-            } => {
+            Self::VCrosslink { staking_action, .. } => {
                 if let Some(staking_action) = staking_action {
                     if staking_action.kind == StakingActionKind::CreateNewDelegationBond {
-                        ValueBalance::from_staking_bonded_amount(Amount::new(staking_action.amount_zats as i64).neg())
+                        ValueBalance::from_staking_bonded_amount(
+                            Amount::new(staking_action.amount_zats as i64).neg(),
+                        )
                     } else if staking_action.kind == StakingActionKind::WithdrawDelegationBond {
-                        ValueBalance::from_staking_unbonded_amount(Amount::new(staking_action.amount_zats as i64).constrain().unwrap())
+                        ValueBalance::from_staking_unbonded_amount(
+                            Amount::new(staking_action.amount_zats as i64)
+                                .constrain()
+                                .unwrap(),
+                        )
                     } else {
                         ValueBalance::zero() // Note(Sam): I would have liked to have the transfer between bonded and unbonded pools to occur here but I do not think it is possible.
                     }
                 } else {
                     ValueBalance::zero()
                 }
-            },
+            }
             _ => ValueBalance::zero(),
         }
     }
@@ -1938,8 +1941,7 @@ impl Transaction {
             | Transaction::VCrosslink {
                 orchard_shielded_data: Some(orchard_shielded_data),
                 ..
-            }
-            => Some(orchard_shielded_data),
+            } => Some(orchard_shielded_data),
             #[cfg(feature = "tx_v6")]
             Transaction::V6 {
                 orchard_shielded_data: Some(orchard_shielded_data),

--- a/zebra-crosslink/zebra-chain/src/value_balance.rs
+++ b/zebra-crosslink/zebra-chain/src/value_balance.rs
@@ -217,7 +217,13 @@ impl ValueBalance<NegativeAllowed> {
         // https://zebra.zfnd.org/dev/rfcs/0012-value-pools.html#definitions
         //
         // This will error if the remaining value in the transaction value pool is negative.
-        (self.transparent + self.sprout + self.sapling + self.orchard + self.staking_bonded + self.staking_unbonded)?.constrain::<NonNegative>()
+        (self.transparent
+            + self.sprout
+            + self.sapling
+            + self.orchard
+            + self.staking_bonded
+            + self.staking_unbonded)?
+            .constrain::<NonNegative>()
     }
 }
 
@@ -531,7 +537,8 @@ where
             orchard: (self.orchard + rhs.orchard).map_err(Orchard)?,
             deferred: (self.deferred + rhs.deferred).map_err(Deferred)?,
             staking_bonded: (self.staking_bonded + rhs.staking_bonded).map_err(StakingBonded)?,
-            staking_unbonded: (self.staking_unbonded + rhs.staking_unbonded).map_err(StakingUnbonded)?,
+            staking_unbonded: (self.staking_unbonded + rhs.staking_unbonded)
+                .map_err(StakingUnbonded)?,
         })
     }
 }
@@ -582,7 +589,8 @@ where
             orchard: (self.orchard - rhs.orchard).map_err(Orchard)?,
             deferred: (self.deferred - rhs.deferred).map_err(Deferred)?,
             staking_bonded: (self.staking_bonded - rhs.staking_bonded).map_err(StakingBonded)?,
-            staking_unbonded: (self.staking_unbonded - rhs.staking_unbonded).map_err(StakingUnbonded)?,
+            staking_unbonded: (self.staking_unbonded - rhs.staking_unbonded)
+                .map_err(StakingUnbonded)?,
         })
     }
 }

--- a/zebra-crosslink/zebra-chain/src/value_balance/arbitrary.rs
+++ b/zebra-crosslink/zebra-chain/src/value_balance/arbitrary.rs
@@ -14,15 +14,25 @@ impl Arbitrary for ValueBalance<NegativeAllowed> {
             any::<Amount<NegativeAllowed>>(),
             any::<Amount<NegativeAllowed>>(),
         )
-            .prop_map(|(transparent, sprout, sapling, orchard, deferred, staking_bonded, staking_unbonded)| Self {
-                transparent,
-                sprout,
-                sapling,
-                orchard,
-                deferred,
-                staking_bonded,
-                staking_unbonded,
-            })
+            .prop_map(
+                |(
+                    transparent,
+                    sprout,
+                    sapling,
+                    orchard,
+                    deferred,
+                    staking_bonded,
+                    staking_unbonded,
+                )| Self {
+                    transparent,
+                    sprout,
+                    sapling,
+                    orchard,
+                    deferred,
+                    staking_bonded,
+                    staking_unbonded,
+                },
+            )
             .boxed()
     }
 
@@ -42,15 +52,25 @@ impl Arbitrary for ValueBalance<NonNegative> {
             any::<Amount<NonNegative>>(),
             any::<Amount<NonNegative>>(),
         )
-            .prop_map(|(transparent, sprout, sapling, orchard, deferred, staking_bonded, staking_unbonded)| Self {
-                transparent,
-                sprout,
-                sapling,
-                orchard,
-                deferred,
-                staking_bonded,
-                staking_unbonded,
-            })
+            .prop_map(
+                |(
+                    transparent,
+                    sprout,
+                    sapling,
+                    orchard,
+                    deferred,
+                    staking_bonded,
+                    staking_unbonded,
+                )| Self {
+                    transparent,
+                    sprout,
+                    sapling,
+                    orchard,
+                    deferred,
+                    staking_bonded,
+                    staking_unbonded,
+                },
+            )
             .boxed()
     }
 

--- a/zebra-crosslink/zebra-consensus/src/transaction.rs
+++ b/zebra-crosslink/zebra-consensus/src/transaction.rs
@@ -907,11 +907,12 @@ where
         // Query the state for bond info
         let query = state.oneshot(zs::Request::BondInfo(bond_key));
 
-        let response = query
-            .await
-            .map_err(|e| TransactionError::ValidateMempoolLockTimeError(
-                format!("failed to query bond info: {}", e)
-            ))?;
+        let response = query.await.map_err(|e| {
+            TransactionError::ValidateMempoolLockTimeError(format!(
+                "failed to query bond info: {}",
+                e
+            ))
+        })?;
 
         let zs::Response::BondInfo(bond_info) = response else {
             unreachable!("BondInfo request always responds with BondInfo")

--- a/zebra-crosslink/zebra-crosslink/src/lib.rs
+++ b/zebra-crosslink/zebra-crosslink/src/lib.rs
@@ -12,10 +12,10 @@ use async_trait::async_trait;
 use strum::{EnumCount, IntoEnumIterator};
 use strum_macros::{EnumCount, EnumIter};
 
+use ed25519_zebra::VerificationKeyBytes;
 use tenderlink::SortedRosterMember;
 use tracing_futures::WithSubscriber;
-use zcash_primitives::transaction::{RosterMember, StakingAction, StakingActionKind, StakeTxId};
-use ed25519_zebra::VerificationKeyBytes;
+use zcash_primitives::transaction::{RosterMember, StakeTxId, StakingAction, StakingActionKind};
 use zebra_chain::serialization::{
     SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
 };
@@ -148,7 +148,10 @@ use zebra_chain::block::{
     Block, CountedHeader, Hash as BlockHash, Header as BlockHeader, Height as BlockHeight,
 };
 use zebra_node_services::mempool::{Request as MempoolRequest, Response as MempoolResponse};
-use zebra_state::{crosslink::*, Request as StateRequest, Response as StateResponse, ReadRequest as StateReadRequest, ReadResponse as StateReadResponse};
+use zebra_state::{
+    crosslink::*, ReadRequest as StateReadRequest, ReadResponse as StateReadResponse,
+    Request as StateRequest, Response as StateResponse,
+};
 
 /// Placeholder activation height for Crosslink functionality
 pub const TFL_ACTIVATION_HEIGHT: BlockHeight = BlockHeight(0);
@@ -195,12 +198,20 @@ pub(crate) struct TFLServiceInternal {
     path_to_pos_store_file: PathBuf,
 }
 
-fn call_from_state_to_crosslink_to_ask_about_fat_pointers(internal_handle: &TFLServiceHandle, parent_fat_pointer: zebra_chain::block::FatPointerToBftBlock, child_fat_pointer: zebra_chain::block::FatPointerToBftBlock) -> bool {
+fn call_from_state_to_crosslink_to_ask_about_fat_pointers(
+    internal_handle: &TFLServiceHandle,
+    parent_fat_pointer: zebra_chain::block::FatPointerToBftBlock,
+    child_fat_pointer: zebra_chain::block::FatPointerToBftBlock,
+) -> bool {
     let mut internal = internal_handle.internal.blocking_lock();
     let parent_height = if parent_fat_pointer == zebra_chain::block::FatPointerToBftBlock::null() {
         0
     } else {
-        if let Some(h) = internal.bft_blocks.iter().position(|b| b.blake3_hash().0 == parent_fat_pointer.points_at_block_hash()) {
+        if let Some(h) = internal
+            .bft_blocks
+            .iter()
+            .position(|b| b.blake3_hash().0 == parent_fat_pointer.points_at_block_hash())
+        {
             h
         } else {
             return false;
@@ -209,7 +220,11 @@ fn call_from_state_to_crosslink_to_ask_about_fat_pointers(internal_handle: &TFLS
     let child_height = if child_fat_pointer == zebra_chain::block::FatPointerToBftBlock::null() {
         0
     } else {
-        if let Some(h) = internal.bft_blocks.iter().position(|b| b.blake3_hash().0 == child_fat_pointer.points_at_block_hash()) {
+        if let Some(h) = internal
+            .bft_blocks
+            .iter()
+            .position(|b| b.blake3_hash().0 == child_fat_pointer.points_at_block_hash())
+        {
             h
         } else {
             return false;
@@ -246,11 +261,16 @@ async fn block_height_hash_from_hash(
     }
 }
 
-async fn block_from_hash( // @Phillip
+async fn block_from_hash(
+    // @Phillip
     call: &TFLServiceCalls,
     hash: BlockHash,
 ) -> Option<Arc<Block>> {
-    if let Ok(StateResponse::Block(Some(block))) = (call.state)(StateRequest::Block(zebra_state::HashOrHeight::Hash(hash.into()))).await {
+    if let Ok(StateResponse::Block(Some(block))) = (call.state)(StateRequest::Block(
+        zebra_state::HashOrHeight::Hash(hash.into()),
+    ))
+    .await
+    {
         let check_hash = block.as_ref().hash();
         assert_eq!(hash, check_hash);
         Some(block)
@@ -259,12 +279,16 @@ async fn block_from_hash( // @Phillip
     }
 }
 
-async fn is_block_known( // @Phillip
+async fn is_block_known(
+    // @Phillip
     call: &TFLServiceCalls,
     hash: BlockHash,
 ) -> bool {
-    if let Ok(StateResponse::KnownBlock(Some(known_block))) = (call.state)(StateRequest::KnownBlock(hash.into())).await {
-        known_block.location == zebra_state::KnownBlockLocation::BestChain || known_block.location == zebra_state::KnownBlockLocation::SideChain
+    if let Ok(StateResponse::KnownBlock(Some(known_block))) =
+        (call.state)(StateRequest::KnownBlock(hash.into())).await
+    {
+        known_block.location == zebra_state::KnownBlockLocation::BestChain
+            || known_block.location == zebra_state::KnownBlockLocation::SideChain
     } else {
         false
     }
@@ -472,7 +496,13 @@ async fn propose_new_bft_block(tfl_handle: &TFLServiceHandle) -> Option<BftBlock
         return None;
     }
 
-    let finality_candidate_height = BlockHeight(finality_candidate_height.0.min(if let Some(v) = latest_final_block { v.0.0+10 } else { u32::MAX }));
+    let finality_candidate_height = BlockHeight(finality_candidate_height.0.min(
+        if let Some(v) = latest_final_block {
+            v.0 .0 + 10
+        } else {
+            u32::MAX
+        },
+    ));
 
     let resp = (call.state)(StateRequest::BlockHeader(finality_candidate_height.into())).await;
 
@@ -546,8 +576,7 @@ async fn new_decided_bft_block_from_malachite(
 
     drop(internal);
     assert_eq!(
-        validate_bft_block_from_malachite(&tfl_handle, new_block)
-            .await,
+        validate_bft_block_from_malachite(&tfl_handle, new_block).await,
         (tenderlink::TMStatus::Pass, tenderlink::TMStatusReason::None)
     );
 
@@ -595,7 +624,10 @@ async fn new_decided_bft_block_from_malachite(
     drop(internal); // Note(Sam): IT IS VERY IMPORTANT THAT WE DROP THE LOCK BECAUSE ZEBRA_STATE MAY CALL US BACK
     match (call.state)(zebra_state::Request::CrosslinkFinalizeBlock(new_final_hash)).await {
         Ok(zebra_state::Response::CrosslinkFinalized(hash, aggregated_stakes)) => {
-            info!("Successfully crosslink-finalized {}, active stakes: {:?}", hash, aggregated_stakes);
+            info!(
+                "Successfully crosslink-finalized {}, active stakes: {:?}",
+                hash, aggregated_stakes
+            );
             got_stakes = aggregated_stakes;
             assert_eq!(
                 hash, new_final_hash,
@@ -611,15 +643,22 @@ async fn new_decided_bft_block_from_malachite(
     internal = tfl_handle.internal.lock().await;
 
     if got_stakes.len() > 0 {
-        internal.validators_at_current_height = got_stakes.into_iter().map(|s| MalValidator { public_key: s.0, voting_power: s.1 }).collect();
+        internal.validators_at_current_height = got_stakes
+            .into_iter()
+            .map(|s| MalValidator {
+                public_key: s.0,
+                voting_power: s.1,
+            })
+            .collect();
     }
 
-//println!("Storing pow ({:?}, {:?}) with roster: {:?}", new_final_height, new_final_hash, internal.validators_at_current_height);
+    //println!("Storing pow ({:?}, {:?}) with roster: {:?}", new_final_height, new_final_hash, internal.validators_at_current_height);
     if internal.path_to_pos_store_file.to_str() != Some("") {
         let mut append_bytes: Vec<u8> = Vec::new();
         new_block.zcash_serialize(&mut append_bytes).unwrap();
         fat_pointer.zcash_serialize(&mut append_bytes).unwrap();
-        append_bytes.extend_from_slice(&(internal.validators_at_current_height.len() as u64).to_le_bytes());
+        append_bytes
+            .extend_from_slice(&(internal.validators_at_current_height.len() as u64).to_le_bytes());
         for v in &internal.validators_at_current_height {
             v.write_to(&mut append_bytes).unwrap();
         }
@@ -627,7 +666,10 @@ async fn new_decided_bft_block_from_malachite(
         for sig in tender_proposal_sigs {
             append_bytes.extend_from_slice(&sig.0);
         }
-        let mut file = OpenOptions::new().append(true).open(&internal.path_to_pos_store_file).unwrap();
+        let mut file = OpenOptions::new()
+            .append(true)
+            .open(&internal.path_to_pos_store_file)
+            .unwrap();
         file.write_all(&append_bytes).unwrap();
         file.flush().unwrap();
     }
@@ -697,7 +739,12 @@ async fn validate_bft_block_from_malachite(
                 "Didn't have hash available for confirmation: {}",
                 new_final_hash
             );
-            return (tenderlink::TMStatus::Indeterminate, tenderlink::TMStatusReason::NeedsBlock { hash: new_final_hash.0 });
+            return (
+                tenderlink::TMStatus::Indeterminate,
+                tenderlink::TMStatusReason::NeedsBlock {
+                    hash: new_final_hash.0,
+                },
+            );
         };
     return (tenderlink::TMStatus::Pass, tenderlink::TMStatusReason::None);
 }
@@ -839,7 +886,10 @@ fn update_roster_for_block(internal: &mut TFLServiceInternal, block: &Block) -> 
         {
             if let Some(staking_action) = staking_action {
                 let txid = tx.unmined_id().mined_id();
-                info!("got staking action in txid: {}", StakingAction::str_from_addr(txid.0));
+                info!(
+                    "got staking action in txid: {}",
+                    StakingAction::str_from_addr(txid.0)
+                );
                 // TODO(Sam)
                 //cmd_c += update_roster_for_cmd(roster, txid.0, validators_keys_to_names, &staking_action);
             }
@@ -850,7 +900,11 @@ fn update_roster_for_block(internal: &mut TFLServiceInternal, block: &Block) -> 
     cmd_c
 }
 
-async fn tfl_service_main_loop(internal_handle: TFLServiceHandle, global_seed: [u8; 32], path_to_pos_store_file: PathBuf) -> Result<(), String> {
+async fn tfl_service_main_loop(
+    internal_handle: TFLServiceHandle,
+    global_seed: [u8; 32],
+    path_to_pos_store_file: PathBuf,
+) -> Result<(), String> {
     let call = internal_handle.call.clone();
     let config = internal_handle.config.clone();
     let params = &PROTOTYPE_PARAMETERS;
@@ -989,7 +1043,12 @@ async fn tfl_service_main_loop(internal_handle: TFLServiceHandle, global_seed: [
             .collect();
 
         if path_to_pos_store_file.to_str() != Some("") {
-            let mut pos_file = OpenOptions::new().read(true).write(true).create(true).open(&path_to_pos_store_file).unwrap();
+            let mut pos_file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .open(&path_to_pos_store_file)
+                .unwrap();
             let mut pos_file_bytes = Vec::new();
             pos_file.read_to_end(&mut pos_file_bytes).unwrap();
 
@@ -997,39 +1056,82 @@ async fn tfl_service_main_loop(internal_handle: TFLServiceHandle, global_seed: [
             let mut valid_byte_count = 0;
             'big_loop: loop {
                 valid_byte_count = cursor.position();
-                let block = if let Ok(block) = BftBlock::zcash_deserialize(&mut cursor) { block } else { break; };
-                let fat_pointer = if let Ok(fat_pointer) = FatPointerToBftBlock2::zcash_deserialize(&mut cursor) { fat_pointer } else { break; };
+                let block = if let Ok(block) = BftBlock::zcash_deserialize(&mut cursor) {
+                    block
+                } else {
+                    break;
+                };
+                let fat_pointer = if let Ok(fat_pointer) =
+                    FatPointerToBftBlock2::zcash_deserialize(&mut cursor)
+                {
+                    fat_pointer
+                } else {
+                    break;
+                };
 
                 let mut buf = [0u8; 8];
-                if cursor.read_exact(&mut buf).is_err() { break; }
+                if cursor.read_exact(&mut buf).is_err() {
+                    break;
+                }
                 let new_roster_count = u64::from_le_bytes(buf);
                 let mut new_roster = Vec::new();
                 for _ in 0..new_roster_count {
                     if let Ok(v) = MalValidator::read_from(&mut cursor) {
                         new_roster.push(v);
-                    } else { break; }
+                    } else {
+                        break;
+                    }
                 }
 
                 let mut buf = [0u8; 8];
-                if cursor.read_exact(&mut buf).is_err() { break; }
+                if cursor.read_exact(&mut buf).is_err() {
+                    break;
+                }
                 let proposal_sigs_n = u64::from_le_bytes(buf);
                 let mut proposal_sigs = Vec::new();
                 for _ in 0..proposal_sigs_n {
                     let mut sig = tenderlink::TMSig::NIL;
-                    if cursor.read_exact(&mut sig.0).is_err() { break 'big_loop; }
+                    if cursor.read_exact(&mut sig.0).is_err() {
+                        break 'big_loop;
+                    }
                     proposal_sigs.push(sig);
                 }
 
-                if block.previous_block_fat_ptr.points_at_block_hash() != fat_pointer_to_tip.points_at_block_hash() { break; }
+                if block.previous_block_fat_ptr.points_at_block_hash()
+                    != fat_pointer_to_tip.points_at_block_hash()
+                {
+                    break;
+                }
 
                 let mut round_data = tenderlink::RoundData::EMPTY;
                 round_data.roster = tenderlink_roster_from_internal(&unsorted_roster);
-                round_data.msg_val_sigs = round_data.roster.iter().map(|v| fat_pointer.signatures.iter().find(|s| s.public_key == v.pub_key.0).map(|s| s.vote_signature).unwrap_or([0u8; 64])).map(|s| [(tenderlink::ValueId::NIL, tenderlink::TMSig::NIL), (tenderlink::ValueId(fat_pointer.points_at_block_hash().0), tenderlink::TMSig(s))]).collect();
+                round_data.msg_val_sigs = round_data
+                    .roster
+                    .iter()
+                    .map(|v| {
+                        fat_pointer
+                            .signatures
+                            .iter()
+                            .find(|s| s.public_key == v.pub_key.0)
+                            .map(|s| s.vote_signature)
+                            .unwrap_or([0u8; 64])
+                    })
+                    .map(|s| {
+                        [
+                            (tenderlink::ValueId::NIL, tenderlink::TMSig::NIL),
+                            (
+                                tenderlink::ValueId(fat_pointer.points_at_block_hash().0),
+                                tenderlink::TMSig(s),
+                            ),
+                        ]
+                    })
+                    .collect();
                 round_data.counts.precommits = fat_pointer.signatures.len() as u64;
                 round_data.counts.yes_precommits = fat_pointer.signatures.len() as u64;
                 round_data.proposal_sigs_n = proposal_sigs_n as usize;
                 round_data.proposal_sigs = proposal_sigs;
-                round_data.proposal = tenderlink::BlockValue(block.zcash_serialize_to_vec().unwrap());
+                round_data.proposal =
+                    tenderlink::BlockValue(block.zcash_serialize_to_vec().unwrap());
                 round_data.proposal_id = tenderlink::ValueId(fat_pointer.points_at_block_hash().0);
                 round_data.height = ingest_data_for_tenderlink.len() as u64;
                 round_data.round = fat_pointer.get_vote_template().round as u32;
@@ -1048,7 +1150,7 @@ async fn tfl_service_main_loop(internal_handle: TFLServiceHandle, global_seed: [
         if let Some(new_block) = i_bft_blocks.last() {
             new_final_hash = new_block.headers.first().expect("at least 1 header").hash();
             new_final_height = block_height_from_hash(&call, new_final_hash).await.unwrap();
-//println!("Loaded at pow ({:?}, {:?}) with roster: {:?}", new_final_height, new_final_hash, unsorted_roster);
+            //println!("Loaded at pow ({:?}, {:?}) with roster: {:?}", new_final_height, new_final_hash, unsorted_roster);
         }
 
         let roster = {
@@ -1094,27 +1196,30 @@ async fn tfl_service_main_loop(internal_handle: TFLServiceHandle, global_seed: [
                     }
                 })
             })),
-            tenderlink::ClosureToPushDecidedBlock(Arc::new(move |block, fat_pointer, tender_proposal_sigs| {
-                let tfl_handle3 = tfl_handle3.clone();
-                Box::pin(async move {
-                    use bytes::Buf;
-                    use zebra_chain::serialization::ZcashDeserialize;
+            tenderlink::ClosureToPushDecidedBlock(Arc::new(
+                move |block, fat_pointer, tender_proposal_sigs| {
+                    let tfl_handle3 = tfl_handle3.clone();
+                    Box::pin(async move {
+                        use bytes::Buf;
+                        use zebra_chain::serialization::ZcashDeserialize;
 
-                    new_decided_bft_block_from_malachite(
-                        &tfl_handle3,
-                        &BftBlock::zcash_deserialize(block.0.reader()).unwrap(),
-                        &fat_pointer.into(),
-                        tender_proposal_sigs,
-                    )
-                    .await
-                })
-            })),
+                        new_decided_bft_block_from_malachite(
+                            &tfl_handle3,
+                            &BftBlock::zcash_deserialize(block.0.reader()).unwrap(),
+                            &fat_pointer.into(),
+                            tender_proposal_sigs,
+                        )
+                        .await
+                    })
+                },
+            )),
             tenderlink::ClosureToGetHistoricalBlock(Arc::new(move |height| {
                 Box::pin(async move {
                     panic!();
                 })
             })),
-            tenderlink::ClosureToGetPow(Arc::new(move |hash| { // @Phillip
+            tenderlink::ClosureToGetPow(Arc::new(move |hash| {
+                // @Phillip
                 let tfl_handle5 = tfl_handle5.clone();
                 Box::pin(async move {
                     if let Some(block) = block_from_hash(&tfl_handle5.call, hash.into()).await {
@@ -1127,12 +1232,16 @@ async fn tfl_service_main_loop(internal_handle: TFLServiceHandle, global_seed: [
                             None
                         }
                     } else {
-                        eprintln!("PowLink: \x1b[93mCouldn't find PoW block\x1b[0m  for hash {:?}.", hash);
+                        eprintln!(
+                            "PowLink: \x1b[93mCouldn't find PoW block\x1b[0m  for hash {:?}.",
+                            hash
+                        );
                         None
                     }
                 })
             })),
-            tenderlink::ClosureToParsePow(Arc::new(move |hash, bytes| { // @Phillip
+            tenderlink::ClosureToParsePow(Arc::new(move |hash, bytes| {
+                // @Phillip
                 Box::pin(async move {
                     let mut slice = &bytes[..];
                     // let slice_ref = &mut slice;
@@ -1150,13 +1259,13 @@ async fn tfl_service_main_loop(internal_handle: TFLServiceHandle, global_seed: [
                     }
                 })
             })),
-            tenderlink::ClosureIsPoWInChain(Arc::new(move |hash| { // @Phillip
+            tenderlink::ClosureIsPoWInChain(Arc::new(move |hash| {
+                // @Phillip
                 let tfl_handle6 = tfl_handle6.clone();
-                Box::pin(async move {
-                    is_block_known(&tfl_handle6.call, BlockHash(hash)).await
-                })
+                Box::pin(async move { is_block_known(&tfl_handle6.call, BlockHash(hash)).await })
             })),
-            tenderlink::ClosureToPushPow(Arc::new(move |block| { // @Phillip
+            tenderlink::ClosureToPushPow(Arc::new(move |block| {
+                // @Phillip
                 let tfl_handle7 = tfl_handle7.clone();
                 Box::pin(async move {
                     (tfl_handle7.call.force_feed_pow)(block.clone()).await;
@@ -1184,10 +1293,24 @@ async fn tfl_service_main_loop(internal_handle: TFLServiceHandle, global_seed: [
                     internal.peer_strings.truncate(0);
 
                     for peer in &all_peers {
-                        internal.peer_strings.push(format!("{} {} ({}) - ({}, {})",
-                            if let Some(pubkey) = peer.root_public_bft_key { tenderlink::PubKeyID(pubkey).to_string() } else { "unknown peer".to_string() },
-                            if peer.connected { "connected" } else { "disconnected" },
-                            if peer.connection_knowledge == tenderlink::ConnectionKnowledge::Unknown { "unknown" } else { "known" },
+                        internal.peer_strings.push(format!(
+                            "{} {} ({}) - ({}, {})",
+                            if let Some(pubkey) = peer.root_public_bft_key {
+                                tenderlink::PubKeyID(pubkey).to_string()
+                            } else {
+                                "unknown peer".to_string()
+                            },
+                            if peer.connected {
+                                "connected"
+                            } else {
+                                "disconnected"
+                            },
+                            if peer.connection_knowledge == tenderlink::ConnectionKnowledge::Unknown
+                            {
+                                "unknown"
+                            } else {
+                                "known"
+                            },
                             peer.latest_status_request_height,
                             peer.latest_status_request_powlink_id
                         ));
@@ -1369,7 +1492,11 @@ async fn tfl_service_incoming_request(
             internal
                 .validators_at_current_height
                 .iter()
-                .map(|v| RosterMember{ pub_key:<[u8; 32]>::from(v.public_key), voting_power: v.voting_power, txids: Vec::new() })
+                .map(|v| RosterMember {
+                    pub_key: <[u8; 32]>::from(v.public_key),
+                    voting_power: v.voting_power,
+                    txids: Vec::new(),
+                })
                 .collect()
         })),
 
@@ -1380,16 +1507,14 @@ async fn tfl_service_incoming_request(
             ))
         }
 
-        TFLServiceRequest::Faucet(request) => {
-            Ok(TFLServiceResponse::Faucet({
-                let closure = wallet::FAUCET_REQUEST.lock().unwrap();
-                if let Some(closure) = closure.as_ref() {
-                    (closure.0)(request)
-                } else {
-                    Err("No faucet available".to_owned())
-                }
-            }))
-        }
+        TFLServiceRequest::Faucet(request) => Ok(TFLServiceResponse::Faucet({
+            let closure = wallet::FAUCET_REQUEST.lock().unwrap();
+            if let Some(closure) = closure.as_ref() {
+                (closure.0)(request)
+            } else {
+                Err("No faucet available".to_owned())
+            }
+        })),
 
         _ => Err(TFLServiceError::NotImplemented),
     }

--- a/zebra-crosslink/zebra-crosslink/src/lib.rs
+++ b/zebra-crosslink/zebra-crosslink/src/lib.rs
@@ -1187,7 +1187,7 @@ async fn tfl_service_main_loop(internal_handle: TFLServiceHandle, global_seed: [
                         internal.peer_strings.push(format!("{} {} ({}) - ({}, {})",
                             if let Some(pubkey) = peer.root_public_bft_key { tenderlink::PubKeyID(pubkey).to_string() } else { "unknown peer".to_string() },
                             if peer.connected { "connected" } else { "disconnected" },
-                            if peer.connection_is_unknown { "unknown" } else { "known" },
+                            if peer.connection_knowledge == tenderlink::ConnectionKnowledge::Unknown { "unknown" } else { "known" },
                             peer.latest_status_request_height,
                             peer.latest_status_request_powlink_id
                         ));

--- a/zebra-crosslink/zebra-crosslink/src/service.rs
+++ b/zebra-crosslink/zebra-crosslink/src/service.rs
@@ -21,14 +21,16 @@ use tracing::{error, info, warn};
 use zebra_chain::block::{Hash as BlockHash, Height as BlockHeight};
 use zebra_chain::transaction::Hash as TxHash;
 use zebra_node_services::mempool::{Request as MempoolRequest, Response as MempoolResponse};
-use zebra_state::{crosslink::*, Request as StateRequest, Response as StateResponse, ReadRequest as StateReadRequest, ReadResponse as StateReadResponse};
+use zebra_state::{
+    crosslink::*, ReadRequest as StateReadRequest, ReadResponse as StateReadResponse,
+    Request as StateRequest, Response as StateResponse,
+};
 
 use crate::chain::BftBlock;
 use crate::FatPointerToBftBlock2;
 use crate::{
-    rng_private_public_key_from_address, tfl_service_incoming_request, TFLBlockFinality,
+    rng_private_public_key_from_address, tfl_service_incoming_request, StakeTxId, TFLBlockFinality,
     TFLServiceInternal,
-    StakeTxId,
 };
 
 use tower::Service;
@@ -68,8 +70,12 @@ pub(crate) type ReadStateServiceProcedure = Arc<
             StateReadRequest,
         ) -> Pin<
             Box<
-                dyn Future<Output = Result<StateReadResponse, Box<dyn std::error::Error + Send + Sync>>>
-                    + Send,
+                dyn Future<
+                        Output = Result<
+                            StateReadResponse,
+                            Box<dyn std::error::Error + Send + Sync>,
+                        >,
+                    > + Send,
             >,
         > + Send
         + Sync,
@@ -135,7 +141,9 @@ pub fn spawn_new_tfl_service(
     mempool_service_call: MempoolServiceProcedure,
     force_feed_pow_call: ForceFeedPoWBlockProcedure,
     config: crate::config::Config,
-    closure_from_state_to_here_mutex: Arc<std::sync::Mutex<Option<zebra_state::ClosureToCallIntoCrosslinkFromState>>>,
+    closure_from_state_to_here_mutex: Arc<
+        std::sync::Mutex<Option<zebra_state::ClosureToCallIntoCrosslinkFromState>>,
+    >,
 ) -> (TFLServiceHandle, JoinHandle<Result<(), String>>) {
     let (validators_at_current_height, validators_keys_to_names) = {
         let mut array = Vec::with_capacity(config.malachite_peers.len());
@@ -143,7 +151,10 @@ pub fn spawn_new_tfl_service(
 
         for (i, peer) in config.malachite_peers.iter().enumerate() {
             let (_, _, public_key) = rng_private_public_key_from_address(peer.as_bytes());
-            array.push(crate::MalValidator { public_key:public_key.into(), voting_power: 1 });
+            array.push(crate::MalValidator {
+                public_key: public_key.into(),
+                voting_power: 1,
+            });
             // array.push(crate::MalValidator::new(public_key, vec![StakeTxId{ txid: [0;32], zats:((i as u64) * 5) + 1 }])); // @Phillip @Testing
             map.insert(public_key, peer.to_string());
         }
@@ -160,7 +171,10 @@ pub fn spawn_new_tfl_service(
             // .unwrap_or(String::from_str("tester").unwrap());
             info!("user_name: {}", user_name);
             let (_, _, public_key) = rng_private_public_key_from_address(&user_name.as_bytes());
-            array.push(crate::MalValidator { public_key:public_key.into(), voting_power: 1 });
+            array.push(crate::MalValidator {
+                public_key: public_key.into(),
+                voting_power: 1,
+            });
             map.insert(public_key, user_name);
         }
 
@@ -192,15 +206,22 @@ pub fn spawn_new_tfl_service(
         let handle = handle_mtx2.lock().unwrap().clone().unwrap();
         Box::pin(async move {
             let accepted = if fat_pointer.points_at_block_hash() == block.blake3_hash() {
-                crate::validate_bft_block_from_malachite(&handle, block.as_ref()).await.0
+                crate::validate_bft_block_from_malachite(&handle, block.as_ref())
+                    .await
+                    .0
                     == tenderlink::TMStatus::Pass
             } else {
                 false
             };
             if accepted {
                 info!("Successfully force-fed BFT block");
-                crate::new_decided_bft_block_from_malachite(&handle, block.as_ref(), &fat_pointer, Vec::new())
-                    .await;
+                crate::new_decided_bft_block_from_malachite(
+                    &handle,
+                    block.as_ref(),
+                    &fat_pointer,
+                    Vec::new(),
+                )
+                .await;
                 true
             } else {
                 error!("Failed to force-feed BFT block");
@@ -224,12 +245,16 @@ pub fn spawn_new_tfl_service(
     *handle_mtx.lock().unwrap() = Some(handle1.clone());
 
     let handle3 = handle1.clone();
-    *closure_from_state_to_here_mutex.lock().unwrap() = Some(Arc::new(move |fpa, fpb| crate::call_from_state_to_crosslink_to_ask_about_fat_pointers(&handle3, fpa, fpb)));
+    *closure_from_state_to_here_mutex.lock().unwrap() = Some(Arc::new(move |fpa, fpb| {
+        crate::call_from_state_to_crosslink_to_ask_about_fat_pointers(&handle3, fpa, fpb)
+    }));
 
     let handle2 = handle1.clone();
     (
         handle1,
-        tokio::spawn(async move { crate::tfl_service_main_loop(handle2, global_seed, path_to_pos_store_file).await }),
+        tokio::spawn(async move {
+            crate::tfl_service_main_loop(handle2, global_seed, path_to_pos_store_file).await
+        }),
     )
 }
 

--- a/zebra-crosslink/zebra-crosslink/src/test_format.rs
+++ b/zebra-crosslink/zebra-crosslink/src/test_format.rs
@@ -613,7 +613,10 @@ pub(crate) async fn handle_instr(
             let mut internal = internal_handle.internal.lock().await;
             internal
                 .validators_at_current_height
-                .push(crate::MalValidator { public_key:pub_key.into(), voting_power: 1 });
+                .push(crate::MalValidator {
+                    public_key: pub_key.into(),
+                    voting_power: 1,
+                });
         }
     }
 }

--- a/zebra-crosslink/zebra-crosslink/src/viz.rs
+++ b/zebra-crosslink/zebra-crosslink/src/viz.rs
@@ -3933,14 +3933,15 @@ pub async fn viz_main(
             pt.y += font_size * 0.5;
 
             for val in &g.validators_at_current_height {
-                let string =
-                    if let Some(user_name) = g.validators_keys_to_names.get(&val.public_key.into()) {
-                        user_name.clone()
-                    } else {
-                        let mut string = format!("{:?}", MalPublicKey2(val.public_key.into()));
-                        string.truncate(16);
-                        string
-                    };
+                let string = if let Some(user_name) =
+                    g.validators_keys_to_names.get(&val.public_key.into())
+                {
+                    user_name.clone()
+                } else {
+                    let mut string = format!("{:?}", MalPublicKey2(val.public_key.into()));
+                    string.truncate(16);
+                    string
+                };
                 draw_text_right_align(
                     &format!("{} - {}", val.voting_power, &string,),
                     pt,

--- a/zebra-crosslink/zebra-crosslink/src/viz2.rs
+++ b/zebra-crosslink/zebra-crosslink/src/viz2.rs
@@ -1,11 +1,13 @@
-
+use std::cmp::{max, min};
 use visualizer_zcash::Hash32;
 use zebra_chain::value_balance::ValueBalance;
-use std::cmp::{max, min};
 
 use crate::*;
 
-pub fn viz_main(tokio_root_thread_handle: Option<std::thread::JoinHandle<()>>, wallet_state: Arc<Mutex<wallet::WalletState>>) {
+pub fn viz_main(
+    tokio_root_thread_handle: Option<std::thread::JoinHandle<()>>,
+    wallet_state: Arc<Mutex<wallet::WalletState>>,
+) {
     // loop {
     //     if let Some(ref thread_handle) = tokio_root_thread_handle {
     //         if thread_handle.is_finished() {
@@ -15,7 +17,6 @@ pub fn viz_main(tokio_root_thread_handle: Option<std::thread::JoinHandle<()>>, w
     // }
     visualizer_zcash::main_thread_run_program(wallet_state, false);
 }
-
 
 /// Bridge between tokio & viz code
 pub async fn service_viz_requests(
@@ -29,13 +30,16 @@ pub async fn service_viz_requests(
     loop {
         let request_queue = visualizer_zcash::REQUESTS_TO_ZEBRA.lock().unwrap();
         let response_queue = visualizer_zcash::RESPONSES_FROM_ZEBRA.lock().unwrap();
-        if request_queue.is_none() || response_queue.is_none() { continue; }
+        if request_queue.is_none() || response_queue.is_none() {
+            continue;
+        }
         let request_queue = request_queue.as_ref().unwrap();
         let response_queue = response_queue.as_ref().unwrap();
 
         'main_loop: loop {
             tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-            let Ok(StateReadResponse::TipPoolValues { value_balance, .. }) = (call.read_state)(StateReadRequest::TipPoolValues).await
+            let Ok(StateReadResponse::TipPoolValues { value_balance, .. }) =
+                (call.read_state)(StateReadRequest::TipPoolValues).await
             else {
                 continue 'main_loop;
             };
@@ -43,11 +47,12 @@ pub async fn service_viz_requests(
             let staking_bonded_pool_balance = value_balance.staking_bonded_amount().zatoshis();
             let staking_unbonded_pool_balance = value_balance.staking_unbonded_amount().zatoshis();
 
-            let Ok(StateResponse::Tip(Some(tip_height_hash))) = (call.state)(StateRequest::Tip).await
+            let Ok(StateResponse::Tip(Some(tip_height_hash))) =
+                (call.state)(StateRequest::Tip).await
             else {
                 continue 'main_loop;
             };
-            let bc_tip_height: u64 = tip_height_hash.0.0 as u64;
+            let bc_tip_height: u64 = tip_height_hash.0 .0 as u64;
 
             let bc_req_h = (bc_ack_height, -1);
 
@@ -61,7 +66,8 @@ pub async fn service_viz_requests(
                     hi
                 );
 
-                let Ok(StateResponse::Tip(Some(tip_height_hash))) = (call.state)(StateRequest::Tip).await
+                let Ok(StateResponse::Tip(Some(tip_height_hash))) =
+                    (call.state)(StateRequest::Tip).await
                 else {
                     continue 'main_loop;
                 };
@@ -98,18 +104,21 @@ pub async fn service_viz_requests(
                     }
                 }
 
-                let Some(hi_height_hash) = get_height_hash(call.clone(), h_hi, tip_height_hash).await
+                let Some(hi_height_hash) =
+                    get_height_hash(call.clone(), h_hi, tip_height_hash).await
                 else {
                     continue 'main_loop;
                 };
 
-                let Some(lo_height_hash) = get_height_hash(call.clone(), h_lo, hi_height_hash).await
+                let Some(lo_height_hash) =
+                    get_height_hash(call.clone(), h_lo, hi_height_hash).await
                 else {
                     continue 'main_loop;
                 };
 
                 let (height_hashes, blocks) =
-                    tfl_block_sequence(&call, lo_height_hash.1, Some(hi_height_hash), true, true).await;
+                    tfl_block_sequence(&call, lo_height_hash.1, Some(hi_height_hash), true, true)
+                        .await;
                 (
                     lo_height_hash.0,
                     Some(tip_height_hash),
@@ -120,7 +129,10 @@ pub async fn service_viz_requests(
 
             // paranoid guards
             if lo_height.0 as i64 != bc_ack_height as i64 {
-                println!("PARANOID != WRONG: lo {} vs ack {bc_ack_height}", lo_height.0);
+                println!(
+                    "PARANOID != WRONG: lo {} vs ack {bc_ack_height}",
+                    lo_height.0
+                );
                 continue 'main_loop;
             }
             if suspect_seq_blocks.is_empty() {
@@ -129,25 +141,24 @@ pub async fn service_viz_requests(
             }
             let mut seq_blocks = Vec::new();
             for (i, maybe) in suspect_seq_blocks.iter().enumerate() {
-                let Some(block) = maybe
-                else {
+                let Some(block) = maybe else {
                     println!("PARANOID != WRONG: None seq block at {i}");
                     continue 'main_loop;
                 };
                 seq_blocks.push(block);
             }
 
-
             for _ in 0..256 {
                 if let Ok(request) = request_queue.try_recv() {
                     let mut internal = tfl_handle.internal.lock().await;
                     let mut response = visualizer_zcash::ResponseFromZebra::_0();
                     response.bc_tip_height = bc_tip_height;
-                    response.bc_finalized_tip_height = if let Some(latest_finalized_block) = internal.latest_final_block {
-                        latest_finalized_block.0.0 as u64
-                    } else {
-                        0
-                    };
+                    response.bc_finalized_tip_height =
+                        if let Some(latest_finalized_block) = internal.latest_final_block {
+                            latest_finalized_block.0 .0 as u64
+                        } else {
+                            0
+                        };
                     response.bft_tip_height = (internal.bft_blocks.len() as u64).saturating_sub(1);
                     response.peer_strings = internal.peer_strings.clone();
 
@@ -172,7 +183,9 @@ pub async fn service_viz_requests(
                             is_best_chain: true,
                             is_finalized: false,
                             is_implicated_by_bft: false,
-                            points_at_bft_block: Hash32::from_bytes(bc.header.fat_pointer_to_bft_block.points_at_block_hash()),
+                            points_at_bft_block: Hash32::from_bytes(
+                                bc.header.fat_pointer_to_bft_block.points_at_block_hash(),
+                            ),
                         });
                     }
                     for i in request.bft_ack_height as usize..internal.bft_blocks.len() {
@@ -186,12 +199,19 @@ pub async fn service_viz_requests(
                             this_hash: this_hash,
                             parent_hash: Hash32::from_bytes(b.previous_block_hash().0),
                             this_height: i as u64,
-                            points_at_bc_block: Hash32::from_bytes(b.finalization_candidate().hash().0),
-                            proving_blocks: b.headers.iter().skip(1).map(|x| Hash32::from_bytes(x.hash().0)).collect(),
+                            points_at_bc_block: Hash32::from_bytes(
+                                b.finalization_candidate().hash().0,
+                            ),
+                            proving_blocks: b
+                                .headers
+                                .iter()
+                                .skip(1)
+                                .map(|x| Hash32::from_bytes(x.hash().0))
+                                .collect(),
                         });
 
                         // TODO: compute the finalized tip height!
-                    };
+                    }
 
                     let _ = response_queue.try_send(response);
                 } else {

--- a/zebra-crosslink/zebra-rpc/src/methods.rs
+++ b/zebra-crosslink/zebra-rpc/src/methods.rs
@@ -57,8 +57,8 @@ use tower::{Service, ServiceExt};
 use tracing::Instrument;
 
 use zcash_address::{unified::Encoding, TryFromAddress};
-use zcash_protocol::consensus::Parameters;
 use zcash_primitives::transaction::{RosterMember, StakeTxId};
+use zcash_protocol::consensus::Parameters;
 
 use zebra_chain::{
     amount::{self, Amount, NegativeAllowed, NonNegative},
@@ -1527,17 +1527,21 @@ where
 
     async fn get_bond_info(&self, bond_key: String) -> Result<Option<GetBondInfoResponse>> {
         let bond_key_bytes: [u8; 32] = Vec::from_hex(&bond_key)
-            .map_err(|_| ErrorObject::owned(
-                ErrorCode::InvalidParams.code(),
-                "invalid hex string for bond_key",
-                None::<()>,
-            ))?
+            .map_err(|_| {
+                ErrorObject::owned(
+                    ErrorCode::InvalidParams.code(),
+                    "invalid hex string for bond_key",
+                    None::<()>,
+                )
+            })?
             .try_into()
-            .map_err(|_| ErrorObject::owned(
-                ErrorCode::InvalidParams.code(),
-                "bond_key must be exactly 32 bytes",
-                None::<()>,
-            ))?;
+            .map_err(|_| {
+                ErrorObject::owned(
+                    ErrorCode::InvalidParams.code(),
+                    "bond_key must be exactly 32 bytes",
+                    None::<()>,
+                )
+            })?;
 
         let request = zebra_state::ReadRequest::BondInfo(bond_key_bytes);
         let response = self
@@ -1548,13 +1552,11 @@ where
             .map_misc_error()?;
 
         match response {
-            zebra_state::ReadResponse::BondInfo(Some(info)) => {
-                Ok(Some(GetBondInfoResponse {
-                    amount: u64::from(info.amount),
-                    status: info.status,
-                    last_action_height: info.last_action_height,
-                }))
-            }
+            zebra_state::ReadResponse::BondInfo(Some(info)) => Ok(Some(GetBondInfoResponse {
+                amount: u64::from(info.amount),
+                status: info.status,
+                last_action_height: info.last_action_height,
+            })),
             zebra_state::ReadResponse::BondInfo(None) => Ok(None),
             _ => unreachable!("Unexpected response from state service: {response:?}"),
         }
@@ -1574,18 +1576,18 @@ where
             .await;
 
         match ret {
-            Ok(TFLServiceResponse::Faucet(Ok(amount))) => Ok(FaucetResponse{ amount }),
+            Ok(TFLServiceResponse::Faucet(Ok(amount))) => Ok(FaucetResponse { amount }),
             Ok(TFLServiceResponse::Faucet(Err(err))) => Err(ErrorObject::owned(
-                    server::error::LegacyCode::Verify.into(),
-                    format!("Faucet request for \"{ua_str}\" failed: {err}"),
-                    None::<()>,
+                server::error::LegacyCode::Verify.into(),
+                format!("Faucet request for \"{ua_str}\" failed: {err}"),
+                None::<()>,
             )),
             Err(err) => {
                 // tracing::error!(?ret, "Bad tfl service return.");
                 Err(ErrorObject::owned(
-                        server::error::LegacyCode::Verify.into(),
-                        format!("Faucet request for \"{ua_str}\" failed: {err}"),
-                        None::<()>,
+                    server::error::LegacyCode::Verify.into(),
+                    format!("Faucet request for \"{ua_str}\" failed: {err}"),
+                    None::<()>,
                 ))
             }
             _ => unreachable!(""),
@@ -4164,17 +4166,7 @@ pub struct GetAddressBalanceResponse {
 pub use self::GetAddressBalanceResponse as AddressBalance;
 
 /// Response to a `getbondinfo` RPC request.
-#[derive(
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    Hash,
-    serde::Serialize,
-    serde::Deserialize,
-    Getters,
-    new,
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize, Getters, new)]
 pub struct GetBondInfoResponse {
     /// The bond amount in zatoshis.
     #[getter(copy)]

--- a/zebra-crosslink/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-crosslink/zebra-rpc/src/methods/types/get_block_template.rs
@@ -889,10 +889,10 @@ pub fn standard_coinbase_outputs(
 
     let script = transparent::Script::new(
         &miner_address
-        .to_transparent_address()
-        .expect("address must have a transparent component")
-        .script()
-        .to_bytes()
+            .to_transparent_address()
+            .expect("address must have a transparent component")
+            .script()
+            .to_bytes(),
     );
 
     // The HashMap returns funding streams in an arbitrary order,

--- a/zebra-crosslink/zebra-rpc/tests/serialization_tests.rs
+++ b/zebra-crosslink/zebra-rpc/tests/serialization_tests.rs
@@ -1055,7 +1055,7 @@ fn test_get_block_template_response() -> Result<(), Box<dyn std::error::Error>> 
         height,
         max_time,
         submit_old,
-        zebra_chain::block::FatPointerToBftBlock::null()
+        zebra_chain::block::FatPointerToBftBlock::null(),
     )));
 
     assert_eq!(obj, new_obj);

--- a/zebra-crosslink/zebra-state/src/lib.rs
+++ b/zebra-crosslink/zebra-state/src/lib.rs
@@ -61,8 +61,7 @@ pub use service::{
     non_finalized_state::NonFinalizedState,
     spawn_init, spawn_init_read_only,
     watch_receiver::WatchReceiver,
-    OutputLocation, TransactionIndex, TransactionLocation,
-    ClosureToCallIntoCrosslinkFromState,
+    ClosureToCallIntoCrosslinkFromState, OutputLocation, TransactionIndex, TransactionLocation,
 };
 
 // Allow use in the scanner and external tests

--- a/zebra-crosslink/zebra-state/src/request.rs
+++ b/zebra-crosslink/zebra-state/src/request.rs
@@ -396,7 +396,12 @@ pub struct FinalizedBlock {
 impl FinalizedBlock {
     /// Constructs [`FinalizedBlock`] from [`CheckpointVerifiedBlock`] and its [`Treestate`].
     pub fn from_checkpoint_verified(block: CheckpointVerifiedBlock, treestate: Treestate) -> Self {
-        Self::from_semantically_verified(SemanticallyVerifiedBlock::from(block), treestate, Vec::new(), Vec::new())
+        Self::from_semantically_verified(
+            SemanticallyVerifiedBlock::from(block),
+            treestate,
+            Vec::new(),
+            Vec::new(),
+        )
     }
 
     /// Constructs [`FinalizedBlock`] from [`ContextuallyVerifiedBlock`], [`Treestate`], bond rewards, and unbonding amounts.
@@ -406,11 +411,21 @@ impl FinalizedBlock {
         bond_rewards: Vec<([u8; 32], u64)>,
         unbonding_amounts: Vec<([u8; 32], u64)>,
     ) -> Self {
-        Self::from_semantically_verified(SemanticallyVerifiedBlock::from(block), treestate, bond_rewards, unbonding_amounts)
+        Self::from_semantically_verified(
+            SemanticallyVerifiedBlock::from(block),
+            treestate,
+            bond_rewards,
+            unbonding_amounts,
+        )
     }
 
     /// Constructs [`FinalizedBlock`] from [`SemanticallyVerifiedBlock`], [`Treestate`], bond rewards, and unbonding amounts.
-    fn from_semantically_verified(block: SemanticallyVerifiedBlock, treestate: Treestate, bond_rewards: Vec<([u8; 32], u64)>, unbonding_amounts: Vec<([u8; 32], u64)>) -> Self {
+    fn from_semantically_verified(
+        block: SemanticallyVerifiedBlock,
+        treestate: Treestate,
+        bond_rewards: Vec<([u8; 32], u64)>,
+        unbonding_amounts: Vec<([u8; 32], u64)>,
+    ) -> Self {
         Self {
             block: block.block,
             hash: block.hash,
@@ -427,7 +442,12 @@ impl FinalizedBlock {
 
 impl FinalizableBlock {
     /// Create a new [`FinalizableBlock`] given a [`ContextuallyVerifiedBlock`], treestate, bond rewards, and unbonding amounts.
-    pub fn new(contextually_verified: ContextuallyVerifiedBlock, treestate: Treestate, bond_rewards: Vec<([u8; 32], u64)>, unbonding_amounts: Vec<([u8; 32], u64)>) -> Self {
+    pub fn new(
+        contextually_verified: ContextuallyVerifiedBlock,
+        treestate: Treestate,
+        bond_rewards: Vec<([u8; 32], u64)>,
+        unbonding_amounts: Vec<([u8; 32], u64)>,
+    ) -> Self {
         Self::Contextual {
             contextually_verified,
             treestate,

--- a/zebra-crosslink/zebra-state/src/response.rs
+++ b/zebra-crosslink/zebra-state/src/response.rs
@@ -25,10 +25,7 @@ use zebra_chain::work::difficulty::CompactDifficulty;
 #[allow(unused_imports)]
 use crate::{ReadRequest, Request};
 
-use crate::{
-    service::read::AddressUtxos,
-    NonFinalizedState, TransactionLocation, WatchReceiver,
-};
+use crate::{service::read::AddressUtxos, NonFinalizedState, TransactionLocation, WatchReceiver};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// A response to a [`StateService`](crate::service::StateService) [`Request`].

--- a/zebra-crosslink/zebra-state/src/service.rs
+++ b/zebra-crosslink/zebra-state/src/service.rs
@@ -24,11 +24,11 @@ use std::{
     time::{Duration, Instant},
 };
 
+use derivative::Derivative;
 use futures::future::FutureExt;
 use tokio::sync::{oneshot, watch};
 use tower::{util::BoxService, Service, ServiceExt};
 use tracing::{instrument, Instrument, Span};
-use derivative::Derivative;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use tower::buffer::Buffer;
@@ -40,8 +40,8 @@ use zebra_chain::{
     subtree::NoteCommitmentSubtreeIndex,
 };
 
-use zebra_chain::{block::Height, serialization::ZcashSerialize};
 use zebra_chain::block::FatPointerToBftBlock;
+use zebra_chain::{block::Height, serialization::ZcashSerialize};
 
 use crate::{
     constants::{
@@ -182,7 +182,8 @@ pub(crate) struct StateService {
     closure_to_call_crosslink: ClosureToCallIntoCrosslinkFromState,
 }
 
-pub type ClosureToCallIntoCrosslinkFromState = Arc<dyn Fn(FatPointerToBftBlock, FatPointerToBftBlock) -> bool + Send + Sync>;
+pub type ClosureToCallIntoCrosslinkFromState =
+    Arc<dyn Fn(FatPointerToBftBlock, FatPointerToBftBlock) -> bool + Send + Sync>;
 
 /// A read-only service for accessing Zebra's cached blockchain state.
 ///
@@ -605,21 +606,35 @@ impl StateService {
     ) -> oneshot::Receiver<Result<block::Hash, CommitSemanticallyVerifiedError>> {
         tracing::debug!(block = %semantically_verrified.block, "queueing block for contextual verification");
         let parent_hash = semantically_verrified.block.header.previous_block_hash;
-        let parent_block_header = self.read_service.non_finalized_state_receiver.with_watch_data(
-            |non_finalized_state| {
+        let parent_block_header = self
+            .read_service
+            .non_finalized_state_receiver
+            .with_watch_data(|non_finalized_state| {
                 let mut ret = None;
                 for chain in non_finalized_state.chain_iter() {
                     if ret.is_none() {
-                        ret = chain.block(crate::HashOrHeight::Hash(parent_hash)).map(|b| b.block.header.clone());
+                        ret = chain
+                            .block(crate::HashOrHeight::Hash(parent_hash))
+                            .map(|b| b.block.header.clone());
                     }
                 }
                 ret
-            },
-        );
-        let parent_block_header = if parent_block_header.is_some() { parent_block_header } else { self.read_service.db.block_header(crate::HashOrHeight::Hash(parent_hash)) };
-        let parent_block_fat_pointer = parent_block_header.map(|h| h.fat_pointer_to_bft_block.clone());
+            });
+        let parent_block_header = if parent_block_header.is_some() {
+            parent_block_header
+        } else {
+            self.read_service
+                .db
+                .block_header(crate::HashOrHeight::Hash(parent_hash))
+        };
+        let parent_block_fat_pointer =
+            parent_block_header.map(|h| h.fat_pointer_to_bft_block.clone());
 
-        let this_header_fat_pointer = semantically_verrified.block.header.fat_pointer_to_bft_block.clone();
+        let this_header_fat_pointer = semantically_verrified
+            .block
+            .header
+            .fat_pointer_to_bft_block
+            .clone();
         let semantically_verrified_height = semantically_verrified.height;
 
         if self
@@ -688,7 +703,13 @@ impl StateService {
                 == self.finalized_block_write_last_sent_hash
         {
             // CROSSLINK
-            if parent_block_fat_pointer.is_none() || false == (self.closure_to_call_crosslink)(parent_block_fat_pointer.unwrap(), this_header_fat_pointer) {
+            if parent_block_fat_pointer.is_none()
+                || false
+                    == (self.closure_to_call_crosslink)(
+                        parent_block_fat_pointer.unwrap(),
+                        this_header_fat_pointer,
+                    )
+            {
                 let (rsp_tx, rsp_rx) = oneshot::channel();
                 let _ = rsp_tx.send(Err(CommitSemanticallyVerifiedError::from(
                     ValidateContextError::CrosslinkNotReady {
@@ -717,7 +738,13 @@ impl StateService {
             tracing::trace!("unready to verify, returning early");
         } else if self.block_write_sender.finalized.is_none() {
             // CROSSLINK
-            if parent_block_fat_pointer.is_none() || false == (self.closure_to_call_crosslink)(parent_block_fat_pointer.unwrap(), this_header_fat_pointer) {
+            if parent_block_fat_pointer.is_none()
+                || false
+                    == (self.closure_to_call_crosslink)(
+                        parent_block_fat_pointer.unwrap(),
+                        this_header_fat_pointer,
+                    )
+            {
                 let (rsp_tx, rsp_rx) = oneshot::channel();
                 let _ = rsp_tx.send(Err(CommitSemanticallyVerifiedError::from(
                     ValidateContextError::CrosslinkNotReady {
@@ -1129,7 +1156,9 @@ impl Service<Request> for StateService {
                         // TODO: replace with Result::flatten once it stabilises
                         // https://github.com/rust-lang/rust/issues/70142
                         .and_then(convert::identity)
-                        .map(|(hash, aggregated_stakes)| Response::CrosslinkFinalized(hash, aggregated_stakes))
+                        .map(|(hash, aggregated_stakes)| {
+                            Response::CrosslinkFinalized(hash, aggregated_stakes)
+                        })
                 }
                 .instrument(span)
                 .boxed()
@@ -2274,9 +2303,14 @@ impl Service<ReadRequest> for ReadStateService {
 
                 tokio::task::spawn_blocking(move || {
                     span.in_scope(move || {
-                        let bond_info = state.non_finalized_state_receiver.with_watch_data(
-                            |non_finalized_state| non_finalized_state.best_chain().map(|chain| chain.delegation_bonds.get(&bond_key).cloned()),
-                        ).flatten();
+                        let bond_info = state
+                            .non_finalized_state_receiver
+                            .with_watch_data(|non_finalized_state| {
+                                non_finalized_state
+                                    .best_chain()
+                                    .map(|chain| chain.delegation_bonds.get(&bond_key).cloned())
+                            })
+                            .flatten();
 
                         timer.finish(module_path!(), line!(), "ReadRequest::BondInfo");
 
@@ -2426,8 +2460,13 @@ pub fn spawn_init(
 pub fn init_test(network: &Network) -> Buffer<BoxService<Request, Response, BoxError>, Request> {
     // TODO: pass max_checkpoint_height and checkpoint_verify_concurrency limit
     //       if we ever need to test final checkpoint sent UTXO queries
-    let (state_service, _, _, _) =
-        StateService::new(Config::ephemeral(), network, block::Height::MAX, 0, Arc::new(|_,_| true));
+    let (state_service, _, _, _) = StateService::new(
+        Config::ephemeral(),
+        network,
+        block::Height::MAX,
+        0,
+        Arc::new(|_, _| true),
+    );
 
     Buffer::new(BoxService::new(state_service), 1)
 }
@@ -2447,8 +2486,13 @@ pub fn init_test_services(
 ) {
     // TODO: pass max_checkpoint_height and checkpoint_verify_concurrency limit
     //       if we ever need to test final checkpoint sent UTXO queries
-    let (state_service, read_state_service, latest_chain_tip, chain_tip_change) =
-        StateService::new(Config::ephemeral(), network, block::Height::MAX, 0, std::sync::Arc::new(|_,_| true));
+    let (state_service, read_state_service, latest_chain_tip, chain_tip_change) = StateService::new(
+        Config::ephemeral(),
+        network,
+        block::Height::MAX,
+        0,
+        std::sync::Arc::new(|_, _| true),
+    );
 
     let state_service = Buffer::new(BoxService::new(state_service), 1);
 

--- a/zebra-crosslink/zebra-state/src/service/arbitrary.rs
+++ b/zebra-crosslink/zebra-state/src/service/arbitrary.rs
@@ -217,8 +217,13 @@ pub async fn populated_state(
 
     // TODO: write a test that checks the finalized to non-finalized transition with UTXOs,
     //       and set max_checkpoint_height and checkpoint_verify_concurrency_limit correctly.
-    let (state, read_state, latest_chain_tip, mut chain_tip_change) =
-        StateService::new(Config::ephemeral(), network, Height::MAX, 0, std::sync::Arc::new(|_,_| true));
+    let (state, read_state, latest_chain_tip, mut chain_tip_change) = StateService::new(
+        Config::ephemeral(),
+        network,
+        Height::MAX,
+        0,
+        std::sync::Arc::new(|_, _| true),
+    );
     let mut state = Buffer::new(BoxService::new(state), 1);
 
     let mut responses = FuturesUnordered::new();

--- a/zebra-crosslink/zebra-state/src/service/check/delegation.rs
+++ b/zebra-crosslink/zebra-state/src/service/check/delegation.rs
@@ -4,7 +4,10 @@ use std::collections::HashMap;
 
 use crate::{
     service::{
-        finalized_state::{disk_format::{BondKey, DelegationBond}, ZebraDb},
+        finalized_state::{
+            disk_format::{BondKey, DelegationBond},
+            ZebraDb,
+        },
         non_finalized_state::Chain,
     },
     SemanticallyVerifiedBlock, ValidateContextError,
@@ -44,14 +47,13 @@ pub fn validate_delegation_bonds(
                     )?;
 
                     // Track this new bond for subsequent validation in this block
-                    let amount =
-                        zebra_chain::amount::Amount::try_from(staking_action.amount_zats)
-                            .map_err(|e| {
-                                ValidateContextError::InvalidDelegationBond(format!(
-                                    "invalid bond amount: {:?}",
-                                    e
-                                ))
-                            })?;
+                    let amount = zebra_chain::amount::Amount::try_from(staking_action.amount_zats)
+                        .map_err(|e| {
+                            ValidateContextError::InvalidDelegationBond(format!(
+                                "invalid bond amount: {:?}",
+                                e
+                            ))
+                        })?;
                     let target_finalizer = staking_action.arg32_2;
                     let bond = DelegationBond::new(
                         amount,

--- a/zebra-crosslink/zebra-state/src/service/finalized_state.rs
+++ b/zebra-crosslink/zebra-state/src/service/finalized_state.rs
@@ -410,7 +410,12 @@ impl FinalizedState {
             } => (
                 contextually_verified.height,
                 contextually_verified.hash,
-                FinalizedBlock::from_contextually_verified(contextually_verified, treestate, bond_rewards, unbonding_amounts),
+                FinalizedBlock::from_contextually_verified(
+                    contextually_verified,
+                    treestate,
+                    bond_rewards,
+                    unbonding_amounts,
+                ),
                 prev_note_commitment_trees,
             ),
         };

--- a/zebra-crosslink/zebra-state/src/service/finalized_state/disk_format/delegation.rs
+++ b/zebra-crosslink/zebra-state/src/service/finalized_state/disk_format/delegation.rs
@@ -178,8 +178,7 @@ impl FromDisk for DelegationBond {
             .try_into()
             .expect("amount should be 8 bytes");
         let amount_zatoshis = u64::from_be_bytes(amount_bytes);
-        let amount = Amount::try_from(amount_zatoshis)
-            .expect("amount should be valid");
+        let amount = Amount::try_from(amount_zatoshis).expect("amount should be valid");
         offset += AMOUNT_DISK_BYTES;
 
         // Deserialize target_finalizer (32 bytes)
@@ -189,7 +188,9 @@ impl FromDisk for DelegationBond {
         offset += TARGET_FINALIZER_DISK_BYTES;
 
         // Deserialize created_at location (5 bytes)
-        let created_at = TransactionLocation::from_bytes(&bytes[offset..offset + TRANSACTION_LOCATION_DISK_BYTES]);
+        let created_at = TransactionLocation::from_bytes(
+            &bytes[offset..offset + TRANSACTION_LOCATION_DISK_BYTES],
+        );
 
         Self {
             amount,
@@ -246,7 +247,8 @@ impl FromDisk for BondStatus {
                     1 + TRANSACTION_LOCATION_DISK_BYTES,
                     bytes.len()
                 );
-                let unbonded_at = TransactionLocation::from_bytes(&bytes[1..1 + TRANSACTION_LOCATION_DISK_BYTES]);
+                let unbonded_at =
+                    TransactionLocation::from_bytes(&bytes[1..1 + TRANSACTION_LOCATION_DISK_BYTES]);
                 BondStatus::Unbonding { unbonded_at }
             }
             2 => {
@@ -256,7 +258,8 @@ impl FromDisk for BondStatus {
                     1 + TRANSACTION_LOCATION_DISK_BYTES,
                     bytes.len()
                 );
-                let withdrawn_at = TransactionLocation::from_bytes(&bytes[1..1 + TRANSACTION_LOCATION_DISK_BYTES]);
+                let withdrawn_at =
+                    TransactionLocation::from_bytes(&bytes[1..1 + TRANSACTION_LOCATION_DISK_BYTES]);
                 BondStatus::Withdrawn { withdrawn_at }
             }
             _ => panic!("Invalid BondStatus tag: {}", tag),

--- a/zebra-crosslink/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-crosslink/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -268,11 +268,16 @@ impl DiskWriteBatch {
 
         // Apply bond rewards to the staking_bonded pool tally FIRST,
         // before unbonding moves value between pools (to match non-finalized state order)
-        let total_rewards: u64 = finalized.bond_rewards.iter().map(|(_, amount)| amount).sum();
+        let total_rewards: u64 = finalized
+            .bond_rewards
+            .iter()
+            .map(|(_, amount)| amount)
+            .sum();
         if total_rewards > 0 {
             let current_bonded = new_value_pool.staking_bonded_amount();
-            let new_bonded: Amount<NonNegative> = (current_bonded + Amount::try_from(total_rewards as i64)?)
-                .expect("staking_bonded pool should not overflow from rewards");
+            let new_bonded: Amount<NonNegative> = (current_bonded
+                + Amount::try_from(total_rewards as i64)?)
+            .expect("staking_bonded pool should not overflow from rewards");
             new_value_pool.set_staking_bonded_amount(new_bonded);
         }
 
@@ -285,8 +290,8 @@ impl DiskWriteBatch {
 
             // Move value from staking_bonded to staking_unbonded
             let current_bonded = new_value_pool.staking_bonded_amount();
-            let new_bonded: Amount<NonNegative> = (current_bonded - bond_amount)
-                .expect("staking_bonded pool should not underflow");
+            let new_bonded: Amount<NonNegative> =
+                (current_bonded - bond_amount).expect("staking_bonded pool should not underflow");
             new_value_pool.set_staking_bonded_amount(new_bonded);
 
             let current_unbonded = new_value_pool.staking_unbonded_amount();

--- a/zebra-crosslink/zebra-state/src/service/finalized_state/zebra_db/delegation.rs
+++ b/zebra-crosslink/zebra-state/src/service/finalized_state/zebra_db/delegation.rs
@@ -150,11 +150,21 @@ impl DiskWriteBatch {
                     }
                     StakingActionKind::BeginDelegationUnbonding => {
                         // Mark bond as unbonding
-                        self.prepare_unbonding_delegation_bond(&db.db, db, bond_key, transaction_location)?;
+                        self.prepare_unbonding_delegation_bond(
+                            &db.db,
+                            db,
+                            bond_key,
+                            transaction_location,
+                        )?;
                     }
                     StakingActionKind::WithdrawDelegationBond => {
                         // Mark bond as withdrawn
-                        self.prepare_withdrawn_delegation_bond(&db.db, db, bond_key, transaction_location)?;
+                        self.prepare_withdrawn_delegation_bond(
+                            &db.db,
+                            db,
+                            bond_key,
+                            transaction_location,
+                        )?;
                     }
                     StakingActionKind::RetargetDelegationBond => {
                         // Update the bond's target_finalizer
@@ -178,7 +188,9 @@ impl DiskWriteBatch {
         for (bond_key, reward_amount) in &finalized.bond_rewards {
             // Get current bond from bonds modified in this block first, then fall back to DB.
             // This ensures we use the updated bond if it was retargeted/created in this block.
-            let bond_opt = bonds_created_in_block.get(bond_key).cloned()
+            let bond_opt = bonds_created_in_block
+                .get(bond_key)
+                .cloned()
                 .or_else(|| db.delegation_bond(bond_key));
 
             if let Some(mut bond) = bond_opt {
@@ -197,7 +209,12 @@ impl DiskWriteBatch {
     /// Inserts into:
     /// - `delegation_bond_by_key`: stores the bond data
     /// - `bond_status_by_key`: stores Active status
-    fn prepare_new_delegation_bond(&mut self, db: &DiskDb, bond_key: BondKey, bond: DelegationBond) {
+    fn prepare_new_delegation_bond(
+        &mut self,
+        db: &DiskDb,
+        bond_key: BondKey,
+        bond: DelegationBond,
+    ) {
         let delegation_bond_by_key_cf = db.cf_handle(DELEGATION_BOND_BY_KEY).unwrap();
         let bond_status_by_key_cf = db.cf_handle(BOND_STATUS_BY_KEY).unwrap();
 
@@ -301,10 +318,13 @@ impl DiskWriteBatch {
 
         // Get current bond from bonds modified in this block first, then fall back to DB.
         // This ensures we use the updated bond if it was modified earlier in this block.
-        let bond_opt = bonds_created_in_block.get(&bond_key).cloned()
+        let bond_opt = bonds_created_in_block
+            .get(&bond_key)
+            .cloned()
             .or_else(|| zebra_db.delegation_bond(&bond_key));
 
-        let mut bond = bond_opt.ok_or_else(|| format!("bond {:?} not found for retarget", bond_key))?;
+        let mut bond =
+            bond_opt.ok_or_else(|| format!("bond {:?} not found for retarget", bond_key))?;
 
         // Update only target_finalizer (not created_at or amount)
         bond.target_finalizer = new_target;

--- a/zebra-crosslink/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-crosslink/zebra-state/src/service/non_finalized_state.rs
@@ -199,7 +199,8 @@ impl NonFinalizedState {
 
         // Pop the lowest height block from the best chain to be finalized, and
         // also obtain its associated treestate, bond rewards, and unbonding amounts.
-        let (best_chain_root, root_treestate, bond_rewards, unbonding_amounts) = mut_best_chain.pop_root();
+        let (best_chain_root, root_treestate, bond_rewards, unbonding_amounts) =
+            mut_best_chain.pop_root();
 
         // add best_chain back to `self.chain_set`
         if !best_chain.is_empty() {
@@ -222,7 +223,8 @@ impl NonFinalizedState {
             let mut_side_chain = Arc::make_mut(&mut side_chain);
 
             // remove the first block from `chain`
-            let (side_chain_root, _treestate, _side_rewards, _side_unbonding) = mut_side_chain.pop_root();
+            let (side_chain_root, _treestate, _side_rewards, _side_unbonding) =
+                mut_side_chain.pop_root();
             assert_eq!(side_chain_root.hash, best_chain_root.hash);
 
             // add the chain back to `self.chain_set`
@@ -236,7 +238,12 @@ impl NonFinalizedState {
         self.update_metrics_for_chains();
 
         // Add the treestate, bond rewards, and unbonding amounts to the finalized block.
-        FinalizableBlock::new(best_chain_root, root_treestate, bond_rewards, unbonding_amounts)
+        FinalizableBlock::new(
+            best_chain_root,
+            root_treestate,
+            bond_rewards,
+            unbonding_amounts,
+        )
     }
 
     /// Remove chains that are no longer valid, i.e. they don't contain the newly-finalized hash
@@ -524,11 +531,7 @@ impl NonFinalizedState {
 
         // Validate delegation bonds
         // Reads from disk
-        check::delegation::validate_delegation_bonds(
-            &prepared,
-            &new_chain,
-            finalized_state,
-        )?;
+        check::delegation::validate_delegation_bonds(&prepared, &new_chain, finalized_state)?;
 
         // Reads from disk
         check::anchors::block_sapling_orchard_anchors_refer_to_final_treestates(

--- a/zebra-crosslink/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-crosslink/zebra-state/src/service/non_finalized_state/chain.rs
@@ -38,9 +38,7 @@ use crate::{
     request::Treestate,
     service::{
         check,
-        finalized_state::disk_format::{
-            self, BondKey, BondStatus, DelegationBond,
-        },
+        finalized_state::disk_format::{self, BondKey, BondStatus, DelegationBond},
     },
     ContextuallyVerifiedBlock, HashOrHeight, OutputLocation, TransactionLocation,
     ValidateContextError,
@@ -278,7 +276,13 @@ impl Chain {
         orchard_note_commitment_tree: Arc<orchard::tree::NoteCommitmentTree>,
         history_tree: Arc<HistoryTree>,
         finalized_tip_chain_value_pools: ValueBalance<NonNegative>,
-        finalized_bonds: impl IntoIterator<Item = (disk_format::BondKey, disk_format::DelegationBond, disk_format::BondStatus)>,
+        finalized_bonds: impl IntoIterator<
+            Item = (
+                disk_format::BondKey,
+                disk_format::DelegationBond,
+                disk_format::BondStatus,
+            ),
+        >,
     ) -> Self {
         // Convert finalized bonds to chain format with their actual status
         let delegation_bonds: HashMap<_, _> = finalized_bonds
@@ -392,7 +396,14 @@ impl Chain {
     /// Pops the lowest height block of the non-finalized portion of a chain,
     /// and returns it with its associated treestate, bond rewards, and unbonding amounts for that block.
     #[instrument(level = "debug", skip(self))]
-    pub(crate) fn pop_root(&mut self) -> (ContextuallyVerifiedBlock, Treestate, Vec<([u8; 32], u64)>, Vec<([u8; 32], u64)>) {
+    pub(crate) fn pop_root(
+        &mut self,
+    ) -> (
+        ContextuallyVerifiedBlock,
+        Treestate,
+        Vec<([u8; 32], u64)>,
+        Vec<([u8; 32], u64)>,
+    ) {
         // Obtain the lowest height.
         let block_height = self.non_finalized_root_height();
 
@@ -435,7 +446,9 @@ impl Chain {
             if let Some(staking_action) = tx.staking_action() {
                 if staking_action.kind == StakingActionKind::BeginDelegationUnbonding {
                     let bond_key = staking_action.arg32_0;
-                    let (bond, _status) = self.delegation_bonds.get(&bond_key)
+                    let (bond, _status) = self
+                        .delegation_bonds
+                        .get(&bond_key)
                         .expect("bond must exist when unbonding");
                     unbonding_amounts.push((bond_key, bond.amount.into()));
                 }
@@ -1618,7 +1631,9 @@ impl Chain {
 
                 // Insert as active bond
                 // Note: duplicate bond check should have been done during contextual validation
-                let previous = self.delegation_bonds.insert(bond_key, (bond, BondStatusInChain::Active));
+                let previous = self
+                    .delegation_bonds
+                    .insert(bond_key, (bond, BondStatusInChain::Active));
                 assert!(
                     previous.is_none(),
                     "duplicate delegation bond should have been rejected during validation"
@@ -1626,7 +1641,9 @@ impl Chain {
             }
             StakingActionKind::BeginDelegationUnbonding => {
                 // Get the bond from self.delegation_bonds
-                let (bond, _status) = self.delegation_bonds.get(&bond_key)
+                let (bond, _status) = self
+                    .delegation_bonds
+                    .get(&bond_key)
                     .copied()
                     .expect("bond must exist in chain (should have been validated)");
 
@@ -1636,27 +1653,35 @@ impl Chain {
                     bond.target_finalizer,
                     transaction_location,
                 );
-                self.delegation_bonds.insert(bond_key, (updated_bond, BondStatusInChain::Unbonding));
+                self.delegation_bonds
+                    .insert(bond_key, (updated_bond, BondStatusInChain::Unbonding));
 
                 // Decrease staking_bonded pool by bond amount
                 let current_bonded = self.chain_value_pools.staking_bonded_amount();
-                let new_bonded = (current_bonded - bond.amount)
-                    .map_err(|e| ValidateContextError::InvalidDelegationBond(
-                        format!("staking_bonded pool underflow when unbonding: {:?}", e)
-                    ))?;
+                let new_bonded = (current_bonded - bond.amount).map_err(|e| {
+                    ValidateContextError::InvalidDelegationBond(format!(
+                        "staking_bonded pool underflow when unbonding: {:?}",
+                        e
+                    ))
+                })?;
                 self.chain_value_pools.set_staking_bonded_amount(new_bonded);
 
                 // Increase staking_unbonded pool by bond amount
                 let current_unbonded = self.chain_value_pools.staking_unbonded_amount();
-                let new_unbonded = (current_unbonded + bond.amount)
-                    .map_err(|e| ValidateContextError::InvalidDelegationBond(
-                        format!("staking_unbonded pool overflow when unbonding: {:?}", e)
-                    ))?;
-                self.chain_value_pools.set_staking_unbonded_amount(new_unbonded);
+                let new_unbonded = (current_unbonded + bond.amount).map_err(|e| {
+                    ValidateContextError::InvalidDelegationBond(format!(
+                        "staking_unbonded pool overflow when unbonding: {:?}",
+                        e
+                    ))
+                })?;
+                self.chain_value_pools
+                    .set_staking_unbonded_amount(new_unbonded);
             }
             StakingActionKind::WithdrawDelegationBond => {
                 // Get the bond from self.delegation_bonds
-                let (bond, _status) = self.delegation_bonds.get(&bond_key)
+                let (bond, _status) = self
+                    .delegation_bonds
+                    .get(&bond_key)
                     .copied()
                     .expect("bond must exist in chain (should have been validated)");
 
@@ -1666,25 +1691,32 @@ impl Chain {
                     bond.target_finalizer,
                     transaction_location,
                 );
-                self.delegation_bonds.insert(bond_key, (updated_bond, BondStatusInChain::Withdrawn));
+                self.delegation_bonds
+                    .insert(bond_key, (updated_bond, BondStatusInChain::Withdrawn));
             }
             StakingActionKind::RetargetDelegationBond => {
                 // Get the old target first (immutable borrow)
                 let old_target = {
-                    let (bond, _status) = self.delegation_bonds.get(&bond_key)
+                    let (bond, _status) = self
+                        .delegation_bonds
+                        .get(&bond_key)
                         .expect("bond must exist in chain (should have been validated)");
                     bond.target_finalizer
                 };
 
                 // Record the pre-block target for this bond (only if not already recorded in this block)
                 // This allows us to restore the original target on revert
-                let retargets_this_block = self.bond_retargets.last_mut()
+                let retargets_this_block = self
+                    .bond_retargets
+                    .last_mut()
                     .expect("bond_retargets should have been initialized for this block");
                 retargets_this_block.entry(bond_key).or_insert(old_target);
 
                 // Update only target_finalizer (not created_at or amount)
                 let new_target = staking_action.arg32_2;
-                let (bond, _status) = self.delegation_bonds.get_mut(&bond_key)
+                let (bond, _status) = self
+                    .delegation_bonds
+                    .get_mut(&bond_key)
                     .expect("bond must exist in chain");
                 bond.target_finalizer = new_target;
             }
@@ -1707,7 +1739,9 @@ impl Chain {
         staking_action: &zcash_primitives::transaction::StakingAction,
         position: RevertPosition,
     ) {
-        if position == RevertPosition::Root { return; }
+        if position == RevertPosition::Root {
+            return;
+        }
         use zcash_primitives::transaction::StakingActionKind;
 
         let bond_key = staking_action.arg32_0;
@@ -1722,11 +1756,15 @@ impl Chain {
             }
             StakingActionKind::BeginDelegationUnbonding => {
                 // Change status back from Unbonding to Active
-                let (bond, status) = self.delegation_bonds.get_mut(&bond_key).expect(
-                    "bond must be present if unbonding was added to chain"
+                let (bond, status) = self
+                    .delegation_bonds
+                    .get_mut(&bond_key)
+                    .expect("bond must be present if unbonding was added to chain");
+                assert_eq!(
+                    *status,
+                    BondStatusInChain::Unbonding,
+                    "bond should be unbonding if unbonding was added to chain"
                 );
-                assert_eq!(*status, BondStatusInChain::Unbonding,
-                    "bond should be unbonding if unbonding was added to chain");
                 *status = BondStatusInChain::Active;
                 let bond_amount = bond.amount;
 
@@ -1739,15 +1777,20 @@ impl Chain {
                 let current_unbonded = self.chain_value_pools.staking_unbonded_amount();
                 let new_unbonded = (current_unbonded - bond_amount)
                     .expect("reverting unbonding should not underflow unbonded pool");
-                self.chain_value_pools.set_staking_unbonded_amount(new_unbonded);
+                self.chain_value_pools
+                    .set_staking_unbonded_amount(new_unbonded);
             }
             StakingActionKind::WithdrawDelegationBond => {
                 // Change status back from Withdrawn to Unbonding
-                let (bond, status) = self.delegation_bonds.get_mut(&bond_key).expect(
-                    "bond must be present if withdrawal was added to chain"
+                let (bond, status) = self
+                    .delegation_bonds
+                    .get_mut(&bond_key)
+                    .expect("bond must be present if withdrawal was added to chain");
+                assert_eq!(
+                    *status,
+                    BondStatusInChain::Withdrawn,
+                    "bond should be withdrawn if withdrawal was added to chain"
                 );
-                assert_eq!(*status, BondStatusInChain::Withdrawn,
-                    "bond should be withdrawn if withdrawal was added to chain");
                 *status = BondStatusInChain::Unbonding;
             }
             _ => {}
@@ -1901,7 +1944,12 @@ impl Chain {
         let size = block.zcash_serialized_size();
         self.update_chain_tip_with(&(*chain_value_pool_change, height, size))?;
 
-        if self.delegation_bonds.iter().position(|(_, (_, status))| *status == BondStatusInChain::Active).is_none() {
+        if self
+            .delegation_bonds
+            .iter()
+            .position(|(_, (_, status))| *status == BondStatusInChain::Active)
+            .is_none()
+        {
             self.bond_rewards.push(Vec::new());
             // TODO handle this case, for prototyping this is whatever.
         } else {
@@ -1911,16 +1959,22 @@ impl Chain {
             */
             let mut total_staked_zats = 0u64;
             let max_staker = {
-                let mut iter = self.inner.delegation_bonds.iter().filter(|(_, (_, status))| *status == BondStatusInChain::Active);
+                let mut iter = self
+                    .inner
+                    .delegation_bonds
+                    .iter()
+                    .filter(|(_, (_, status))| *status == BondStatusInChain::Active);
                 let first = iter.next().expect("is any checked already");
                 let mut max_staker = *first.0;
-                let mut biggest = first.1.0.amount.zatoshis() as u64;
-                total_staked_zats += first.1.0.amount.zatoshis() as u64;
+                let mut biggest = first.1 .0.amount.zatoshis() as u64;
+                total_staked_zats += first.1 .0.amount.zatoshis() as u64;
                 for other in iter {
-                    total_staked_zats += other.1.0.amount.zatoshis() as u64;
-                    if other.1.0.amount.zatoshis() as u64 > biggest || (other.1.0.amount.zatoshis() as u64 == biggest && *other.0 < max_staker) {
+                    total_staked_zats += other.1 .0.amount.zatoshis() as u64;
+                    if other.1 .0.amount.zatoshis() as u64 > biggest
+                        || (other.1 .0.amount.zatoshis() as u64 == biggest && *other.0 < max_staker)
+                    {
                         max_staker = *other.0;
-                        biggest = other.1.0.amount.zatoshis() as u64;
+                        biggest = other.1 .0.amount.zatoshis() as u64;
                     }
                 }
                 max_staker
@@ -1937,20 +1991,28 @@ impl Chain {
                     so_far_payed_reward += reward;
 
                     bond.amount = (bond.amount + Amount::new(reward as i64)).unwrap();
-                    reward_store_for_revert.push((*bond_key, reward,));
+                    reward_store_for_revert.push((*bond_key, reward));
                 }
             }
 
             // Biggest bond position gets the remainder.
             {
-                let (bond, _status) = self.inner.delegation_bonds.get_mut(&max_staker).expect("checked earlier");
+                let (bond, _status) = self
+                    .inner
+                    .delegation_bonds
+                    .get_mut(&max_staker)
+                    .expect("checked earlier");
                 let reward = bond_reward_total - so_far_payed_reward;
 
                 bond.amount = (bond.amount + Amount::new(reward as i64)).unwrap();
-                reward_store_for_revert.push((max_staker, reward,));
+                reward_store_for_revert.push((max_staker, reward));
             }
 
-            self.inner.chain_value_pools.set_staking_bonded_amount((self.inner.chain_value_pools.staking_bonded_amount() + Amount::new(bond_reward_total as i64)).unwrap());
+            self.inner.chain_value_pools.set_staking_bonded_amount(
+                (self.inner.chain_value_pools.staking_bonded_amount()
+                    + Amount::new(bond_reward_total as i64))
+                .unwrap(),
+            );
             self.bond_rewards.push(reward_store_for_revert);
         }
         Ok(())
@@ -2023,10 +2085,15 @@ impl UpdateWith<ContextuallyVerifiedBlock> for Chain {
             // Block being finalized - rewards already extracted by pop_root, nothing to do here
         } else {
             // Block being reverted from tip, reverse the rewards
-            let rewards = self.bond_rewards.pop().expect("rewards must exist for tip block");
+            let rewards = self
+                .bond_rewards
+                .pop()
+                .expect("rewards must exist for tip block");
             for (bond_key, reward_amount) in rewards {
                 // Subtract reward from bond amount
-                let (bond, _status) = self.delegation_bonds.get_mut(&bond_key)
+                let (bond, _status) = self
+                    .delegation_bonds
+                    .get_mut(&bond_key)
                     .expect("bond must exist if it received rewards");
                 bond.amount = (bond.amount - Amount::try_from(reward_amount as i64).unwrap())
                     .expect("reverting reward should not underflow bond amount");
@@ -2039,9 +2106,14 @@ impl UpdateWith<ContextuallyVerifiedBlock> for Chain {
             }
 
             // Revert bond retargets - restore old target_finalizer values
-            let retargets = self.bond_retargets.pop().expect("retargets must exist for tip block");
+            let retargets = self
+                .bond_retargets
+                .pop()
+                .expect("retargets must exist for tip block");
             for (bond_key, old_target) in retargets {
-                let (bond, _status) = self.delegation_bonds.get_mut(&bond_key)
+                let (bond, _status) = self
+                    .delegation_bonds
+                    .get_mut(&bond_key)
                     .expect("bond must exist if it was retargeted");
                 bond.target_finalizer = old_target;
             }

--- a/zebra-crosslink/zebra-state/src/service/read.rs
+++ b/zebra-crosslink/zebra-state/src/service/read.rs
@@ -37,15 +37,15 @@ pub use block::{
 #[cfg(feature = "indexer")]
 pub use block::spending_transaction_hash;
 
+pub use delegation::{
+    bond_exists, delegation_bond, is_bond_active, is_bond_unbonding, is_bond_withdrawn,
+};
 pub use find::{
     best_tip, block_locator, depth, finalized_state_contains_block_hash, find_chain_hashes,
     find_chain_headers, hash_by_height, height_by_hash, next_median_time_past,
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
 };
 pub use tree::{orchard_subtrees, orchard_tree, sapling_subtrees, sapling_tree};
-pub use delegation::{
-    bond_exists, delegation_bond, is_bond_active, is_bond_unbonding, is_bond_withdrawn,
-};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 #[allow(unused_imports)]

--- a/zebra-crosslink/zebra-state/src/service/read/delegation.rs
+++ b/zebra-crosslink/zebra-state/src/service/read/delegation.rs
@@ -1,7 +1,10 @@
 //! Delegation bond queries that search both finalized and non-finalized state.
 
 use crate::service::{
-    finalized_state::{disk_format::{BondKey, BondStatus, DelegationBond}, ZebraDb},
+    finalized_state::{
+        disk_format::{BondKey, BondStatus, DelegationBond},
+        ZebraDb,
+    },
     non_finalized_state::Chain,
 };
 

--- a/zebra-crosslink/zebra-state/src/service/write.rs
+++ b/zebra-crosslink/zebra-state/src/service/write.rs
@@ -370,7 +370,9 @@ impl WriteBlockWorkerTask {
                             std::collections::HashMap::new();
                         for (_bond_key, bond) in finalized_state.db.active_bonds() {
                             let amount: u64 = bond.amount.into();
-                            *stakes_by_finalizer.entry(bond.target_finalizer).or_insert(0) += amount;
+                            *stakes_by_finalizer
+                                .entry(bond.target_finalizer)
+                                .or_insert(0) += amount;
                         }
                         let aggregated_stakes: Vec<([u8; 32], u64)> =
                             stakes_by_finalizer.into_iter().collect();

--- a/zebra-crosslink/zebra-state/tests/basic.rs
+++ b/zebra-crosslink/zebra-state/tests/basic.rs
@@ -81,7 +81,13 @@ async fn check_transcripts(network: Network) -> Result<(), Report> {
 
     for transcript_data in net_data {
         // We're not verifying UTXOs here.
-        let (service, _, _, _) = zebra_state::init(Config::ephemeral(), &network, Height::MAX, 0, std::sync::Arc::new(|_,_| true));
+        let (service, _, _, _) = zebra_state::init(
+            Config::ephemeral(),
+            &network,
+            Height::MAX,
+            0,
+            std::sync::Arc::new(|_, _| true),
+        );
         let transcript = Transcript::from(transcript_data.iter().cloned());
         /// SPANDOC: check the on disk service against the transcript
         transcript.check(service).await?;

--- a/zebra-crosslink/zebrad/src/application.rs
+++ b/zebra-crosslink/zebrad/src/application.rs
@@ -242,8 +242,10 @@ impl Application for ZebradApp {
                         .cache_dir
                         .push("zebra_crosslink_workshop_january_cache_delete_me");
 
-                    c.crosslink.malachite_peers =
-                        vec!["70.34.201.202:8234".to_owned(), "45.76.30.90:8234".to_owned()];
+                    c.crosslink.malachite_peers = vec![
+                        "70.34.201.202:8234".to_owned(),
+                        "45.76.30.90:8234".to_owned(),
+                    ];
 
                     c.consensus.checkpoint_sync = false;
                 }
@@ -617,7 +619,8 @@ impl Application for ZebradApp {
 /// command-line arguments, and terminating when complete.
 // <https://docs.rs/abscissa_core/0.7.0/src/abscissa_core/application.rs.html#174-178>
 pub fn boot(app_cell: &'static AppCell<ZebradApp>) -> ! {
-    let args = EntryPoint::process_cli_args(env::args_os().collect()).unwrap_or_else(|err| err.exit());
+    let args =
+        EntryPoint::process_cli_args(env::args_os().collect()).unwrap_or_else(|err| err.exit());
 
     #[cfg(feature = "viz_gui")]
     {

--- a/zebra-crosslink/zebrad/src/commands/copy_state.rs
+++ b/zebra-crosslink/zebrad/src/commands/copy_state.rs
@@ -145,7 +145,14 @@ impl CopyStateCmd {
             _target_read_only_state_service,
             _target_latest_chain_tip,
             _target_chain_tip_change,
-        ) = new_zs::spawn_init(target_config.clone(), network, Height::MAX, 0, std::sync::Arc::new(move |fat_pointer_a, fat_pointer_b| { true })).await?;
+        ) = new_zs::spawn_init(
+            target_config.clone(),
+            network,
+            Height::MAX,
+            0,
+            std::sync::Arc::new(move |fat_pointer_a, fat_pointer_b| true),
+        )
+        .await?;
 
         let elapsed = target_start_time.elapsed();
         info!(?elapsed, "finished initializing target state service");

--- a/zebra-crosslink/zebrad/src/commands/start.rs
+++ b/zebra-crosslink/zebrad/src/commands/start.rs
@@ -114,7 +114,6 @@ pub struct StartCmd {
 
 impl StartCmd {
     async fn start(&self) -> Result<(), Report> {
-
         #[cfg(not(feature = "viz_gui"))]
         {
             let wallet_state = Arc::new(std::sync::Mutex::new(wallet::WalletState::new()));
@@ -164,8 +163,8 @@ impl StartCmd {
 
         // workshop-specific key seed
         let global_seed = loop {
-            use std::{fs::File, io::Read, io::Write};
             use rand::{Rng, RngCore, SeedableRng};
+            use std::{fs::File, io::Read, io::Write};
 
             let mut key_path = config.state.cache_dir.clone();
             let _ = std::fs::create_dir_all(key_path.clone());
@@ -182,21 +181,24 @@ impl StartCmd {
 
             // all else failed, create/replace file from scratch
             seed = rand::thread_rng().gen();
-            let mut f = File::create(key_path).expect("couldn't create seed file; add one manually");
-            f.write(&seed).expect("couldn't write to seed file; add one manually");
+            let mut f =
+                File::create(key_path).expect("couldn't create seed file; add one manually");
+            f.write(&seed)
+                .expect("couldn't write to seed file; add one manually");
 
             break seed;
         };
         *wallet::GLOBAL_SEED.lock().unwrap() = Some(global_seed);
 
-        let path_to_pos_store_file = if config.state.ephemeral { std::path::PathBuf::new() } else {
+        let path_to_pos_store_file = if config.state.ephemeral {
+            std::path::PathBuf::new()
+        } else {
             let mut key_path = config.state.cache_dir.clone();
             let _ = std::fs::create_dir_all(key_path.clone());
 
             key_path.push("pos.chain");
             key_path
         };
-
 
         info!("initializing node state");
         let (_, max_checkpoint_height) = zebra_consensus::router::init_checkpoint_list(
@@ -206,7 +208,9 @@ impl StartCmd {
 
         info!("opening database, this may take a few minutes");
 
-        let actual_closure: Arc<std::sync::Mutex<Option<zebra_state::ClosureToCallIntoCrosslinkFromState>>> = Arc::new(std::sync::Mutex::new(None));
+        let actual_closure: Arc<
+            std::sync::Mutex<Option<zebra_state::ClosureToCallIntoCrosslinkFromState>>,
+        > = Arc::new(std::sync::Mutex::new(None));
         let actual_closure2 = Arc::clone(&actual_closure);
 
         let (state_service, read_only_state_service, latest_chain_tip, chain_tip_change) =
@@ -350,7 +354,14 @@ impl StartCmd {
                 }),
                 Arc::new(move |req| {
                     let read_only_state_service = read_only_state_service.clone();
-                    Box::pin(async move { read_only_state_service.clone().ready().await?.call(req).await })
+                    Box::pin(async move {
+                        read_only_state_service
+                            .clone()
+                            .ready()
+                            .await?
+                            .call(req)
+                            .await
+                    })
                 }),
                 Arc::new(move |req| {
                     let mempool = mempool2.clone();
@@ -640,16 +651,28 @@ impl StartCmd {
             let zaino_config = zainodlib::config::ZainodConfig {
                 backend: zaino_state::BackendType::Fetch,
                 json_server_settings: Some(zaino_serve::server::config::JsonRpcServerConfig {
-                    json_rpc_listen_address: std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)), zebra_port_base + 10000),
+                    json_rpc_listen_address: std::net::SocketAddr::new(
+                        std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
+                        zebra_port_base + 10000,
+                    ),
                     cookie_dir: None,
                 }),
                 grpc_settings: zaino_serve::server::config::GrpcServerConfig {
-                    listen_address: std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)), zebra_port_base + 10001),
+                    listen_address: std::net::SocketAddr::new(
+                        std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
+                        zebra_port_base + 10001,
+                    ),
                     tls: None,
                 },
                 validator_settings: zaino_common::ValidatorConfig {
-                    validator_grpc_listen_address: std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)), zebra_port_base-1),
-                    validator_jsonrpc_listen_address: std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)), zebra_port_base-1),
+                    validator_grpc_listen_address: std::net::SocketAddr::new(
+                        std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
+                        zebra_port_base - 1,
+                    ),
+                    validator_jsonrpc_listen_address: std::net::SocketAddr::new(
+                        std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
+                        zebra_port_base - 1,
+                    ),
                     validator_cookie_path: None,
                     validator_user: Some("xxxxxx".to_owned()),
                     validator_password: Some("xxxxxx".to_owned()),
@@ -682,9 +705,13 @@ impl StartCmd {
                     nu7: None,
                 }),
             };
-            *zebra_crosslink::wallet::wallet_main_zaino_port.lock().unwrap() = zebra_port_base + 10001;
+            *zebra_crosslink::wallet::wallet_main_zaino_port
+                .lock()
+                .unwrap() = zebra_port_base + 10001;
 
-            zainodlib::indexer::spawn_indexer(zaino_config).await.unwrap();
+            zainodlib::indexer::spawn_indexer(zaino_config)
+                .await
+                .unwrap();
         }
 
         // Wait for tasks to finish

--- a/zebra-crosslink/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebra-crosslink/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -779,7 +779,13 @@ async fn caches_getaddr_response() {
 
         // UTXO verification doesn't matter for these tests.
         let (state, _read_only_state_service, latest_chain_tip, _chain_tip_change) =
-            zebra_state::init(state_config.clone(), &network, Height::MAX, 0, std::sync::Arc::new(|_,_| true));
+            zebra_state::init(
+                state_config.clone(),
+                &network,
+                Height::MAX,
+                0,
+                std::sync::Arc::new(|_, _| true),
+            );
 
         let state_service = ServiceBuilder::new().buffer(1).service(state);
 
@@ -893,7 +899,13 @@ async fn setup(
 
     // UTXO verification doesn't matter for these tests.
     let (state, _read_only_state_service, latest_chain_tip, mut chain_tip_change) =
-        zebra_state::init(state_config.clone(), &network, Height::MAX, 0, std::sync::Arc::new(|_,_| true));
+        zebra_state::init(
+            state_config.clone(),
+            &network,
+            Height::MAX,
+            0,
+            std::sync::Arc::new(|_, _| true),
+        );
 
     let mut state_service = ServiceBuilder::new().buffer(1).service(state);
 

--- a/zebra-crosslink/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebra-crosslink/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -644,7 +644,13 @@ async fn setup(
     // UTXO verification doesn't matter for these tests.
     let state_config = StateConfig::ephemeral();
     let (state_service, _read_only_state_service, latest_chain_tip, chain_tip_change) =
-        zebra_state::init(state_config, &network, Height::MAX, 0, std::sync::Arc::new(|_,_| true));
+        zebra_state::init(
+            state_config,
+            &network,
+            Height::MAX,
+            0,
+            std::sync::Arc::new(|_, _| true),
+        );
     let state_service = ServiceBuilder::new().buffer(10).service(state_service);
 
     // Network
@@ -838,7 +844,13 @@ mod submitblock_test {
         // State
         let state_config = StateConfig::ephemeral();
         let (_state_service, _read_only_state_service, latest_chain_tip, chain_tip_change) =
-            zebra_state::init(state_config, &Network::Mainnet, Height::MAX, 0, std::sync::Arc::new(|_,_| true));
+            zebra_state::init(
+                state_config,
+                &Network::Mainnet,
+                Height::MAX,
+                0,
+                std::sync::Arc::new(|_, _| true),
+            );
 
         let config_listen_addr = "127.0.0.1:0".parse().unwrap();
 

--- a/zebra-crosslink/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebra-crosslink/zebrad/src/components/mempool/tests/vector.rs
@@ -1132,7 +1132,13 @@ async fn setup(
     // UTXO verification doesn't matter here.
     let state_config = StateConfig::ephemeral();
     let (state, _read_only_state_service, latest_chain_tip, mut chain_tip_change) =
-        zebra_state::init(state_config, network, Height::MAX, 0, std::sync::Arc::new(|_,_| true));
+        zebra_state::init(
+            state_config,
+            network,
+            Height::MAX,
+            0,
+            std::sync::Arc::new(|_, _| true),
+        );
     let mut state_service = ServiceBuilder::new().buffer(10).service(state);
 
     let tx_verifier = MockService::build().for_unit_tests();

--- a/zebra-crosslink/zebrad/tests/crosslink.rs
+++ b/zebra-crosslink/zebrad/tests/crosslink.rs
@@ -19,8 +19,8 @@ use zebra_chain::{
     serialization::*,
     work::{self, difficulty::CompactDifficulty},
 };
-use zebra_crosslink::{FatPointerToBftBlock2, chain::*};
 use zebra_crosslink::test_format::*;
+use zebra_crosslink::{chain::*, FatPointerToBftBlock2};
 use zebra_state::crosslink::*;
 use zebrad::application::CROSSLINK_TEST_CONFIG_OVERRIDE;
 use zebrad::config::ZebradConfig;


### PR DESCRIPTION
Depends on #8.

This patch is built on top of dw/fix-build-macos and aims to standardize the formatting on the repository.
No specific formatting rules have been used, but it could be applied later.