### PR TITLE
remove dead catch-all + unreachable_patterns allow on TFLServiceRequest

### DIFF
--- a/zebra-crosslink/zebra-crosslink/src/lib.rs
+++ b/zebra-crosslink/zebra-crosslink/src/lib.rs
@@ -1311,7 +1311,6 @@ async fn tfl_service_incoming_request(
 
     // from this point onwards we must race to completion in order to avoid stalling the main thread
 
-    #[allow(unreachable_patterns)]
     match request {
         TFLServiceRequest::IsTFLActivated => Ok(TFLServiceResponse::IsTFLActivated(
             internal_handle.internal.lock().await.tfl_is_activated,
@@ -1390,8 +1389,6 @@ async fn tfl_service_incoming_request(
                 }
             }))
         }
-
-        _ => Err(TFLServiceError::NotImplemented),
     }
 }
 


### PR DESCRIPTION
All 9 TFLServiceRequest variants are matched explicitly, so the trailing `_ => Err(TFLServiceError::NotImplemented)` arm is dead. The `#[allow(unreachable_patterns)]` above the match suppresses the lint that catches this.

Dropping both. With the catch-all gone, adding a new TFLServiceRequest variant becomes a compile error until it has a handler, instead of silently routing to NotImplemented.