### PR TITLE
add configurable block hash checkpoints

### DIFF
--- a/zebra-crosslink/zebra-consensus/src/checkpoint/list.rs
+++ b/zebra-crosslink/zebra-consensus/src/checkpoint/list.rs
@@ -192,6 +192,20 @@ impl CheckpointList {
         Ok(checkpoints)
     }
 
+    /// Return a checkpoint list with `extra_checkpoints` appended.
+    pub fn with_extra_checkpoints(
+        &self,
+        extra_checkpoints: impl IntoIterator<Item = (block::Height, block::Hash)>,
+    ) -> Result<Self, BoxError> {
+        let checkpoint_list = self
+            .0
+            .iter()
+            .map(|(height, hash)| (*height, *hash))
+            .chain(extra_checkpoints);
+
+        Self::from_list(checkpoint_list)
+    }
+
     /// Return true if there is a checkpoint at `height`.
     ///
     /// See `BTreeMap::contains_key()` for details.

--- a/zebra-crosslink/zebra-consensus/src/checkpoint/list/tests.rs
+++ b/zebra-crosslink/zebra-consensus/src/checkpoint/list/tests.rs
@@ -196,6 +196,39 @@ fn checkpoint_list_duplicate_heights_fail() -> Result<(), BoxError> {
     Ok(())
 }
 
+#[test]
+fn checkpoint_list_extra_checkpoints_append() -> Result<(), BoxError> {
+    let _init_guard = zebra_test::init();
+
+    let checkpoint_data = [
+        (block::Height(0), block::Hash([1; 32])),
+        (block::Height(10), block::Hash([2; 32])),
+    ];
+    let list = CheckpointList::from_list(checkpoint_data)?;
+    let list = list.with_extra_checkpoints([(block::Height(20), block::Hash([3; 32]))])?;
+
+    assert_eq!(list.max_height(), block::Height(20));
+    assert_eq!(list.hash(block::Height(20)), Some(block::Hash([3; 32])));
+
+    Ok(())
+}
+
+#[test]
+fn checkpoint_list_extra_checkpoints_reject_duplicate_height() -> Result<(), BoxError> {
+    let _init_guard = zebra_test::init();
+
+    let checkpoint_data = [
+        (block::Height(0), block::Hash([1; 32])),
+        (block::Height(10), block::Hash([2; 32])),
+    ];
+    let list = CheckpointList::from_list(checkpoint_data)?;
+    let _ = list
+        .with_extra_checkpoints([(block::Height(10), block::Hash([3; 32]))])
+        .expect_err("duplicate extra checkpoint height should fail");
+
+    Ok(())
+}
+
 /// Make sure that a checkpoint list containing duplicate hashes
 /// (at different heights) fails
 #[test]

--- a/zebra-crosslink/zebra-consensus/src/config.rs
+++ b/zebra-crosslink/zebra-consensus/src/config.rs
@@ -1,6 +1,48 @@
 //! Configuration for semantic verification which is run in parallel.
 
+use std::str::FromStr;
+
 use serde::{Deserialize, Serialize};
+
+use zebra_chain::block;
+
+use crate::BoxError;
+
+/// A configured checkpoint that requires a block hash at a specific height.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckpointConfig {
+    /// The block height for this checkpoint.
+    pub height: u32,
+
+    /// The block hash for this checkpoint, in display order.
+    pub hash: String,
+}
+
+impl CheckpointConfig {
+    /// Convert this config entry into consensus checkpoint types.
+    pub fn height_and_hash(&self) -> Result<(block::Height, block::Hash), BoxError> {
+        Ok((block::Height(self.height), self.hash.parse()?))
+    }
+}
+
+impl FromStr for CheckpointConfig {
+    type Err = BoxError;
+
+    fn from_str(checkpoint: &str) -> Result<Self, Self::Err> {
+        let Some((height, hash)) = checkpoint.split_once(':') else {
+            return Err(format!("invalid checkpoint '{checkpoint}': expected HEIGHT:HASH").into());
+        };
+
+        let checkpoint = Self {
+            height: height.parse()?,
+            hash: hash.to_string(),
+        };
+        checkpoint.height_and_hash()?;
+
+        Ok(checkpoint)
+    }
+}
 
 /// Configuration for parallel semantic verification:
 /// <https://zebra.zfnd.org/dev/rfcs/0002-parallel-verification.html#definitions>
