### PR TITLE
staking-cli: sequential multi-bond stake cli on top of stake_orchard_to_finalizer_batch

### DIFF
--- a/CHAIN_SEMANTICS.md
+++ b/CHAIN_SEMANTICS.md
@@ -1,0 +1,48 @@
+# Crosslink Chain Semantics Reference
+
+This note collects four chain-semantics questions that came up repeatedly in the workshop channel and points back to the code for each answer.
+
+## Finalizer pub_key byte order
+
+Node-facing finalizer formatting reverses the stored bytes before printing them. `PubKeyID`'s `Display` and `Debug` impls both call reverse-byte helpers, and Tenderlink log/debug context strings format finalizer IDs through `PubKeyID` ([`librustzcash/zcash_primitives/src/bft.rs#L335-L356`](librustzcash/zcash_primitives/src/bft.rs#L335-L356), [`tenderlink/src/lib.rs#L825-L839`](tenderlink/src/lib.rs#L825-L839), [`tenderlink/src/lib.rs#L594-L597`](tenderlink/src/lib.rs#L594-L597)).
+
+`get_tfl_roster_zats` returns `zcash_primitives::transaction::RosterMember` ([`zebra-crosslink/zebra-rpc/src/methods.rs#L1941-L1955`](zebra-crosslink/zebra-rpc/src/methods.rs#L1941-L1955)). `RosterMember.pub_key` is hex-serialized directly from the raw `[u8; 32]` storage order, and the same raw order is written to bytes and read back into wallet state without reversal ([`librustzcash/zcash_primitives/src/transaction/mod.rs#L1415-L1438`](librustzcash/zcash_primitives/src/transaction/mod.rs#L1415-L1438), [`zebra-crosslink/wallet/src/lib.rs#L3431-L3487`](zebra-crosslink/wallet/src/lib.rs#L3431-L3487)).
+
+The GUI's "copy" path reverses `member.pub_key` before hex-encoding it, which matches the human-facing finalizer form used elsewhere ([`zebra-gui/src/ui.rs#L2847-L2850`](zebra-gui/src/ui.rs#L2847-L2850)).
+
+Convert between the RPC form and the log/display form with:
+
+```python
+log_hex = bytes.fromhex(rpc_hex)[::-1].hex()
+rpc_hex = bytes.fromhex(log_hex)[::-1].hex()
+```
+
+## Staking cycle
+
+Consensus uses a 150-block staking period with a 70-block staking window. Staking actions are valid only when `block_height % 150 < 70`; transactions outside that window are rejected ([`zebra-crosslink/zebra-consensus/src/transaction.rs#L863-L870`](zebra-crosslink/zebra-consensus/src/transaction.rs#L863-L870), [`zebra-crosslink/zebra-consensus/src/transaction.rs#L936-L967`](zebra-crosslink/zebra-consensus/src/transaction.rs#L936-L967), [`zebra-crosslink/zebra-consensus/src/error.rs#L239-L247`](zebra-crosslink/zebra-consensus/src/error.rs#L239-L247)).
+
+At the current community 30-second-per-PoW-block estimate, a 70-block window is about 35 minutes.
+
+For operators using the shipped GUI, "staking day" is keyed off the finalized PoW tip, not the unfinalized tip. `bc_finalized_tip_height` is sourced from `internal.latest_final_block`, and the UI applies the same 150/70 window check to that finalized height ([`zebra-crosslink/zebra-crosslink/src/viz2.rs#L155-L160`](zebra-crosslink/zebra-crosslink/src/viz2.rs#L155-L160), [`zebra-gui/src/lib.rs#L66-L68`](zebra-gui/src/lib.rs#L66-L68), [`zebra-gui/src/ui.rs#L1142`](zebra-gui/src/ui.rs#L1142)).
+
+## Fat pointer signer semantics
+
+Each PoW block header carries a fat pointer to the BFT chain tip in `fat_pointer_to_bft_block` ([`zebra-crosslink/zebra-chain/src/block/header.rs#L110-L111`](zebra-crosslink/zebra-chain/src/block/header.rs#L110-L111)). The RPC entry point is `get_tfl_fat_pointer_to_bft_chain_tip` ([`zebra-crosslink/zebra-rpc/src/methods.rs#L1958-L1972`](zebra-crosslink/zebra-rpc/src/methods.rs#L1958-L1972)).
+
+`FatPointerToBftBlock` is defined as a 44-byte `vote_for_block_without_finalizer_public_key` payload plus a `signatures` vector ([`librustzcash/zcash_primitives/src/bft.rs#L423-L425`](librustzcash/zcash_primitives/src/bft.rs#L423-L425)). `FatPointerToBftBlock::from_parts` writes those 44 bytes as:
+
+- 32 bytes: BFT block hash
+- 8 bytes: PoS height as `u64` little-endian
+- 4 bytes: round and precommit overhead as `u32` little-endian
+
+See [`librustzcash/zcash_primitives/src/bft.rs#L493-L500`](librustzcash/zcash_primitives/src/bft.rs#L493-L500). `get_vote_template` reconstructs the full 76-byte vote by adding the finalizer pubkey back in later, per signature entry ([`librustzcash/zcash_primitives/src/bft.rs#L512-L519`](librustzcash/zcash_primitives/src/bft.rs#L512-L519)). The underlying vote builder uses the same layout: 32-byte finalizer pubkey, 32-byte block hash/value ID, 8-byte height in little-endian, and 4 trailing bytes for round and precommit flag ([`tenderlink/src/lib.rs#L1142-L1148`](tenderlink/src/lib.rs#L1142-L1148)).
+
+Tenderlink does not put the whole roster into the fat pointer. It filters down to non-`NIL` precommit signatures for the decided proposal only ([`tenderlink/src/lib.rs#L132-L154`](tenderlink/src/lib.rs#L132-L154)). Decision threshold is stake-weighted `2f+1`, where `f = (total_active_stake - 1) / 3`; the block is decided once `yes_precommits` reaches that threshold ([`tenderlink/src/lib.rs#L576`](tenderlink/src/lib.rs#L576), [`tenderlink/src/lib.rs#L844-L856`](tenderlink/src/lib.rs#L844-L856), [`tenderlink/src/lib.rs#L985-L991`](tenderlink/src/lib.rs#L985-L991)).
+
+In practice, the signer list in a fat pointer is a quorum certificate for at least 67% of active stake, not a roster dump. A finalizer missing from one certificate is therefore not enough evidence to conclude it missed a vote.
+
+## Bond privacy
+
+The current bond format is per-bond, not aggregate. `StakingAction_CreateNewDelegationBond` holds one `amount_zats`, one `unique_pubkey` bond key, and one `target_finalizer` ([`librustzcash/zcash_primitives/src/transaction/mod.rs#L1445-L1463`](librustzcash/zcash_primitives/src/transaction/mod.rs#L1445-L1463)). The wallet's `stake_orchard_to_finalizer` flow creates one such action per call ([`zebra-crosslink/wallet/src/lib.rs#L1951-L1969`](zebra-crosslink/wallet/src/lib.rs#L1951-L1969)), and wallet state plus GUI state track bonded positions as separate `(bond_key, target_finalizer, amount)` tuples ([`zebra-crosslink/wallet/src/lib.rs#L935-L936`](zebra-crosslink/wallet/src/lib.rs#L935-L936), [`zebra-crosslink/wallet/src/lib.rs#L4288-L4300`](zebra-crosslink/wallet/src/lib.rs#L4288-L4300), [`zebra-gui/src/ui.rs#L1144-L1149`](zebra-gui/src/ui.rs#L1144-L1149)).
+
+Channel consensus from 2026-04-17: each Orchard-side stake bond is intentionally kept as its own private position. Consolidating multiple bonds into one on-chain restake would link those positions and weaken privacy. The current pain around multi-bond restaking is therefore a tooling gap, not a hidden alternative encoding in the current bond format. For a workflow helper built on the same per-bond model, see [`stake_orchard_to_finalizer_batch` PR #18](https://github.com/ShieldedLabs/crosslink_monolith/pull/18).

--- a/zebra-crosslink/Cargo.lock
+++ b/zebra-crosslink/Cargo.lock
@@ -6724,6 +6724,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "staking-cli"
+version = "0.1.0"
+dependencies = [
+ "clap 4.5.47",
+ "hex",
+ "tokio",
+ "tonic 0.14.2",
+ "wallet",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8226,6 +8237,7 @@ name = "wallet"
 version = "1.0.0-beta.1"
 dependencies = [
  "bip39",
+ "hex",
  "incrementalmerkletree",
  "orchard",
  "prost 0.14.1",

--- a/zebra-crosslink/Cargo.toml
+++ b/zebra-crosslink/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/ZcashFoundation/zebra"
 
 [workspace]
 members = [
+        "staking-cli",
         "wallet",
         "zebrad",
         "zebra-chain",

--- a/zebra-crosslink/staking-cli/Cargo.toml
+++ b/zebra-crosslink/staking-cli/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "staking-cli"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+readme = "README.md"
+
+[[bin]]
+name = "staking-cli"
+path = "src/main.rs"
+
+[dependencies]
+wallet = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+hex.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tonic = { workspace = true, features = ["transport"] }

--- a/zebra-crosslink/staking-cli/README.md
+++ b/zebra-crosslink/staking-cli/README.md
@@ -1,0 +1,24 @@
+# staking-cli
+
+`staking-cli` is a thin command-line wrapper around `stake_orchard_to_finalizer_batch` for sequential multi-bond staking.
+
+It reads a seed file, syncs a single account from `lightwalletd` or `zainod`, then builds and optionally broadcasts one orchard stake transaction per requested amount.
+
+The seed file must contain either:
+
+- a plain-text bip39 mnemonic
+- a 32-byte hex seed for testing only
+
+Example:
+
+```bash
+cargo run --manifest-path zebra-crosslink/staking-cli/Cargo.toml -- \
+  --target 00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff \
+  --amounts 100000,200000,300000 \
+  --seed /path/to/seed.txt \
+  --network regtest \
+  --lightwalletd-url http://127.0.0.1:9067 \
+  --dry-run
+```
+
+The endpoint at `--lightwalletd-url` must already be synced enough for the wallet scan to build the orchard tree state needed for staking.

--- a/zebra-crosslink/staking-cli/src/main.rs
+++ b/zebra-crosslink/staking-cli/src/main.rs
@@ -1,0 +1,146 @@
+use std::{fs, path::PathBuf};
+
+use clap::{Parser, ValueEnum};
+use tonic::transport::Channel;
+use wallet::{CompactTxStreamerClient, ManualWallet, StakingCliNetwork};
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum NetworkArg {
+    Main,
+    Regtest,
+}
+
+impl From<NetworkArg> for StakingCliNetwork {
+    fn from(value: NetworkArg) -> Self {
+        match value {
+            NetworkArg::Main => StakingCliNetwork::Main,
+            NetworkArg::Regtest => StakingCliNetwork::Regtest,
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "staking-cli",
+    about = "sequential multi-bond stake cli on top of stake_orchard_to_finalizer_batch",
+    long_about = "Build and optionally broadcast a sequence of orchard delegation-bond stake transactions.\n\nThe seed file must contain either a plain-text bip39 mnemonic or a 32-byte hex seed. The hex seed format is for testing only.\n\nThis command requires a synced lightwalletd or zainod endpoint at --lightwalletd-url."
+)]
+struct Args {
+    #[arg(long, help = "target finalizer pubkey in wallet-expected byte order")]
+    target: String,
+
+    #[arg(
+        long,
+        value_delimiter = ',',
+        help = "comma-separated list of amounts in zatoshis"
+    )]
+    amounts: Vec<u64>,
+
+    #[arg(
+        long,
+        value_name = "PATH",
+        long_help = "Path to a seed file. The file must contain either a plain-text bip39 mnemonic or a 32-byte hex seed. The hex seed format is for testing only."
+    )]
+    seed: PathBuf,
+
+    #[arg(long, value_enum, help = "network parameter")]
+    network: NetworkArg,
+
+    #[arg(
+        long,
+        default_value = "http://127.0.0.1:9067",
+        help = "lightwalletd or zainod endpoint"
+    )]
+    lightwalletd_url: String,
+
+    #[arg(long, help = "do not broadcast, just print what would be sent")]
+    dry_run: bool,
+}
+
+fn parse_target(hex_target: &str) -> Result<[u8; 32], String> {
+    let bytes = hex::decode(hex_target)
+        .map_err(|err| format!("failed to decode --target as hex: {err}"))?;
+    <[u8; 32]>::try_from(bytes.as_slice()).map_err(|_| {
+        format!(
+            "--target must decode to exactly 32 bytes, got {}",
+            bytes.len()
+        )
+    })
+}
+
+fn print_results(results: &[Option<(String, u64)>], amounts: &[u64], dry_run: bool) {
+    for (index, amount) in amounts.iter().copied().enumerate() {
+        match results.get(index).and_then(|entry| entry.as_ref()) {
+            Some((txid, _)) if dry_run => {
+                println!("{index}: would broadcast built_txid={txid} amount={amount}");
+            }
+            Some((txid, _)) => {
+                println!("{index}: ok txid={txid} amount={amount}");
+            }
+            None => {
+                println!("{index}: FAILED amount={amount}");
+            }
+        }
+    }
+}
+
+async fn run() -> Result<(), String> {
+    let args = Args::parse();
+    if args.amounts.is_empty() {
+        return Err("--amounts must not be empty".to_owned());
+    }
+
+    let target = parse_target(&args.target)?;
+    let seed_text = fs::read_to_string(&args.seed)
+        .map_err(|err| format!("failed to read {}: {err}", args.seed.display()))?;
+    let network = StakingCliNetwork::from(args.network);
+
+    let channel = Channel::from_shared(args.lightwalletd_url.clone())
+        .map_err(|err| {
+            format!(
+                "invalid --lightwalletd-url {}: {err}",
+                args.lightwalletd_url
+            )
+        })?
+        .connect()
+        .await
+        .map_err(|err| format!("failed to connect to {}: {err}", args.lightwalletd_url))?;
+    let mut client = CompactTxStreamerClient::new(channel);
+
+    let (mut wallet, usk) = ManualWallet::from_seed_text(network, &seed_text)?;
+    let orchard_tree = wallet.sync_from_lightwalletd(network, &mut client).await?;
+
+    if args.dry_run {
+        let results = wallet.dry_run_stake_orchard_to_finalizer_batch(
+            network,
+            &mut client,
+            &usk,
+            &args.amounts,
+            &orchard_tree,
+            target,
+        );
+        print_results(&results, &args.amounts, true);
+    } else {
+        let results = wallet
+            .stake_orchard_to_finalizer_batch(
+                network,
+                &mut client,
+                &usk,
+                &args.amounts,
+                &orchard_tree,
+                target,
+            )
+            .await;
+        print_results(&results, &args.amounts, false);
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(err) = run().await {
+        eprintln!("error: {err}");
+        std::process::exit(1);
+    }
+}

--- a/zebra-crosslink/wallet/Cargo.toml
+++ b/zebra-crosslink/wallet/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { workspace = true, features = ["time", "rt-multi-thread", "macros", "tr
 tokio-rustls = { version = "0.26", default-features = false }
 tokio-stream = { workspace = true, features = ["time"] }
 reqwest = { version = "0.12", default-features = false, features = ["cookies", "rustls-tls"] }
+hex = { workspace = true }
 
 secrecy = "0.8.0"
 sapling-crypto = "0.5.0"

--- a/zebra-crosslink/wallet/src/lib.rs
+++ b/zebra-crosslink/wallet/src/lib.rs
@@ -57,7 +57,7 @@ use zcash_primitives::transaction::txid::TxIdDigester;
 use zcash_primitives::transaction::{Authorized, StakingAction_BeginDelegationUnbonding, StakingAction_CreateNewDelegationBond, StakingAction_RetargetDelegationBond, StakingAction_WithdrawDelegationBond, Transaction, TransactionData, TxVersion, Unauthorized};
 use zcash_primitives::transaction::{RosterMember, StakingAction, StakingActionKind, StakeTxId};
 use zcash_proofs::prover::LocalTxProver;
-use zcash_protocol::consensus::{BlockHeight as LRZBlockHeight, BranchId};
+use zcash_protocol::consensus::{BlockHeight as LRZBlockHeight, BranchId, NetworkUpgrade};
 use zcash_protocol::memo::MemoBytes;
 use zcash_protocol::value::{ZatBalance, Zatoshis};
 use zcash_protocol::{PoolType, ShieldedProtocol, TxId};
@@ -77,6 +77,8 @@ use rustls::crypto::CryptoProvider;
 use rustls::crypto::WebPkiSupportedAlgorithms;
 use rustls::CertificateError;
 use tokio::runtime::Builder;
+pub use zcash_client_backend::keys::UnifiedSpendingKey;
+pub use zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient;
 use zcash_client_backend::{
     address::UnifiedAddress,
     data_api::{
@@ -89,13 +91,13 @@ use zcash_client_backend::{
     },
     encoding::AddressCodec,
     keys::{
-        UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedIncomingViewingKey, UnifiedSpendingKey,
+        UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedIncomingViewingKey,
     },
     proto::{
         compact_formats::{CompactBlock, CompactTx, CompactSaplingSpend, CompactSaplingOutput, CompactOrchardAction},
         service::{
-            compact_tx_streamer_client::CompactTxStreamerClient, BlockId, BlockRange, ChainSpec,
-            Empty, GetAddressUtxosArg, LightdInfo, TransparentAddressBlockFilter,
+            BlockId, BlockRange, ChainSpec, Empty, GetAddressUtxosArg, LightdInfo,
+            TransparentAddressBlockFilter,
         },
     },
 };
@@ -168,6 +170,28 @@ impl std::fmt::Display for BlockHeight {
             Self::SENT     => write!(f, "<sent>"),
             Self::MEMPOOL  => write!(f, "<mempool>"),
             _ => self.0.fmt(f)
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum StakingCliNetwork {
+    Main,
+    Regtest,
+}
+
+impl Parameters for StakingCliNetwork {
+    fn network_type(&self) -> NetworkType {
+        match self {
+            Self::Main => NetworkType::Main,
+            Self::Regtest => NetworkType::Regtest,
+        }
+    }
+
+    fn activation_height(&self, nu: NetworkUpgrade) -> Option<LRZBlockHeight> {
+        match self {
+            Self::Main => MAIN_NETWORK.activation_height(nu),
+            Self::Regtest => TEST_NETWORK.activation_height(nu),
         }
     }
 }
@@ -1351,6 +1375,135 @@ pub struct ManualWallet {
 }
 // N.B. using some of the same API as WalletDb to allow smooth transition/comparison
 impl ManualWallet {
+    pub fn from_seed_text<P: Parameters + 'static>(params: P, seed_text: &str) -> Result<(ManualWallet, UnifiedSpendingKey), String> {
+        let usk = unified_spending_key_from_seed_text(params.clone(), seed_text)?;
+        let (mut wallet, account) = manual_wallet_from_usk_inner(params, "staking-cli", &usk);
+        let (t_addr, p2sh, _ua) = addrs_from_account(&account, 0)
+            .ok_or_else(|| "failed to derive default addresses from the spending key".to_owned())?;
+
+        wallet.strms.push(ManualStream { account_id: 0, sync_h: BlockHeight(0), t_addr });
+        if TEST_P2SH {
+            wallet.strms.push(ManualStream { account_id: 0, sync_h: BlockHeight(0), t_addr: p2sh });
+        }
+
+        Ok((wallet, usk))
+    }
+
+    pub async fn sync_from_lightwalletd<P: Parameters + Copy>(
+        &mut self,
+        network: P,
+        client: &mut CompactTxStreamerClient<Channel>,
+    ) -> Result<OrchardShardTree, String> {
+        const MAX_BLOCKS_TO_DOWNLOAD_AT_TIME: u64 = 64;
+        const CHECKPOINTS_N: usize = 100;
+
+        let tip_info = client.get_lightd_info(Empty {}).await
+            .map_err(|err| format!("failed to fetch lightwalletd info: {err:?}"))?;
+        let tip_height_u64 = tip_info.into_inner().block_height;
+        let tip_height = u32::try_from(tip_height_u64)
+            .map_err(|_| format!("lightwalletd tip height {tip_height_u64} does not fit in u32"))?;
+
+        client.get_tree_state(BlockId {
+            height: tip_height_u64,
+            hash: Vec::new(),
+        }).await.map_err(|err| {
+            format!("failed to fetch orchard tree state at height {tip_height}: {err:?}")
+        })?;
+
+        let mut orchard_tree = OrchardShardTree::new(
+            shardtree::store::memory::MemoryShardStore::empty(),
+            CHECKPOINTS_N,
+        );
+        let mut next_orchard_pos = 0u64;
+        let mut seen_transparent_txids = HashSet::<TxId>::new();
+        let full_keys = PreparedKeys::from_ufvk_all(&self.accounts[0].ufvk);
+        let ivk_keys = PreparedKeys::from_ufvk_ivks(&self.accounts[0].ufvk);
+
+        let mut start_height = 0u64;
+        while start_height <= tip_height_u64 {
+            let end_height = (start_height + MAX_BLOCKS_TO_DOWNLOAD_AT_TIME - 1).min(tip_height_u64);
+
+            for strm_i in 0..self.strms.len() {
+                let strm = self.strms[strm_i].clone();
+                let address = strm.t_addr.encode(&network);
+                let response = client.get_taddress_txids(TransparentAddressBlockFilter {
+                    address: address.clone(),
+                    range: Some(block_range_from_heights((start_height, end_height))),
+                }).await.map_err(|err| {
+                    format!("failed to fetch transparent transactions for {} in {}-{}: {err:?}", address, start_height, end_height)
+                })?;
+
+                let mut tx_stream = response.into_inner();
+                loop {
+                    let raw_tx = tx_stream.message().await.map_err(|err| {
+                        format!("failed to read transparent transaction stream for {} in {}-{}: {err:?}", address, start_height, end_height)
+                    })?;
+                    let Some(raw_tx) = raw_tx else { break; };
+
+                    let Some(Some(block_h)) = bc_h_from_raw_tx_h(raw_tx.height) else { continue; };
+                    if !block_h.is_in_block() {
+                        continue;
+                    }
+
+                    let tx = Transaction::read(
+                        &raw_tx.data[..],
+                        BranchId::for_height(&network, LRZBlockHeight::from_u32(block_h.0)),
+                    ).map_err(|err| {
+                        format!("failed to decode transparent transaction for {} at height {}: {err:?}", address, block_h.0)
+                    })?;
+                    let txid = tx.txid();
+                    if !seen_transparent_txids.insert(txid) {
+                        continue;
+                    }
+
+                    let mut insert_i = 0;
+                    update_insert_i(&self.txs, &mut insert_i, block_h);
+                    read_full_tx(self, strm.account_id, &full_keys, block_h, &tx, &mut insert_i, TxStatus::OnBc);
+                }
+
+                self.strms[strm_i].sync_h = BlockHeight(end_height.try_into().unwrap_or(u32::MAX));
+            }
+
+            let response = client.get_block_range(block_range_from_heights((start_height, end_height))).await
+                .map_err(|err| format!("failed to fetch compact blocks in {}-{}: {err:?}", start_height, end_height))?;
+            let mut block_stream = response.into_inner();
+            loop {
+                let block = block_stream.message().await.map_err(|err| {
+                    format!("failed to read compact block stream in {}-{}: {err:?}", start_height, end_height)
+                })?;
+                let Some(block) = block else { break; };
+
+                let block_h = BlockHeight(block.height.try_into().map_err(|_| {
+                    format!("compact block height {} does not fit in u32", block.height)
+                })?);
+                let mut insert_i = 0;
+                update_insert_i(&self.txs, &mut insert_i, block_h);
+
+                for tx in &block.vtx {
+                    let _ = read_compact_tx(
+                        self,
+                        0,
+                        &ivk_keys,
+                        block_h,
+                        tx,
+                        &mut next_orchard_pos,
+                        &mut insert_i,
+                        &mut orchard_tree,
+                    );
+                }
+
+                orchard_tree.checkpoint(block_h).expect("Infallible MemoryShardStore");
+                self.chain_tip_h = block_h;
+                self.accounts[0].fully_detected_h = block_h;
+                self.accounts[0].fully_decoded_h = block_h;
+            }
+
+            start_height = end_height.saturating_add(1);
+        }
+
+        Ok(orchard_tree)
+    }
+
     pub fn chain_height(&self)          -> BlockHeight { self.chain_tip_h }
     pub fn fully_detected_height(&self) -> BlockHeight {
         let mut h = BlockHeight(0);
@@ -2039,6 +2192,46 @@ impl ManualWallet {
         results
     }
 
+    pub fn dry_run_stake_orchard_to_finalizer_batch<P: Parameters + Copy>(
+        &mut self, network: P, client: &mut CompactTxStreamerClient<Channel>,
+        src_usk: &UnifiedSpendingKey, amounts_zats: &[u64], orchard_tree: &OrchardShardTree,
+        target_finalizer: [u8; 32],
+    ) -> Vec<Option<(String, u64)>>
+    {
+        let mut results = Vec::with_capacity(amounts_zats.len());
+
+        for &amount_zats in amounts_zats {
+            let mut tx = ProposedTx::EMPTY;
+            if self.stake_orchard_to_finalizer(network, &mut tx, client, src_usk, amount_zats, orchard_tree, target_finalizer).is_none() {
+                results.push(None);
+                continue;
+            }
+
+            let Some(prep_view) = tx.prep.as_ref() else {
+                results.push(None);
+                continue;
+            };
+            let orchard_spends = prep_view.o_inputs.iter().map(|input| input.note).collect::<Vec<_>>();
+            let transparent_spends = prep_view.t_inputs.iter().map(|input| input.outpoint().clone()).collect::<Vec<_>>();
+
+            let Some(prep) = tx.prep.take() else {
+                results.push(None);
+                continue;
+            };
+
+            if !self.build_tx_from_prep(network, &mut tx, prep) {
+                results.push(None);
+                continue;
+            }
+
+            let txid_hex = tx.tx.txid.to_string();
+            self.mark_batch_inputs_spent(tx.tx.account_id, &orchard_spends, &transparent_spends, tx.tx.h);
+            results.push(Some((txid_hex, amount_zats)));
+        }
+
+        results
+    }
+
     pub fn begin_unbonding_using_orchard<P: Parameters>(
         &mut self, network: P, tx: &mut ProposedTx, client: &mut CompactTxStreamerClient<Channel>,
         src_usk: &UnifiedSpendingKey, orchard_tree: &OrchardShardTree, bond_key: [u8; 32],
@@ -2722,7 +2915,7 @@ type OrchardTree = incrementalmerkletree::frontier::CommitmentTree<orchard::tree
 type OrchardFrontier = incrementalmerkletree::frontier::Frontier<orchard::tree::MerkleHashOrchard, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }>;
 type OrchardWitness = incrementalmerkletree::witness::IncrementalWitness<orchard::tree::MerkleHashOrchard, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }>;
 const SHARD_HEIGHT: u8 = 16; // default => 65536 leaves per shard
-type OrchardShardTree = shardtree::ShardTree::<
+pub type OrchardShardTree = shardtree::ShardTree::<
     shardtree::store::memory::MemoryShardStore::<
         orchard::tree::MerkleHashOrchard,
         // shardtree::Node<orchard::tree::MerkleHashOrchard, (), ()>,
@@ -2801,6 +2994,76 @@ fn stuff_from_seed_phrase<P: Parameters>(params: P, phrase: &str) -> (
     // );
 
     (seed, usk)
+}
+
+fn unified_spending_key_from_seed_text<P: Parameters>(
+    params: P,
+    seed_text: &str,
+) -> Result<UnifiedSpendingKey, String> {
+    use secrecy::ExposeSecret;
+
+    let trimmed = seed_text.trim();
+    if trimmed.is_empty() {
+        return Err("seed file is empty".to_owned());
+    }
+
+    let seed = if let Ok(mnemonic) = bip39::Mnemonic::parse(trimmed) {
+        let seed64 = mnemonic.to_seed("");
+        SecretVec::new(seed64[..32].to_vec())
+    } else {
+        let seed_bytes = hex::decode(trimmed).map_err(|_|
+            "seed file must contain a bip39 mnemonic or a 32-byte hex seed".to_owned()
+        )?;
+        if seed_bytes.len() != 32 {
+            return Err(format!("hex seed file must decode to 32 bytes, got {} bytes", seed_bytes.len()));
+        }
+        SecretVec::new(seed_bytes)
+    };
+
+    let account_id = zip32::AccountId::try_from(0)
+        .map_err(|err| format!("failed to create account id 0: {err:?}"))?;
+    UnifiedSpendingKey::from_seed(&params, seed.expose_secret(), account_id)
+        .map_err(|err| format!("failed to derive unified spending key from seed text: {err:?}"))
+}
+
+fn manual_wallet_from_usk_inner<P: Parameters + 'static>(
+    _params: P,
+    name: &'static str,
+    usk: &UnifiedSpendingKey,
+) -> (ManualWallet, ManualAccount) {
+    let account = ManualAccount {
+        ufvk: usk.to_unified_full_viewing_key(),
+        birthday: BlockHeight(0),
+        balance_changes: vec![(BlockHeight(0), data_api::AccountBalance::ZERO)],
+        fully_decoded_h: BlockHeight(0),
+        fully_detected_h: BlockHeight(0),
+        recv_txos: Vec::new(),
+        utxos: Vec::new(),
+        stxos: Vec::new(),
+        recv_orchard_notes: Vec::new(),
+        unspent_orchard_notes: Vec::new(),
+        spent_orchard_notes: Vec::new(),
+    };
+
+    let wallet = ManualWallet {
+        name,
+        accounts: vec![account.clone()],
+        strms: Vec::new(),
+        chain_tip_h: BlockHeight(0),
+        txs: Vec::new(),
+        tx_h_map: HashMap::new(),
+        seen_bond_values: HashMap::new(),
+        care_about_bonds: Vec::new(),
+    };
+
+    (wallet, account)
+}
+
+fn block_range_from_heights(heights: (u64, u64)) -> BlockRange {
+    BlockRange {
+        start: Some(BlockId { height: heights.0, hash: Vec::new() }),
+        end: Some(BlockId { height: heights.1, hash: Vec::new() }),
+    }
 }
 
 pub fn default_p2pkh_from_entropy<P: Parameters>(params: P, entropy: &[u8; 32]) -> Option<TransparentAddress> {

--- a/zebra-crosslink/wallet/src/lib.rs
+++ b/zebra-crosslink/wallet/src/lib.rs
@@ -1879,6 +1879,33 @@ impl ManualWallet {
         res
     }
 
+    fn upsert_wallet_tx(&mut self, wallet_tx: WalletTx) {
+        let mut insert_i = 0;
+        update_insert_i(&self.txs, &mut insert_i, wallet_tx.h);
+        update_with_tx(self, wallet_tx, &mut insert_i);
+    }
+
+    fn mark_batch_inputs_spent(&mut self, account_id: usize, orchard_notes: &[OrchardNote], transparent_inputs: &[OutPoint], spent_h: BlockHeight) {
+        let transparent_inputs_with_heights = transparent_inputs.iter()
+            .filter_map(|outpoint| self.tx_h_map.get(outpoint.txid()).copied().map(|recv_h| (outpoint.clone(), recv_h)))
+            .collect::<Vec<_>>();
+        let account = &mut self.accounts[account_id];
+
+        for note in orchard_notes {
+            if let Some(note_i) = orchard_recv_h_position(&account.unspent_orchard_notes, note.recv_h, &note.nf) {
+                let unspent_note = account.unspent_orchard_notes.remove(note_i);
+                orchard_spent_h_insert(&mut account.spent_orchard_notes, OrchardNote { spent_h, ..unspent_note });
+            }
+        }
+
+        for (outpoint, recv_h) in transparent_inputs_with_heights {
+            if let Some(utxo_i) = txo_recv_h_position(&account.utxos, recv_h, &outpoint) {
+                let utxo = account.utxos.remove(utxo_i);
+                txo_spent_h_insert(&mut account.stxos, Txo { spent_h, ..utxo });
+            }
+        }
+    }
+
     // NOTE: because we get 2 grace actions, we don't need to try and special-case getting all
     // change outputs within a single output, although that might be better for later note use...
     pub fn shield_transparent_zats<P: Parameters>(
@@ -1948,6 +1975,68 @@ impl ManualWallet {
         } else {
             None
         }
+    }
+
+    /// Sequentially prepare, build, and broadcast one orchard stake per requested amount.
+    ///
+    /// This only filters locally consumed orchard notes and transparent inputs between successful
+    /// sends. Any orchard change created by an earlier batch transaction becomes usable only after
+    /// the caller refreshes wallet state with a newer orchard tree.
+    pub async fn stake_orchard_to_finalizer_batch<P: Parameters + Copy>(
+        &mut self, network: P, client: &mut CompactTxStreamerClient<Channel>,
+        src_usk: &UnifiedSpendingKey, amounts_zats: &[u64], orchard_tree: &OrchardShardTree,
+        target_finalizer: [u8; 32],
+    ) -> Vec<Option<(String, u64)>>
+    {
+        let mut results = Vec::with_capacity(amounts_zats.len());
+
+        for &amount_zats in amounts_zats {
+            let mut tx = ProposedTx::EMPTY;
+            if self.stake_orchard_to_finalizer(network, &mut tx, client, src_usk, amount_zats, orchard_tree, target_finalizer).is_none() {
+                results.push(None);
+                continue;
+            }
+
+            let Some(prep_view) = tx.prep.as_ref() else {
+                results.push(None);
+                continue;
+            };
+            let orchard_spends = prep_view.o_inputs.iter().map(|input| input.note).collect::<Vec<_>>();
+            let transparent_spends = prep_view.t_inputs.iter().map(|input| input.outpoint().clone()).collect::<Vec<_>>();
+
+            let Some(prep) = tx.prep.take() else {
+                results.push(None);
+                continue;
+            };
+
+            if !self.build_tx_from_prep(network, &mut tx, prep) {
+                tx.tx.status = TxStatus::HardFail(tx.tx.h, ErrBuf::from_str("failed to build"));
+                tx.tx.h = self.chain_tip_h;
+                self.upsert_wallet_tx(tx.tx);
+                results.push(None);
+                continue;
+            }
+            self.upsert_wallet_tx(tx.tx);
+
+            let txid_hex = tx.tx.txid.to_string();
+            let sent_ok = if let Some(tx_res) = &tx.tx_res {
+                self.send_built_tx(network, client, &mut tx.tx, tx_res.transaction()).await
+            } else {
+                tx.tx.status = TxStatus::HardFail(tx.tx.h, ErrBuf::from_str("missing built tx"));
+                tx.tx.h = self.chain_tip_h;
+                false
+            };
+            self.upsert_wallet_tx(tx.tx);
+
+            if sent_ok {
+                self.mark_batch_inputs_spent(tx.tx.account_id, &orchard_spends, &transparent_spends, tx.tx.h);
+                results.push(Some((txid_hex, amount_zats)));
+            } else {
+                results.push(None);
+            }
+        }
+
+        results
     }
 
     pub fn begin_unbonding_using_orchard<P: Parameters>(


### PR DESCRIPTION
## summary
- add a `staking-cli` bin crate on top of `stake_orchard_to_finalizer_batch`
- parse the target pubkey, amount list, seed file, network, endpoint, and dry-run mode from the command line
- load a local spending key, sync wallet state from lightwalletd or zainod, then run sequential orchard stake sends or dry-run builds

## notes
- this is phase 2 on top of #18, which added the batch staking helper in the wallet crate
- the seed loader in this pass accepts either a bip39 mnemonic file or a 32-byte hex seed file
- the hex seed format is for testing only until a fuller operator loader lands
- the command requires a synced lightwalletd or zainod endpoint at `--lightwalletd-url`

## checks
- [x] `cargo check --manifest-path zebra-crosslink/staking-cli/Cargo.toml`
- [x] `cargo build --release --manifest-path zebra-crosslink/staking-cli/Cargo.toml`
- [x] `target/release/staking-cli --help`
- [x] `--dry-run` parse path against an unavailable local endpoint to confirm target and amount decoding without broadcast
