### PR TITLE
wallet: move sleep inside mempool_reconnect loop so failures actually back off

### DIFF
--- a/zebra-crosslink/wallet/src/lib.rs
+++ b/zebra-crosslink/wallet/src/lib.rs
@@ -3345,9 +3345,8 @@ pub async fn wallet_main(wallet_state: Arc<Mutex<WalletState>>) {
                     println!("MEMPOOL stream connection error: {err:?}");
                 }
             }
+            tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
         }
-
-        tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
     });
 
     fn block_rng_from_heights(heights: (u64, u64)) -> BlockRange {


### PR DESCRIPTION
the finding was surfaced in the crosslink updates signal channel and the fix lines up with the reported diagnosis: the 250ms sleep was outside the reconnect loop, so connection failures could spin until success instead of backing off.

`mempool_reconnect` starts at `zebra-crosslink/wallet/src/lib.rs:3319`. when `get_mempool_stream` fails and logs at `zebra-crosslink/wallet/src/lib.rs:3345`, the task immediately loops again.

this keeps the existing 250ms delay but moves it to `zebra-crosslink/wallet/src/lib.rs:3348`, inside the reconnect loop. failed stream opens and dropped streams now wait before reconnecting.

validation:
- `cargo check --manifest-path zebra-crosslink/wallet/Cargo.toml`