@@ -35,22 +77,40 @@ pub struct Config {
     /// For security reasons, this option might be deprecated or ignored in a future Zebra
     /// release.
     pub checkpoint_sync: bool,
+
+    /// Additional checkpoints that Zebra must verify by block height and hash.
+    ///
+    /// These checkpoints are appended to the network's built-in checkpoint list at startup.
+    /// They can be used to pin a node to a known fork.
+    #[serde(default)]
+    pub extra_checkpoints: Vec<CheckpointConfig>,
 }
 
 impl From<InnerConfig> for Config {
     fn from(
         InnerConfig {
-            checkpoint_sync, ..
+            checkpoint_sync,
+            extra_checkpoints,
+            ..
         }: InnerConfig,
     ) -> Self {
-        Self { checkpoint_sync }
+        Self {
+            checkpoint_sync,
+            extra_checkpoints,
+        }
     }
 }
 
 impl From<Config> for InnerConfig {
-    fn from(Config { checkpoint_sync }: Config) -> Self {
+    fn from(
+        Config {
+            checkpoint_sync,
+            extra_checkpoints,
+        }: Config,
+    ) -> Self {
         Self {
             checkpoint_sync,
+            extra_checkpoints,
             _debug_skip_parameter_preload: false,
         }
     }
@@ -66,6 +126,10 @@ pub struct InnerConfig {
     /// See [`Config`] for more details.
     pub checkpoint_sync: bool,
 
+    /// See [`Config`] for more details.
+    #[serde(default)]
+    pub extra_checkpoints: Vec<CheckpointConfig>,
+
     #[serde(skip_serializing, rename = "debug_skip_parameter_preload")]
     /// Unused config field for backwards compatibility.
     pub _debug_skip_parameter_preload: bool,
@@ -78,6 +142,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             checkpoint_sync: true,
+            extra_checkpoints: Vec::new(),
         }
     }
 }
