### PR TITLE
Build: Pin zerocopy before non-ascii regression

### DIFF
--- a/zebra-crosslink/Cargo.lock
+++ b/zebra-crosslink/Cargo.lock
@@ -10582,18 +10582,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zebra-crosslink/zebra-crosslink/Cargo.toml
+++ b/zebra-crosslink/zebra-crosslink/Cargo.toml
@@ -47,8 +47,8 @@ tempfile = "3.19.1"
 prost = "0.14.1"
 strum = "0.26.3"
 strum_macros = "0.26.4"
-zerocopy = "0.8.25"
-zerocopy-derive = "0.8.25"
+zerocopy = "=0.8.31"
+zerocopy-derive = "=0.8.31"
 blake3 = "1.8.2"
 byteorder = { workspace = true }
 ed25519-zebra = { workspace = true }


### PR DESCRIPTION
 Pins `zerocopy` and `zerocopy-derive` to `0.8.31`, the latest known-good version before a proc-macro regression that triggers `non_ascii_idents` errors under `-D non-ascii-idents`. This fixes the `test_format.rs` build failure without changing the serialization code.