### PR TITLE
make visualizer optional for headless builds

### DIFF
--- a/zebra-crosslink/zebra-crosslink/Cargo.toml
+++ b/zebra-crosslink/zebra-crosslink/Cargo.toml
@@ -70,14 +70,14 @@ hex = { version = "0.4.3", features = ["serde"] }
 lazy_static = "1.5.0"
 
 tenderlink = { workspace = true }
-visualizer_zcash = { workspace = true }
+visualizer_zcash = { workspace = true, optional = true }
 
 [dev-dependencies]
 zebra-test = { path = "../zebra-test", version = "1.0.0-beta.45" }
 
 [features]
 default = []
-viz_gui = ["macroquad", "macroquad-profiler", "image", "miniquad"]
+viz_gui = ["macroquad", "macroquad-profiler", "image", "miniquad", "visualizer_zcash"]
 audio = []
 
 [build-dependencies]

--- a/zebra-crosslink/zebra-crosslink/src/lib.rs
+++ b/zebra-crosslink/zebra-crosslink/src/lib.rs
@@ -166,6 +166,7 @@ pub mod test_format;
 #[cfg(feature = "viz_gui")]
 pub mod viz;
 
+#[cfg(feature = "viz_gui")]
 pub mod viz2;
 
 use crate::service::{TFLServiceCalls, TFLServiceHandle};
@@ -2115,4 +2116,3 @@ async fn _tfl_dump_block_sequence(
     .await;
     tfl_dump_blocks(&blocks[..], &infos[..]);
 }
-


### PR DESCRIPTION
This patch should allow headless builds without having the (useless) gui dependencies installed.