@@ -86,6 +151,7 @@ impl Default for InnerConfig {
     fn default() -> Self {
         Self {
             checkpoint_sync: Config::default().checkpoint_sync,
+            extra_checkpoints: Config::default().extra_checkpoints,
             _debug_skip_parameter_preload: false,
         }
     }

--- a/zebra-crosslink/zebra-consensus/src/router.rs
+++ b/zebra-crosslink/zebra-consensus/src/router.rs
@@ -393,14 +393,36 @@ where
 pub fn init_checkpoint_list(config: Config, network: &Network) -> (CheckpointList, Height) {
     // TODO: Zebra parses the checkpoint list three times at startup.
     //       Instead, cache the checkpoint list for each `network`.
-    let list = network.checkpoint_list();
+    let hardcoded_list = network.checkpoint_list();
+    let extra_checkpoints: Vec<_> = config
+        .extra_checkpoints
+        .iter()
+        .map(|checkpoint| {
+            checkpoint
+                .height_and_hash()
+                .expect("configured checkpoint should parse")
+        })
+        .collect();
 
-    let max_checkpoint_height = if config.checkpoint_sync {
-        list.max_height()
+    let list = if config.checkpoint_sync {
+        hardcoded_list
+            .with_extra_checkpoints(extra_checkpoints.iter().copied())
+            .expect("configured checkpoints should be valid")
     } else {
-        list.min_height_in_range(network.mandatory_checkpoint_height()..)
-            .expect("hardcoded checkpoint list extends past canopy activation")
+        let max_mandatory_checkpoint_height = hardcoded_list
+            .min_height_in_range(network.mandatory_checkpoint_height()..)
+            .expect("hardcoded checkpoint list extends past canopy activation");
+
+        let required_checkpoints = hardcoded_list
+            .iter()
+            .filter(|(height, _hash)| **height <= max_mandatory_checkpoint_height)
+            .map(|(height, hash)| (*height, *hash))
+            .chain(extra_checkpoints.iter().copied());
+
+        CheckpointList::from_list(required_checkpoints)
+            .expect("configured checkpoints should be valid")
     };
+    let max_checkpoint_height = list.max_height();
 
     (list, max_checkpoint_height)
 }

--- a/zebra-crosslink/zebra-consensus/src/router/tests.rs
+++ b/zebra-crosslink/zebra-consensus/src/router/tests.rs
@@ -6,6 +6,8 @@ use color_eyre::eyre::Report;
 use once_cell::sync::Lazy;
 use tower::{layer::Layer, timeout::TimeoutLayer};
 
+use crate::config::CheckpointConfig;
+
 use zebra_chain::{
     block::Block,
     serialization::{ZcashDeserialize, ZcashDeserializeInto},
@@ -141,14 +143,43 @@ static STATE_VERIFY_TRANSCRIPT_GENESIS: Lazy<
 async fn verify_checkpoint_test() -> Result<(), Report> {
     verify_checkpoint(Config {
         checkpoint_sync: true,
+        extra_checkpoints: Vec::new(),
     })
     .await?;
     verify_checkpoint(Config {
         checkpoint_sync: false,
+        extra_checkpoints: Vec::new(),
     })
     .await?;
 
     Ok(())
+}
+
+#[test]
+fn checkpoint_sync_false_still_enforces_extra_checkpoints() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+    let hardcoded_list = network.checkpoint_list();
+    let mandatory_checkpoint_height = hardcoded_list
+        .min_height_in_range(network.mandatory_checkpoint_height()..)
+        .expect("hardcoded checkpoint list extends past mandatory checkpoint height");
+    let extra_height = block::Height(mandatory_checkpoint_height.0 + 1);
+    let extra_hash = block::Hash([1; 32]);
+
+    let (list, max_checkpoint_height) = super::init_checkpoint_list(
+        Config {
+            checkpoint_sync: false,
+            extra_checkpoints: vec![CheckpointConfig {
+                height: extra_height.0,
+                hash: extra_hash.to_string(),
+            }],
+        },
+        &network,
+    );
+
+    assert_eq!(max_checkpoint_height, extra_height);
+    assert_eq!(list.hash(extra_height), Some(extra_hash));
 }
 
 /// Test that checkpoint verifies work.

--- a/zebra-crosslink/zebrad/src/commands/start.rs
+++ b/zebra-crosslink/zebrad/src/commands/start.rs
@@ -81,6 +81,7 @@ use futures::FutureExt;
 use tokio::{pin, select, sync::oneshot, time::timeout};
 use tower::{builder::ServiceBuilder, util::BoxService, ServiceExt};
 use tracing_futures::Instrument;
+use zebra_consensus::config::CheckpointConfig;
 
 use zebra_chain::block::genesis::regtest_genesis_block;
 use zebra_consensus::{router::BackgroundTaskHandles, ParameterCheckpoint};
@@ -110,6 +111,10 @@ pub struct StartCmd {
     /// Filter strings which override the config file and defaults
     #[clap(help = "tracing filters which override the zebrad.toml config")]
     filters: Vec<String>,
+
+    /// Add an extra checkpoint as HEIGHT:HASH, requiring that hash at that block height
+    #[clap(long, value_name = "HEIGHT:HASH")]
+    checkpoint: Vec<CheckpointConfig>,
 }
 
 impl StartCmd {
@@ -954,6 +959,8 @@ impl config::Override<ZebradConfig> for StartCmd {
         if !self.filters.is_empty() {
             config.tracing.filter = Some(self.filters.join(","));
         }
+
+        config.consensus.extra_checkpoints.extend(self.checkpoint.clone());
 
         Ok(config)
     }

--- a/zebra-crosslink/zebrad/src/commands/tests.rs
+++ b/zebra-crosslink/zebrad/src/commands/tests.rs
@@ -1,5 +1,6 @@
 //! Tests for parsing zebrad commands
 
+use abscissa_core::config::Override;
 use clap::Parser;
 
 use crate::commands::ZebradCmd;
@@ -44,4 +45,24 @@ fn args_with_subcommand_pass_through() {
 
         assert_eq!(matches!(args.cmd(), ZebradCmd::Start(_)), should_be_start,);
     }
+}
+
+#[test]
+fn start_checkpoint_arg_parses() {
+    let hash = "00040fe8ec8471911baa1db1266ea15dd06b4a8a5c453883c000b031973dce08";
+    let args =
+        EntryPoint::try_parse_from(["zebrad", "start", "--checkpoint", &format!("0:{hash}")])
+            .expect("checkpoint arg should parse successfully");
+
+    let ZebradCmd::Start(cmd) = args.cmd() else {
+        panic!("expected start command");
+    };
+
+    let config = cmd
+        .override_config(crate::config::ZebradConfig::default())
+        .expect("checkpoint arg should override config successfully");
+
+    assert_eq!(config.consensus.extra_checkpoints.len(), 1);
+    assert_eq!(config.consensus.extra_checkpoints[0].height, 0);
+    assert_eq!(config.consensus.extra_checkpoints[0].hash, hash);
 }


### PR DESCRIPTION
 Adds configurable block hash checkpoints. Allows node operators to force the node to pick a particular fork.

 Changes:

- Adds consensus.extra_checkpoints config entries: { height, hash }
- Adds repeatable zebrad start --checkpoint HEIGHT:HASH
- Merges configured checkpoints into checkpoint verification
- Ensures configured checkpoints are enforced even when checkpoint_sync = false
- Rejects duplicate checkpoint heights/hashes at startup
- Adds tests for checkpoint merging, duplicate rejection, disabled checkpoint sync behavior, and CLI parsing